### PR TITLE
fix(switch): ensure consistency with MDC switch when reattached

### DIFF
--- a/src/lib/switch/switch.ts
+++ b/src/lib/switch/switch.ts
@@ -97,13 +97,9 @@ export class SwitchComponent extends BaseComponent implements ISwitchComponent {
   }
 
   private _applyInitialState(): void {
-    if (this._disabled) {
-      this._mdcSwitch.disabled = this._disabled;
-    }
+    this._mdcSwitch.disabled = this._disabled;
+    this._mdcSwitch.selected = this._selected;
 
-    if (this._selected) {
-      this._mdcSwitch.selected = this._selected;
-    }
 
     this._applyDense();
     this._applyLabelPosition();

--- a/src/test/spec/switch/switch.spec.ts
+++ b/src/test/spec/switch/switch.spec.ts
@@ -74,6 +74,20 @@ describe('SwitchComponent', function (this: ITestContext) {
     expect(this.context.getMDCSwitch().selected).withContext('Expected MDCSwitch.selected to be true').toBeTrue();
   });
 
+  it('should properly synchronize selected state with display when reattached', async function (this: ITestContext) {
+    this.context = setupTestContext(false);
+    this.context.component.setAttribute(SWITCH_CONSTANTS.attributes.SELECTED, '');
+    this.context.append();
+    await tick();
+    this.context.component.remove();
+
+    this.context.component.selected = false;
+    document.body.appendChild(this.context.component);
+
+    expect(this.context.component.selected).withContext('Expected selected property to be false').toBeFalse();
+    expect(this.context.getMDCSwitch().selected).withContext('Expected MDCSwitch.selected to be false').toBeFalse();
+  });
+
   it('should be enabled by default', function (this: ITestContext) {
     this.context = setupTestContext();
     expect(this.context.component.disabled).withContext('Expected disabled property to be false').toBeFalse();
@@ -116,6 +130,20 @@ describe('SwitchComponent', function (this: ITestContext) {
 
     expect(this.context.component.disabled).withContext('Expected disabled property to be true').toBeTrue();
     expect(this.context.getMDCSwitch().disabled).withContext('Expected MDCSwitch.disabled to be true').toBeTrue();
+  });
+
+  it('should properly synchronize disabled state with display when reattached', async function (this: ITestContext) {
+    this.context = setupTestContext(false);
+    this.context.component.setAttribute(SWITCH_CONSTANTS.attributes.DISABLED, '');
+    this.context.append();
+    await tick();
+    this.context.component.remove();
+
+    this.context.component.disabled = false;
+    document.body.appendChild(this.context.component);
+
+    expect(this.context.component.disabled).withContext('Expected disabled property to be false').toBeFalse();
+    expect(this.context.getMDCSwitch().disabled).withContext('Expected MDCSwitch.disabled to be false').toBeFalse();
   });
 
   it('should not be dense by default', function (this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
When `connectedCallback` is invoked, the switch component will always set the `selected` and `disabled` state of the wrapped MDCSwitch to ensure consistency, not just if either is true.  This will prevent the display from being out of sync with the component state.

## Additional information
Fixes #96 
