### PR TITLE
feat: update field dimensions

### DIFF
--- a/src/lib/chip-field/_base.scss
+++ b/src/lib/chip-field/_base.scss
@@ -125,14 +125,6 @@
   @include field-utils.error-layout-state(input-container-padding-right, $layout-state);
 }
 
-// Label
-@mixin label-top($layout-state) {
-  @if $layout-state == default {
-    // override the field-base.label-top at default because chip-field is 46px height and field is 44px
-    top: 0.95rem;
-  }
-}
-
 // Member
 @mixin member-core {
   display: block;

--- a/src/lib/chip-field/_core.scss
+++ b/src/lib/chip-field/_core.scss
@@ -10,7 +10,6 @@
   .forge-field {
     @include selector.label-input-container;
     @include selector.input-container;
-    @include selector.label;
     @include selector.member;
     @include selector.input;
     @include selector.leading;

--- a/src/lib/chip-field/_selector.scss
+++ b/src/lib/chip-field/_selector.scss
@@ -77,16 +77,6 @@
   }
 }
 
-@mixin label {
-  // Top
-  &:not(.forge-field--dense):not(.forge-field--roomy) {
-    ::slotted(label) {
-      @include base.label-top(default);
-    }
-  }
-}
-
-
 @mixin member {
   // Core
   ::slotted([slot='member']) {

--- a/src/lib/chip-field/_variables.scss
+++ b/src/lib/chip-field/_variables.scss
@@ -5,7 +5,7 @@ $input-container: (
     default: 2px 12px,
     top: (
       roomy: 22px,
-      default: 20px
+      default: 22px
     ),
     left: (
       leading: 0,

--- a/src/lib/field/_variables.scss
+++ b/src/lib/field/_variables.scss
@@ -7,7 +7,7 @@ $theme-values: (
 $field: (
   height: (
     roomy: 3.5rem,
-    default: 2.75rem,
+    default: 3rem,
     dense: 1.5rem
   )
 ) !default;
@@ -34,7 +34,7 @@ $label: (
   ),
   top: (
     roomy: 1.285rem,
-    default: 0.9rem
+    default: 1rem
   ),
   left: (
     default: 12px,
@@ -54,7 +54,7 @@ $label: (
     scale-default: 0.54rem
   ),
   float-scale: (
-    default: 0.875
+    default: 0.8125
   )
 ) !default;
 
@@ -68,7 +68,7 @@ $input: (
     default: 0 12px,
     top: (
       roomy: 29px,
-      default: 22px
+      default: 24px
     ),
     bottom: (
       roomy: 8px,

--- a/src/lib/field/field-constants.ts
+++ b/src/lib/field/field-constants.ts
@@ -27,14 +27,9 @@ const classes = {
   LABEL: 'forge-field--label'
 };
 
-const numbers = {
-  FLOATING_LABEL_SCALE_FACTOR: 0.875
-};
-
 export const FIELD_CONSTANTS = {
   attributes,
   observedInputAttributes,
-  numbers,
   classes
 };
 

--- a/src/lib/floating-label/_variables.scss
+++ b/src/lib/floating-label/_variables.scss
@@ -7,4 +7,4 @@ $class-name: 'forge-floating-label' !default;
 $position-y: 106% !default;
 $transition-duration: 150ms !default;
 $font-size: 1rem !default;
-$float-scale: 0.875 !default;
+$float-scale: 0.8125 !default;

--- a/src/lib/select/select/_selector.scss
+++ b/src/lib/select/select/_selector.scss
@@ -14,8 +14,10 @@
   .forge-select__selected-text {
     @include base.selected-text-core;
   }
+
   // Field Input Styles
   @include field-selector.input('.forge-select__selected-text', $exclude: (core, padding-right));
+
   // Line Height
   &:not(.forge-field--label) {
     &:not(.forge-field--dense):not(.forge-field--roomy) .forge-select__selected-text {
@@ -39,6 +41,11 @@
     &:empty::before {
       @include base.select-text-placeholder;
     }
+  }
+
+  // Padding
+  .forge-select__selected-text {
+    padding-top: 25px; // Override the default field padding styles to align text content
   }
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N/A

## Describe the new behavior?
A concern was brought up regarding the default field dimensions (text-field, select, chip-field) as being too cramped using the new inset field design. This is a valid concern and these updates use a slightly larger overall field height while also ensuring the spacing between the label and value within the field is consistent and matches our design specs.

Here are the adjustments that were made at a high level:

- Use `48px` height for the field container (increase from `44px`)
- Label `font-size` is now `13px` (decrease from `14px`)

See the screenshots below for examples of the 3 fields with the new updates included:

`<forge-text-field>`:
![image](https://user-images.githubusercontent.com/2653457/171473332-2a87806e-1550-4b82-b911-7004afc71e4e.png)

`<forge-select>`:
![image](https://user-images.githubusercontent.com/2653457/171473381-548c3d8a-81cb-4524-93fb-6931d69ab72c.png)

`<forge-chip-field>`:
![image](https://user-images.githubusercontent.com/2653457/171473430-c615ac92-7ca7-4f03-8c18-8e0e0b2103c7.png)


## Additional information
The roomy variant for each was also updated to use the new `13px` (`0.8125rem`) label `font-size` for consistency, but no other dimensions were adjusted with those variants on these components.
