### PR TITLE
feat(list-item): emit select event when enter and space key is presse…

### DIFF
--- a/src/lib/list/list-item/index.ts
+++ b/src/lib/list/list-item/index.ts
@@ -1,6 +1,5 @@
 import { defineCustomElement } from '@tylertech/forge-core';
-
-import { ListItemComponent, IListItemComponent } from './list-item';
+import { ListItemComponent } from './list-item';
 
 export * from './list-item-adapter';
 export * from './list-item-constants';

--- a/src/lib/list/list-item/list-item-foundation.ts
+++ b/src/lib/list/list-item/list-item-foundation.ts
@@ -40,10 +40,12 @@ export class ListItemFoundation implements IListItemFoundation {
   private _wrap = false;
   private _clickListener: (evt: MouseEvent) => void;
   private _mouseDownListener: (evt: MouseEvent) => void;
+  private _keydownListener: (evt: KeyboardEvent) => void;
 
   constructor(private _adapter: IListItemAdapter) {
     this._clickListener = (evt: MouseEvent) => this._onClick(evt);
     this._mouseDownListener = (evt: MouseEvent) => this._onMouseDown(evt);
+    this._keydownListener = (evt: KeyboardEvent) => this._onKeydown(evt);
   }
 
   public initialize(): void {
@@ -58,6 +60,7 @@ export class ListItemFoundation implements IListItemFoundation {
     if (!this._static) {
       this._adapter.addListener('click', this._clickListener);
       this._adapter.addListener('mousedown', this._mouseDownListener, { passive: false, capture: true });
+      this._adapter.addListener('keydown', this._keydownListener);
     }
 
     if (this._threeLine) {
@@ -82,12 +85,25 @@ export class ListItemFoundation implements IListItemFoundation {
     }
   }
 
+  private _onKeydown(evt: KeyboardEvent): void {
+    if (evt.key === 'Enter' || evt.key === ' ') {
+      if (evt.key === ' ') {
+        evt.preventDefault();
+      }
+      this._select(evt.target as HTMLElement);
+    }
+  }
+
   /**
    * Handles clicking a list item.
    * @param evt
    */
   private _onClick(evt: MouseEvent): void {
-    const ignoreElement = evt.target && (evt.target as HTMLElement).hasAttribute(LIST_ITEM_CONSTANTS.attributes.IGNORE);
+    this._select(evt.target as HTMLElement);
+  }
+
+  private _select(targetElement: HTMLElement): void {
+    const ignoreElement = targetElement?.hasAttribute(LIST_ITEM_CONSTANTS.attributes.IGNORE);
     if (this._static || this._disabled || ignoreElement) {
       return;
     }
@@ -106,7 +122,7 @@ export class ListItemFoundation implements IListItemFoundation {
     }
 
     // If the target was not a checkbox or radio button, attempt to find one and toggle its checked state
-    if (!matchesSelectors(evt.target as HTMLElement, LIST_ITEM_CONSTANTS.selectors.CHECKBOX_RADIO_SELECTOR)) {
+    if (!matchesSelectors(targetElement, LIST_ITEM_CONSTANTS.selectors.CHECKBOX_RADIO_SELECTOR)) {
       this._adapter.tryToggleCheckboxRadio();
     }
 

--- a/src/lib/list/list/list-foundation.ts
+++ b/src/lib/list/list/list-foundation.ts
@@ -46,8 +46,6 @@ export class ListFoundation implements IListFoundation {
     const isArrowUp = evt.key === 'ArrowUp' || evt.keyCode === 38;
     const isHome = evt.key === 'Home' || evt.keyCode === 36;
     const isEnd = evt.key === 'End' || evt.keyCode === 35;
-    const isEnter = evt.key === 'Enter' || evt.keyCode === 13;
-    const isSpace = evt.key === 'Space' || evt.keyCode === 32;
     const isTab = evt.key === 'Tab' || evt.keyCode === 9;
 
     // We don't capture modifier keys
@@ -55,7 +53,7 @@ export class ListFoundation implements IListFoundation {
       return;
     }
 
-    if (!isEnter && !isSpace && !isTab) {
+    if (!isTab) {
       this._preventDefaultEvent(evt);
     }
 
@@ -67,16 +65,6 @@ export class ListFoundation implements IListFoundation {
       this._adapter.focusNextListItem();
     } else if (isArrowUp) {
       this._adapter.focusPreviousListItem();
-    } else if (isEnter || isSpace) {
-      if (evt.target && (evt.target as HTMLElement).tagName.toLowerCase() === LIST_ITEM_CONSTANTS.elementName) {
-        this._preventDefaultEvent(evt);
-        const listItem = evt.target as IListItemComponent;
-        const data: IListItemSelectEventData = {
-          value: listItem.value,
-          listItem
-        };
-        this._adapter.emitHostEvent(LIST_ITEM_CONSTANTS.events.SELECT, data);
-      }
     }
   }
 

--- a/src/test/spec/list/list-item/list-item.spec.ts
+++ b/src/test/spec/list/list-item/list-item.spec.ts
@@ -212,6 +212,22 @@ describe('ListItemComponent', function(this: ITestContext) {
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
+    it('should emit selected event when enter key is pressed', function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      const listener = jasmine.createSpy('selected listener');
+      this.context.component.addEventListener(LIST_ITEM_CONSTANTS.events.SELECT, listener);
+      (this.context as ITestListItemDefaultContext).getRootElement().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should emit selected event when enter space is pressed', function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      const listener = jasmine.createSpy('selected listener');
+      this.context.component.addEventListener(LIST_ITEM_CONSTANTS.events.SELECT, listener);
+      (this.context as ITestListItemDefaultContext).getRootElement().dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
     it('should set value via property', function(this: ITestContext) {
       this.context = setupTestContext(true);
       this.context.component.value = 1;

--- a/src/test/spec/list/list/list.spec.ts
+++ b/src/test/spec/list/list/list.spec.ts
@@ -287,7 +287,10 @@ describe('ListComponent', function(this: ITestContext) {
       const listener = jasmine.createSpy('selected listener');
       this.context.component.addEventListener(LIST_ITEM_CONSTANTS.events.SELECT, listener);
       await tick();
-      dispatchKeyEvent(this.context.getListItemComponents()[0], 'keydown', 'Enter');
+
+      const listItemEl = getShadowElement(this.context.getListItemComponents()[0], LIST_ITEM_CONSTANTS.selectors.LIST_ITEM);
+      listItemEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
@@ -296,7 +299,10 @@ describe('ListComponent', function(this: ITestContext) {
       const listener = jasmine.createSpy('selected listener');
       this.context.component.addEventListener(LIST_ITEM_CONSTANTS.events.SELECT, listener);
       await tick();
-      dispatchKeyEvent(this.context.getListItemComponents()[0], 'keydown', 'Space');
+      
+      const listItemEl = getShadowElement(this.context.getListItemComponents()[0], LIST_ITEM_CONSTANTS.selectors.LIST_ITEM);
+      listItemEl.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+
       expect(listener).toHaveBeenCalledTimes(1);
     });
 

--- a/src/test/spec/menu/menu.spec.ts
+++ b/src/test/spec/menu/menu.spec.ts
@@ -491,7 +491,9 @@ describe('MenuComponent', function(this: ITestContext) {
         this.context.component.options = options;
         this.context.component.open = true;
         await timer(300);
-        dispatchKeyEvent(getPopupListItem(0), 'keydown', 'Enter');
+        
+        getShadowElement(getPopupListItem(0), LIST_ITEM_CONSTANTS.selectors.LIST_ITEM).dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+
         await timer(300);
 
         expect(this.context.component.open).toBe(false);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?

The `keydown` handler in the `<forge-list>` element no longer captures the enter and space keys, as well as no longer emits the `forge-list-item-select` event directly. Each `<forge-list-item>` now has a new `keydown` listener applied internally to capture these two keys, and emits a the `forge-list-item-select` event the same way it would as if it were clicked. The event already bubbles by default, so this will not change any existing usages since any consumers listening for the event on the `<forge-list>` will still work, but now consumers can listen for this event on the individual `<forge-list-item>` elements and it will emit when either clicked, enter key, or space key is pressed.

## Additional information

Closes #72 

Migrated these changes from a TCW PR: https://github.com/tyler-technologies/tyler-components-web/pull/761
