### PR TITLE
fix(typography): fix MDC typography overrides

### DIFF
--- a/src/demo/index.html
+++ b/src/demo/index.html
@@ -91,9 +91,6 @@
             <forge-list-item role="listitem" href="#ViewSwitcher">View Switcher</forge-list-item>
           </forge-list>
         </aside>
-        <forge-toolbar inverted slot="footer">
-          <h2 slot="start" class="forge-typography--subtitle2" id="app-version-identifier">N/A</h2>
-        </forge-toolbar>
       </forge-drawer>
       <forge-toolbar slot="body-header">
         <h1 slot="start" class="forge-typography--title" style="white-space: nowrap;">Component Examples</h1>
@@ -4957,10 +4954,6 @@
         }
       }
       darkModeSwitch.addEventListener('forge-switch-select', evt => toggleDarkTheme(evt.detail));
-
-      // Set the version identifier in the drawer
-      var versionIdentifierElement = document.getElementById('app-version-identifier');
-      versionIdentifierElement.textContent = 'v' + Forge.lib.VERSION;
 
       var appBar = document.querySelector('#app-bar');
       appBar.addEventListener('forge-profile-card-sign-out', function() {

--- a/src/lib/typography/_mixins.scss
+++ b/src/lib/typography/_mixins.scss
@@ -15,11 +15,10 @@
   }
 
   // Create custom classes for built-in MDC typography styles
-  $all-styles: map.merge(mdc-typography.$styles, variables.$mdc-typography-overrides);
-  @each $style in map.keys($all-styles) {
+  @each $style in map.keys(mdc-typography.$styles) {
     .forge-typography--#{$style} {
       @include mdc-typography.typography($style);
-      @include addon-styles(variables.$mdc-typography-additional-styles, $style);
+      @include apply-additional-styles(variables.$mdc-typography-additional-styles, $style);
     }
   }
   
@@ -27,7 +26,6 @@
   @each $style in map.keys(variables.$styles) {
     .forge-typography--#{$style} {
       @include typography($style);
-      @include addon-styles(variables.$additional-styles, $style);
     }
   }
   
@@ -41,7 +39,7 @@
   }
 }
 
-@mixin addon-styles($styles, $style) {
+@mixin apply-additional-styles($styles, $style) {
   @if map.has-key($styles, $style) {
     $additional-styles: map.get($styles, $style);
     @each $additional-style in map.keys($additional-styles) {

--- a/src/lib/typography/_variables.scss
+++ b/src/lib/typography/_variables.scss
@@ -32,12 +32,7 @@ $styles: (
     font-weight: map.get(typography.$font-weight-values, regular),
     letter-spacing: typography.get-letter-spacing_(0.1, 0.71428571),
     text-decoration: inherit,
-    text-transform: inherit
-  )
-) !default;
-
-$additional-styles: (
-  subtitle2-secondary: (
+    text-transform: inherit,
     color: var(--mdc-theme-text-secondary-on-background)
   )
 ) !default;
@@ -60,13 +55,30 @@ $mdc-typography-overrides: (
     letter-spacing: typography.get-letter-spacing_(-1.5, 2.125)
   ),
   headline4: (
-    line-height: typography.px-to-rem(34px),
+    font-size: typography.px-to-rem(24px),
+    line-height: typography.px-to-rem(24px),
     letter-spacing: typography.get-letter-spacing_(0.25, 1.5)
   ),
   headline5: (
     font-size: typography.px-to-rem(20px),
+    line-height: typography.px-to-rem(32px),
     font-weight: map.get(typography.$font-weight-values, medium),
     letter-spacing: typography.get-letter-spacing_(0.25, 2)
+  ),
+  headline6: (
+    font-size: typography.px-to-rem(16px),
+    line-height: normal,
+    font-weight: 400,
+    letter-spacing: normal
+  ),
+  subtitle1: (
+    letter-spacing: typography.get-letter-spacing_(0.15, 0.9375)
+  ),
+  subtitle2: (
+    letter-spacing: typography.get-letter-spacing_(0.1, 0.71428571)
+  ),
+  overline: (
+    text-transform: none
   ),
   button: (
     text-transform: none


### PR DESCRIPTION
Due to how MDC uses Sass modules and their addition of CSS custom properties for all typography styles, our existing solution (migrated from TCW 1.x) for how we were overriding styles was not working properly.

To achieve parity with TCW 1.x, we needed to update how our style overrides were being applied to use the CSS custom properties.

Here is an example of the proper typography values:
![image](https://user-images.githubusercontent.com/2653457/167209480-11dfecea-a2ab-4b50-a95d-c3e1ec006e84.png)
