### PR TITLE
fix(autocomplete): ensure that input exists before initialization

### DIFF
--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -1,4 +1,4 @@
-import { attachShadowTemplate, coerceBoolean, coerceNumber, CustomElement, ensureChildren, FoundationProperty } from '@tylertech/forge-core';
+import { attachShadowTemplate, coerceBoolean, coerceNumber, CustomElement, ensureChild, FoundationProperty } from '@tylertech/forge-core';
 import { tylIconCheckBox, tylIconCheckBoxOutlineBlank } from '@tylertech/tyler-icons/standard';
 import { DividerComponent } from '../divider';
 import { IconComponent, IconRegistry } from '../icon';
@@ -94,12 +94,10 @@ export class AutocompleteComponent extends ListDropdownAware implements IAutocom
   }
 
   public connectedCallback(): void {
-    if (this.children.length) {
+    if (this.querySelector(AUTOCOMPLETE_CONSTANTS.selectors.INPUT)) {
       this._foundation.initialize();
     } else {
-      ensureChildren(this)
-        .then(() => this._foundation.initialize())
-        .catch(e => console.error(e));
+      ensureChild(this, AUTOCOMPLETE_CONSTANTS.selectors.INPUT).then(() => this._foundation.initialize());
     }
   }
 

--- a/src/test/spec/autocomplete/autocomplete.spec.ts
+++ b/src/test/spec/autocomplete/autocomplete.spec.ts
@@ -1257,10 +1257,13 @@ describe('AutocompleteComponent', function(this: ITestContext) {
   });
 
   describe('with dynamic <input> element', function(this: ITestContext) {
-    it('should not initialize if input element is not provided', async function(this: ITestContext) {
+    it('should wait for input element to initialize', async function(this: ITestContext) {
       this.context = setupDynamicTestContext(true);
+      await timer(100);
+      this.context.component.appendChild(this.context.input);
       await tick();
-      expect(this.context.component.isInitialized).toBe(false);
+
+      expect(this.context.component.isInitialized).toBe(true);
     });
 
     it('should initialize if input is provided', async function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N (not necessary)
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The autocomplete will now wait for the input to exist before initializing itself to support better use in frameworks such as Angular

## Additional information
Fixes #47
