### PR TITLE
chore: fix step select event name

### DIFF
--- a/src/stories/src/components/stepper/stepper.mdx
+++ b/src/stories/src/components/stepper/stepper.mdx
@@ -192,9 +192,9 @@ Sets the tab index on the step
 
 ## Events
 
-| Name                                  | Description
-| :-------------------------------------| :----------------
-| `forge-step-selected`                   | Emits when the user selects a step. **Emits from the `<forge-stepper>` element only.**
+| Name                                    | Description
+| :---------------------------------------| :----------------
+| `forge-step-select`                     | Emits when the user selects a step. **Emits from the `<forge-stepper>` element only.**
 | `forge-step-expanded-content-focusin`   | Emits when the user focus enters the expanded content in a step. **Emits from the `<forge-stepper>` element only.**
 | `forge-step-expanded-content-focusout`  | Emits when the user focus exits the expanded content in a step. **Emits from the `<forge-stepper>` element only.**
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: -
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? -

## Describe the new behavior?
Fixed name of `forge-step-select` event in Storybook docs.