### PR TITLE
fix(chip): fixed disabled border color in dark theme

### DIFF
--- a/src/lib/button/_mixins.scss
+++ b/src/lib/button/_mixins.scss
@@ -10,7 +10,6 @@
 @use '@material/ripple/ripple-theme';
 @use '@material/theme/theme';
 @use '@material/theme/color-palette';
-
 @use '../theme' as forge-theme;
 
 @mixin core-styles() {
@@ -118,8 +117,8 @@
 }
 
 @mixin outlined-disabled() {
-  @include theme.property(border-color, border-color);
-  @include theme.prop(color, text-disabled-on-light);
+  @include forge-theme.property(border-color, border-color);
+  @include theme.property(color, text-disabled-on-light);
 }
 
 @mixin raised() {

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -64,7 +64,7 @@ export class ButtonComponent extends BaseComponent implements IButtonComponent {
 
   /**
    * Sets the type of button decoration.
-   * Possbile values are: raised, elevated, outlined, and dense.
+   * Possible values are: raised, elevated, outlined, and dense.
    * Can be combined as: outlined-dense.
    */
   public get type(): string {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The chip will now properly set the `border-color` when disabled and this will use the proper theme for both light and dark themes.

![image](https://user-images.githubusercontent.com/2653457/170743333-acef0de1-02e8-4016-8e0f-6ea65aa3a988.png)


## Additional information
Fixes #59 
