### PR TITLE
fix(date-picker): fixed a bug where the input value listeners were no…

### DIFF
--- a/src/lib/chip-field/_variables.scss
+++ b/src/lib/chip-field/_variables.scss
@@ -60,7 +60,7 @@ $icon: (
     y: (
       roomy: 10px,
       default: 5px,
-      dense: 0 // TODO
+      dense: 0
     )
   ),
   padding: (

--- a/src/lib/date-picker/base/base-date-picker-adapter.ts
+++ b/src/lib/date-picker/base/base-date-picker-adapter.ts
@@ -59,6 +59,7 @@ export abstract class BaseDatePickerAdapter<T extends BaseComponent> extends Bas
   protected _identifier: string;
   protected _calendarDropdown?: ICalendarDropdown;
   protected _toggleElement?: HTMLElement;
+  protected _valueChangeListeners: Array<() => void> = [];
 
   constructor(component: T) {
     super(component);
@@ -99,6 +100,11 @@ export abstract class BaseDatePickerAdapter<T extends BaseComponent> extends Bas
 
   public destroy(): void {
     this._calendarDropdown?.destroy();
+    this.destroyValueChangeListener();
+  }
+
+  public destroyValueChangeListener(): void {
+    this._valueChangeListeners.forEach(cb => cb());
   }
 
   public addToggleListener(type: string, listener: (event: Event) => void): void {
@@ -219,7 +225,7 @@ export abstract class BaseDatePickerAdapter<T extends BaseComponent> extends Bas
 
   protected _getDefaultTargetElement(): HTMLElement {
     // This component is often used with the Forge text-field, if so, let's target our popup around
-    // one if its internal elements for best alignnment
+    // one if its internal elements for best alignment
     const textField = this._component.querySelector('forge-text-field');
     if (textField && textField.shadowRoot) {
       const textFieldRoot = getShadowElement(textField, TEXT_FIELD_CONSTANTS.selectors.ROOT) as HTMLElement;

--- a/src/lib/date-picker/date-picker-adapter.ts
+++ b/src/lib/date-picker/date-picker-adapter.ts
@@ -64,10 +64,9 @@ export class DatePickerAdapter extends BaseDatePickerAdapter<IDatePickerComponen
   }
 
   public setInputValueChangedListener(context: any, listener: (value: any) => void): void {
-    if (this._inputElement.hasOwnProperty('value')) {
-      return;
-    }
-    listenOwnProperty(context, this._inputElement, 'value', listener);
+    this.destroyValueChangeListener();
+    const destroyListenerCb = listenOwnProperty(context, this._inputElement, 'value', listener);
+    this._valueChangeListeners.push(destroyListenerCb);
   }
 
   public hasInputElement(): boolean {

--- a/src/lib/date-picker/date-picker-foundation.ts
+++ b/src/lib/date-picker/date-picker-foundation.ts
@@ -140,6 +140,11 @@ export class DatePickerFoundation extends BaseDatePickerFoundation<IDatePickerAd
 
   protected _onInputValueChanged(value: string): void {
     const sanitizedValue = this._getSanitizedDateString(value);
+    if (this._masked && sanitizedValue) {
+      // If masked, allow clearing value by setting input.value directly
+      // To set a date value, dispatch `input` event and mask will handle it.
+      return;
+    }
     const date = this._coerceDateValue(sanitizedValue);
     if (!isSameDate(date, this._value) && this._isDateValueAcceptable(date)) {
       this.value = date;

--- a/src/lib/date-range-picker/date-range-picker-adapter.ts
+++ b/src/lib/date-range-picker/date-range-picker-adapter.ts
@@ -27,6 +27,7 @@ export class DateRangePickerAdapter extends BaseDatePickerAdapter<IDateRangePick
   private _toInputMask: DateInputMask | undefined;
   private _fromInputMask: DateInputMask | undefined;
   private _dropdownIdentifier: string;
+  private _toValueChangeListener: (() => void) | undefined;
 
   constructor(component: DateRangePickerComponent) {
     super(component);
@@ -61,6 +62,11 @@ export class DateRangePickerAdapter extends BaseDatePickerAdapter<IDateRangePick
     this._toInputMask = new DateInputMask(this._toInputElement, toOptions);
   }
 
+  public destroy(): void {
+    super.destroy();
+    this._destroyToValueChangeListener();
+  }
+
   public destroyMask(): void {
     if (this._fromInputMask) {
       this._fromInputMask.destroy();
@@ -69,6 +75,12 @@ export class DateRangePickerAdapter extends BaseDatePickerAdapter<IDateRangePick
     if (this._toInputMask) {
       this._toInputMask.destroy();
       this._toInputMask = undefined;
+    }
+  }
+
+  private _destroyToValueChangeListener(): void {
+    if (typeof this._toValueChangeListener === 'function') {
+      this._toValueChangeListener();
     }
   }
 
@@ -102,17 +114,16 @@ export class DateRangePickerAdapter extends BaseDatePickerAdapter<IDateRangePick
   }
 
   public setInputValueChangedListener(context: any, listener: (value: any) => void): void {
-    if (this._fromInputElement.hasOwnProperty('value')) {
-      return;
+    if (this._valueChangeListeners.length) {
+      this.destroyValueChangeListener();
     }
-    listenOwnProperty(context, this._fromInputElement, 'value', listener);
+    const destroyListenerCb = listenOwnProperty(context, this._fromInputElement, 'value', listener);
+    this._valueChangeListeners.push(destroyListenerCb);
   }
 
   public setToInputValueChangedListener(context: any, listener: (value: any) => void): void {
-    if (this._toInputElement.hasOwnProperty('value')) {
-      return;
-    }
-    listenOwnProperty(context, this._toInputElement, 'value', listener);
+    this._destroyToValueChangeListener();
+    this._toValueChangeListener = listenOwnProperty(context, this._toInputElement, 'value', listener);
   }
 
   public hasInputElement(): boolean {

--- a/src/lib/field/field-adapter.ts
+++ b/src/lib/field/field-adapter.ts
@@ -161,11 +161,11 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
   public setValueChangedListener(context: any, listener: (value: any) => void): void {
     this.destroyValueChangeListener();
     const destroyListener = listenOwnProperty(context, this._inputElement, 'value', listener);
-    this._valueChangeListeners.push(destroyListener); // TODO
+    this._valueChangeListeners.push(destroyListener);
   }
 
   public destroyValueChangeListener(): void {
-    this._valueChangeListeners.forEach(cb => cb()); // TODO
+    this._valueChangeListeners.forEach(cb => cb());
   }
 
   public detectLabel(required: boolean): void {

--- a/src/lib/text-field/text-field-adapter.ts
+++ b/src/lib/text-field/text-field-adapter.ts
@@ -63,7 +63,7 @@ export class TextFieldAdapter extends FieldAdapter implements ITextFieldAdapter 
     this.destroyValueChangeListener();
     this._applyToInputs(input => {
       const destroyListener = listenOwnProperty(context, input, 'value', listener);
-      this._valueChangeListeners.push(destroyListener); // TODO
+      this._valueChangeListeners.push(destroyListener);
     });
   }
 

--- a/src/stories/src/components/date-picker/templates/default.tsx
+++ b/src/stories/src/components/date-picker/templates/default.tsx
@@ -22,25 +22,23 @@ export const DefaultTemplate: Story<IDatePickerProps> = ({
   if (max) {
     max = new Date(max);
   }
-
-  const datepickerProps = {
-    disabled,
-    min,
-    max,
-    open,
-    masked,
-    maskFormat,
-    showMaskFormat,
-    allowInvalidDate,
-    showToday,
-    showClear,
-    disabledDaysOfWeek
-  };
   return (
-    <ForgeDatePicker {...datepickerProps} style={{ maxWidth: '256px' }}>
+    <ForgeDatePicker
+      disabled={disabled}
+      min={min}
+      max={max}
+      open={open}
+      masked={masked}
+      maskFormat={maskFormat}
+      showMaskFormat={showMaskFormat}
+      allowInvalidDate={allowInvalidDate}
+      showToday={showToday}
+      showClear={showClear}
+      disabledDaysOfWeek={disabledDaysOfWeek}
+      style={{ maxWidth: '256px' }}>
       <ForgeTextField>
-        <input type="text" id="input-datepicker"/>
-        <label htmlFor="input-datepicker">Choose date</label>
+        <input type="text" id="input-date-picker" />
+        <label htmlFor="input-date-picker">Choose date</label>
       </ForgeTextField>
     </ForgeDatePicker>
   );

--- a/src/test/spec/date-picker/date-picker.spec.ts
+++ b/src/test/spec/date-picker/date-picker.spec.ts
@@ -1269,6 +1269,27 @@ describe('DatePickerComponent', function(this: ITestContext) {
 
       expect(inputElement.value).toBe(`01/01/${currentCentury - 1}${year}`);
     });
+
+    it('should clear the value when the input is cleared programmatically', function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      this.context.component.value = new Date();
+
+      getInputElement(this.context.component).value = '';
+
+      expect(this.context.component.value).toBeNull();
+    });
+
+    it('should update value properly when backspacing', function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      this.context.component.value = new Date('01/01/2021');
+      this.context.component.masked = true;
+      this.context.component.showMaskFormat = true;
+
+      const inputElement = getInputElement(this.context.component);
+      inputElement.value = inputElement.value.slice(0,-1);
+      inputElement.dispatchEvent(new KeyboardEvent('input'));
+      expect(inputElement.value).toEqual('01/01/202_');
+    });
   });
 
   function setupTestContext(append = false, hasInput = true, hasToggle = true): ITestDatePickerContext {


### PR DESCRIPTION
A bug was found where the date-picker would not listen for `value` property changes to the child `<input>` element if the property was already patched. Removing this restriction fixes the bug and properly allows multiple patches to the property.

This change includes the changes from TCW 1.x located [here](https://github.com/tyler-technologies/tyler-components-web/pull/753/files?w=1).

