### PR TITLE
fix(chip-field): fixed a bug where the label would incorrectly unfloat when a placeholder was present

### DIFF
--- a/src/lib/field/field-foundation.ts
+++ b/src/lib/field/field-foundation.ts
@@ -301,7 +301,7 @@ export class FieldFoundation {
   protected _onValueChanged(value: any): void {
     if (this._adapter.fieldHasValue()) {
       this.floatLabel(true);
-    } else if (!this._adapter.inputHasFocus()) {
+    } else if (!this._adapter.inputHasFocus() && !this._adapter.hasPlaceholder()) {
       this.floatLabel(false);
     }
   }

--- a/src/test/spec/chip-field/chip-field.spec.ts
+++ b/src/test/spec/chip-field/chip-field.spec.ts
@@ -210,6 +210,23 @@ describe('ChipFieldComponent', function(this: ITestContext) {
       expectFloatingLabelState(this.context, true);
     });
 
+
+    it('should not un-float label when blurred if placeholder exists', async function(this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.input.placeholder = 'Some placeholder text...';
+      await tick();
+
+      this.context.input.focus();
+      await floatTick();
+
+      expectFloatingLabelState(this.context, true);
+
+      this.context.input.blur();
+      await floatTick();
+
+      expectFloatingLabelState(this.context, true);
+    });
+
     it('should set proper state when focused', async function(this: ITestContext) {
       this.context = setupTestContext();
       this.context.input.dispatchEvent(new Event('focus'));


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The chip-field will now correctly leave the label floating when the field is blurred if placeholder text exists.

## Additional information
Fixes #57 
