### PR TITLE
fix(autocomplete): fix keyboard navigation of disabled options

### DIFF
--- a/src/lib/autocomplete/autocomplete-foundation.ts
+++ b/src/lib/autocomplete/autocomplete-foundation.ts
@@ -288,7 +288,7 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
   }
 
   private _onKeydown(evt: KeyboardEvent): void {
-    switch (evt.code) {
+    switch (evt.key) {
       case 'Tab':
         if (this._isDropdownOpen && !this._multiple) {
           this._selectActiveOption(false);
@@ -307,25 +307,25 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
         if (!this._isDropdownOpen) {
           this._showDropdown({ activateFirst: true });
         } else {
-          this._adapter.propagateKey(evt.code);
+          this._adapter.propagateKey(evt.key);
         }
         break;
       case 'Up':
       case 'ArrowUp':
         evt.preventDefault();
         if (this._isDropdownOpen) {
-          this._adapter.propagateKey(evt.code);
+          this._adapter.propagateKey(evt.key);
         }
         break;
       case 'Enter':
       case 'Home':
       case 'End':
         if (this._isDropdownOpen) {
-          if (evt.code === 'Enter') {
+          if (evt.key === 'Enter') {
             evt.stopPropagation();
           }
           evt.preventDefault();
-          this._adapter.propagateKey(evt.code);
+          this._adapter.propagateKey(evt.key);
         }
         break;
       case 'Backspace':

--- a/src/lib/list-dropdown/list-dropdown-foundation.ts
+++ b/src/lib/list-dropdown/list-dropdown-foundation.ts
@@ -204,7 +204,7 @@ export class ListDropdownFoundation implements IListDropdownFoundation {
       case 'Enter':
         const activeOptionIndex = this.getActiveOptionIndex();
         const activeOption = this._nonDividerOptions[activeOptionIndex];
-        if (activeOption) {
+        if (this._canSelectOption(activeOption)) {
           const id = this._adapter.getActiveOptionIdByIndex(activeOptionIndex);
           if (id) {
             this._onSelect(activeOption.value, id);
@@ -215,6 +215,10 @@ export class ListDropdownFoundation implements IListDropdownFoundation {
       case 'ArrowUp':
       case 'Down':
       case 'ArrowDown':
+        const options = this._nonDividerOptions;
+        if (options.length && options.every(o => !this._canSelectOption(o))) {
+          return;
+        }
         const index = this._getNextActiveOptionIndex(key);
         this.activateOption(index);
         break;
@@ -225,6 +229,10 @@ export class ListDropdownFoundation implements IListDropdownFoundation {
         this.activateLastOption();
         break;
     }
+  }
+
+  private _canSelectOption(option: IListDropdownOption): boolean {
+    return option && !option.disabled && !option.divider;
   }
 
   private _getNextActiveOptionIndex(key: string): number {

--- a/src/test/spec/autocomplete/autocomplete.spec.ts
+++ b/src/test/spec/autocomplete/autocomplete.spec.ts
@@ -389,7 +389,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       _triggerDropdownClick(this.context.input);
       await tick();
       await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
 
       const activeListItemIndex = _getActiveListItemIndex(this.context.component.popupElement);
       expect(activeListItemIndex).toBe(0);
@@ -403,9 +403,9 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       await tick();
       await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
 
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' })); // 0
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' })); // 1
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowUp' })); // 0
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' })); // 0
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' })); // 1
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' })); // 0
 
       const activeListItemIndex = _getActiveListItemIndex(this.context.component.popupElement);
       expect(activeListItemIndex).toBe(0);
@@ -418,7 +418,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       _triggerDropdownClick(this.context.input);
       await tick();
       await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowUp' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
 
       const activeListItemIndex = _getActiveListItemIndex(this.context.component.popupElement);
       expect(activeListItemIndex).toBe(2);
@@ -433,10 +433,10 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
 
       // We have 3 options
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' })); // Index 0
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' })); // Index 1
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' })); // Index 2
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' })); // Index 0
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' })); // Index 0
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' })); // Index 1
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' })); // Index 2
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' })); // Index 0
 
       const activeListItemIndex = _getActiveListItemIndex(this.context.component.popupElement);
       expect(activeListItemIndex).toBe(0);
@@ -449,7 +449,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       _triggerDropdownClick(this.context.input);
       await tick();
       await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'End' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
 
       const activeListItemIndex = _getActiveListItemIndex(this.context.component.popupElement);
       expect(activeListItemIndex).toBe(2);
@@ -463,8 +463,8 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       await tick();
       await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
 
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' }));
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'Home' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
 
       const activeListItemIndex = _getActiveListItemIndex(this.context.component.popupElement);
       expect(activeListItemIndex).toBe(0);
@@ -478,7 +478,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       await tick();
       await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
 
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'Escape' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
       await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
 
       expect(this.context.component.popupElement).toBeNull();
@@ -493,7 +493,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       await timer();
       this.context.input.value = '';
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'Backspace' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace' }));
 
       expect(changeSpy).toHaveBeenCalledTimes(1);
       expect(changeSpy).toHaveBeenCalledWith(jasmine.objectContaining({ detail: null }));
@@ -540,13 +540,40 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       _triggerDropdownClick(this.context.input);
       await tick();
       await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' }));
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'Enter' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 
       expect(changeSpy).toHaveBeenCalledTimes(1);
       expect(changeSpy).toHaveBeenCalledWith(jasmine.objectContaining({ detail: DEFAULT_FILTER_OPTIONS[0].value }));
       expect(this.context.component.value).toBe(DEFAULT_FILTER_OPTIONS[0].value);
       expect(this.context.input.value).toBe(DEFAULT_FILTER_OPTIONS[0].label);
+    });
+
+    it('should not emit change event if enter key is pressed in multiple mode when only one disabled option exists in the filtered options', async function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      this.context.component.multiple = true;
+      function filter(filterText: string, value: any): Promise<IOption[]> {
+        return new Promise<IOption[]>(resolve => {
+          resolve([{ label: 'No results', value: undefined, disabled: true }]);
+        });
+      }
+      const filterSpy = jasmine.createSpy('filter callback', filter).and.callThrough();
+      this.context.component.filter = filterSpy;
+      const changeSpy = jasmine.createSpy('change event');
+      this.context.component.addEventListener(AUTOCOMPLETE_CONSTANTS.events.CHANGE, changeSpy);
+
+      _triggerDropdownClick(this.context.input);
+      await tick();
+      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+
+      _sendInputValue(this.context.input, 'other');
+      await timer(AUTOCOMPLETE_CONSTANTS.numbers.DEFAULT_DEBOUNCE_TIME);
+      await tick();
+
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+
+      expect(filterSpy).toHaveBeenCalled();
+      expect(changeSpy).not.toHaveBeenCalled();
     });
 
     it('should not select active option if input is blurred', async function(this: ITestContext) {
@@ -574,9 +601,9 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       _triggerDropdownClick(this.context.input);
       await tick();
       await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       await tick();
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'Tab' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
 
       expect(changeSpy).toHaveBeenCalledTimes(1);
       expect(changeSpy).toHaveBeenCalledWith(jasmine.objectContaining({ detail: DEFAULT_FILTER_OPTIONS[0].value }));
@@ -611,12 +638,12 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       await tick();
       await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
 
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' }));
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'Enter' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
       await tick();
 
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' }));
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'Enter' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
       await tick();
 
       const listItems = _getListItems(this.context.component.popupElement);
@@ -662,7 +689,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       this.context.component.addEventListener(AUTOCOMPLETE_CONSTANTS.events.CHANGE, changeSpy);
 
       await timer();
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'Enter' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 
       expect(changeSpy).toHaveBeenCalledTimes(0);
       expect(this.context.component.value).toBeNull();
@@ -674,7 +701,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       this.context.component.filter = () => DEFAULT_FILTER_OPTIONS;
       this.context.input.focus();
 
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       await tick();
       await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
 
@@ -686,7 +713,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       this.context.component.filter = () => DEFAULT_FILTER_OPTIONS;
       this.context.input.focus();
 
-      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' }));
+      this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       await tick();
       await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Does this PR introduce a breaking change? N

## Describe the new behavior?
There were two bugs fixed in this PR:
1. Enter key was toggling disabled options in multiple mode
2. Using up and down arrows to navigation dropdown when only disabled options exist causing an exception

These two issues have both been fixed by ensuring that disabled options are properly accounted for in the keyboard traversal.

Additionally, I swapped out the use of `event.code` for `event.key` for consistency with other components.