### PR TITLE
fix(modal-drawer): fix cancel close event

### DIFF
--- a/src/lib/drawer/modal-drawer/modal-drawer-foundation.ts
+++ b/src/lib/drawer/modal-drawer/modal-drawer-foundation.ts
@@ -38,8 +38,10 @@ export class ModalDrawerFoundation extends BaseDrawerFoundation implements IModa
   }
 
   private _onBackdropClick(evt: Event): void {
-    this.open = false;
-    this._adapter.emitHostEvent(MODAL_DRAWER_CONSTANTS.events.CLOSE);
+    const canClose = this._adapter.emitHostEvent(MODAL_DRAWER_CONSTANTS.events.CLOSE, undefined, true, true);
+    if (canClose) {
+      this.open = false;
+    }
   }
 
   private _setBackdrop(open: boolean): void {

--- a/src/test/spec/drawer/modal-drawer.spec.ts
+++ b/src/test/spec/drawer/modal-drawer.spec.ts
@@ -63,6 +63,22 @@ describe('ModalDrawerComponent', function(this: ITestContext) {
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
+  it('should not close backdrop when clicked if close event is cancelled', async function (this: ITestContext) {
+    this.context = setupTestContext();
+    this.context.component.open = true;
+    this.context.append();
+    this.context.component.addEventListener(MODAL_DRAWER_CONSTANTS.events.CLOSE, evt => evt.preventDefault());
+    await timer(100);
+    await tick();
+
+    const backdrop = getShadowElement(this.context.component, BACKDROP_CONSTANTS.elementName);
+    const backdropElement = getShadowElement(backdrop, BACKDROP_CONSTANTS.selectors.CONTAINER);
+    dispatchNativeEvent(backdropElement, 'click');
+    await tick();
+
+    expect(this.context.component.open).toBe(true);
+  });
+
   it('should not show backdrop when open is set to false by default', async function(this: ITestContext) {
     this.context = setupTestContext();
     this.context.append();


### PR DESCRIPTION
Fixes https://tylerjira.tylertech.com/browse/TCPSD-6699

Cloned from: https://github.com/tyler-technologies/tyler-components-web/pull/759

This change allows the `forge-modal-drawer-close` event, which is only dispatched when clicking the backdrop, to be cancelled (using `event.preventDefault()`) to stop the drawer from closing automatically if desired.