### PR TITLE
fix(expansion-panel): fix expansion panel `visibility` style when open by default

### DIFF
--- a/src/lib/expansion-panel/expansion-panel-adapter.ts
+++ b/src/lib/expansion-panel/expansion-panel-adapter.ts
@@ -44,6 +44,7 @@ export class ExpansionPanelAdapter extends BaseAdapter<IExpansionPanelComponent>
         this._contentElement.style.width = '';
       }
       this._contentElement.style.removeProperty('opacity');
+      this._contentElement.style.removeProperty('visibility');
       const openIconElement = this._component.querySelector(EXPANSION_PANEL_CONSTANTS.selectors.OPEN_ICON) as OpenIconComponent;
       if (openIconElement) {
         openIconElement.open = true;

--- a/src/test/spec/expansion-panel/expansion-panel.spec.ts
+++ b/src/test/spec/expansion-panel/expansion-panel.spec.ts
@@ -68,6 +68,53 @@ describe('ExpansionPanelComponent', function(this: ITestContext) {
       await timer(EXPANSION_PANEL_CONSTANTS.numbers.COLLAPSE_ANIMATION_DURATION);
       expect(getInternalPanelContent(this.context.component).clientWidth).toBeGreaterThan(0);
     });
+
+    it('should set hidden visibility style by default', async function(this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.append();
+      await tick();
+
+      expect(getInternalPanelContent(this.context.component).style.visibility).toBe('hidden');
+    });
+
+    it('should remove hidden visibility style when expanded', async function(this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.append();
+      await tick();
+
+      this.context.component.open = true;
+      await timer(EXPANSION_PANEL_CONSTANTS.numbers.COLLAPSE_ANIMATION_DURATION);
+      await tick();
+
+      expect(getInternalPanelContent(this.context.component).style.visibility).not.toBe('hidden');
+    });
+
+    it('should remove visibility style if open by default', async function(this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.component.setAttribute(EXPANSION_PANEL_CONSTANTS.attributes.OPEN, '');
+      this.context.append();
+      await tick();
+
+      expect(getInternalPanelContent(this.context.component).style.visibility).not.toBe('hidden');
+    });
+
+    it('should set hidden visibility style when collapsed after being expanded', async function(this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.append();
+      await tick();
+
+      this.context.component.open = true;
+      await timer(EXPANSION_PANEL_CONSTANTS.numbers.COLLAPSE_ANIMATION_DURATION);
+      await tick();
+
+      expect(getInternalPanelContent(this.context.component).style.visibility).not.toBe('hidden');
+
+      this.context.component.open = false;
+      await timer(EXPANSION_PANEL_CONSTANTS.numbers.COLLAPSE_ANIMATION_DURATION);
+      await tick();
+
+      expect(getInternalPanelContent(this.context.component).style.visibility).toBe('hidden');
+    });
   });
 
   describe('interaction with component in DOM already', function(this: ITestContext) {


### PR DESCRIPTION
Fixes #31 

## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Expansion panels that are set to be expanded (open) by default will now properly remove the `visibility` style during initialization.
