### PR TITLE
fix(storybook): fix font-size in Safari

### DIFF
--- a/src/stories/preview-head.html
+++ b/src/stories/preview-head.html
@@ -6,6 +6,10 @@
 <link rel="stylesheet" href="https://cdn.forge.tylertech.com/v1/css/tyler-icons-standard.css">
 
 <style>
+  html {
+    font-size: 16px;
+  }
+
   html, body {
     height: 100%;
     width: 100%;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Fixes `font-size` issues in the Storybook preview `<iframe>`.

Safari screenshot:
![image](https://user-images.githubusercontent.com/2653457/172651694-8340f8c8-89f7-4e12-9493-75c2210da55f.png)

## Additional information
Closes #67 
