### PR TITLE
chore: update CDN deployment strategy

### DIFF
--- a/.github/workflows/auto-pr-check.yml
+++ b/.github/workflows/auto-pr-check.yml
@@ -10,4 +10,4 @@ on:
 jobs:
   release:
     name: Pull Request Validation
-    uses: tyler-technologies/forge-automation-shared/.github/workflows/wf-auto-pr-check.yml@v0.21.0
+    uses: tyler-technologies/forge-automation-shared/.github/workflows/wf-auto-pr-check.yml@v0.22.0

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -43,7 +43,7 @@ jobs:
   build:
     name: Build and Test
     needs: wf-config
-    uses: tyler-technologies/forge-automation-shared/.github/workflows/wf-build-and-test.yml@v0.21.0
+    uses: tyler-technologies/forge-automation-shared/.github/workflows/wf-build-and-test.yml@v0.22.0
     if: ${{ needs.wf-config.outputs.build-files-changed == 'true' || needs.wf-config.outputs.test-files-changed == 'true' }}
     with:
       BUILD_ENABLED: ${{ needs.wf-config.outputs.build-files-changed == 'true' }}
@@ -54,7 +54,7 @@ jobs:
   deploy-storybook:
     name: Deploy Storybook
     needs: wf-config
-    uses: tyler-technologies/forge-automation-shared/.github/workflows/wf-publish-gh-pages.yml@v0.21.0
+    uses: tyler-technologies/forge-automation-shared/.github/workflows/wf-publish-gh-pages.yml@v0.22.0
     if: ${{ needs.wf-config.outputs.deploy-storybook == 'true' }}
     with:
       PRODUCTION_RELEASE: false

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -135,14 +135,12 @@ jobs:
   publish-cdn:
     name: Publish Components to CDN
     needs: [wf-config, build-and-release]
-    uses: tyler-technologies/forge-automation-shared/.github/workflows/wf-publish-cloudfront-assets.yml@v0.21.0
+    uses: tyler-technologies/forge-automation-shared/.github/workflows/wf-publish-cloudfront-assets.yml@v0.22.0
     if: ${{ needs.wf-config.outputs.is-release == 'true' }}
     with:
       AWS_IAM_ROLE: "arn:aws:iam::505039608154:role/forge-prod-cdnmgmt-forge"
       AWS_REGION: "us-east-1"
       AWS_S3_BUCKET_NAME: "tylerforge-s3assets51e60022-1ols9p4m4dr5y"
-      AWS_S3_BUCKET_PATH: "/v1/libs/@tylertech/forge@v2/"
-      AWS_S3_DELETE: true
       AWS_CLOUDFRONT_DISTRIBUTION_ID: "EDE7DVFI1X60B"
       MAX_CLOUDFRONT_INVALIDATIONS: 25
 
@@ -150,7 +148,7 @@ jobs:
   deploy-storybook:
     name: Deploy Storybook
     needs: wf-config
-    uses: tyler-technologies/forge-automation-shared/.github/workflows/wf-publish-gh-pages.yml@v0.21.0
+    uses: tyler-technologies/forge-automation-shared/.github/workflows/wf-publish-gh-pages.yml@v0.22.0
     if: ${{ needs.wf-config.outputs.deploy-storybook == 'true' }}
     with:
       PRODUCTION_RELEASE: true

--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -8,6 +8,6 @@ on:
 jobs:
   cleanup-storybook-pr:
     name: Cleanup Storybook Deployment
-    uses: tyler-technologies/forge-automation-shared/.github/workflows/wf-cleanup-gh-pages.yml@v0.21.0
+    uses: tyler-technologies/forge-automation-shared/.github/workflows/wf-cleanup-gh-pages.yml@v0.22.0
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Forge provides the following framework adapters:
 
 The component library is distributed on npm and as static assets on the Forge CDN.
 
+### Versioning strategy
+
+The Forge component library follows [semver](https://semver.org/) to ensure that consumers can rely on a standard versioning scheme when using Forge components.
+
 ### Using via NPM
 
 To install the library from npm:
@@ -51,6 +55,22 @@ defineButtonComponent();
 
 > **Note:** the components are actually self-defining, but without something in your application referencing those components they could be left out during bundling.
 > These definition functions ensure that the components are bundled within your application.
+
+#### Package format
+
+The `@tylertech/forge` package follows the following format:
+
+- `dist/`: Contains all pre-built static distribution sources.
+  - `<component name>/`: pre-built CSS stylesheets for specific components.
+  - `esm/`: Contains the bundled ESM JavaScript sources (includes dependencies as code-split chunks)
+  - `forge-core.css`: The optional Forge core stylesheet. Typically useful when using the `<forge-scaffold>` for your outer page layout.
+  - `forge-dark.css`: The default Forge dark theme (must be loaded after `forge.css`).
+  - `forge.css`: The pre-built Forge global stylesheet. Contains all required component-specific stylesheets. You should prefer to load individual stylesheets instead of this global stylesheet in production.
+- `esm/`: Contains the unbundled ESM JavaScript sources as the main entry to the package (includes bare module specifiers)
+- `styles/`: Contains all Sass stylesheets as a copy directly from the library.
+- `LICENSE`: The Apache 2.0 license.
+- `package.json`: The package specification.
+- `README.md`: This README.md file.
 
 #### CSS
 
@@ -74,7 +94,6 @@ The `forge.css` file contains other stylesheets that you may or may not need. We
 @use '@tylertech/forge/dist/button/forge-button.css';
 ```
 
-
 Additionally apply the `forge-typography` class to a root element (typically the `<body>`):
 
 ```html
@@ -89,24 +108,19 @@ As an example, the text-field and button components can be loaded directly like 
 
 ```html
 <!-- Optionally include a minimal base set of styles commonly used with Forge-based applications -->
-<link rel="stylesheet" href="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/forge-core.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/forge-core.css">
 
 <!-- Always include the theme and typography styles -->
-<link rel="stylesheet" href="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/theme/forge-theme.css">
-<link rel="stylesheet" href="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/typography/forge-typography.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/theme/forge-theme.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/typography/forge-typography.css">
 
 <!-- Some components (such as button) require the use of a global stylesheet (for now) -->
-<link rel="stylesheet" href="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/button/forge-button.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/button/forge-button.css">
 
 <!-- Load the ES modules JavaScript for each component you need -->
-<script type="module" src="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/text-field/index.js"></script>
-<script type="module" src="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/button/index.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/esm/text-field/index.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/esm/button/index.js"></script>
 ```
-
-> **Note:** the Forge CDN always contains the latest published changes on a per major version basis. If you need a specific version
-> please use CDN services such as [unpkg](https://unpkg.com/@tylertech/forge@2.0.0/esm/index.js).
->
-> Additionally, the components will automatically be defined within the custom element registry in the browser when loaded from the CDN.
 
 ### HTML
 

--- a/auto.config.ts
+++ b/auto.config.ts
@@ -15,7 +15,8 @@ export default function rc(): AutoRc {
       ['npm', npmOptions],
       'conventional-commits',
       'released',
-      'first-time-contributor'
+      'first-time-contributor',
+      './plugins/auto/forge-prepare-publish'
     ]
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2425,9 +2425,9 @@
       }
     },
     "@tylertech/forge-cli": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tylertech/forge-cli/-/forge-cli-2.1.0.tgz",
-      "integrity": "sha512-Q0yG6p6LHhryEffuR3g6KOVRebUj97RFS1xTWxvRsI9aTgjIwFnYIZqXDnfKJmAlqIsri4shaUJT4kcjXTUkIA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@tylertech/forge-cli/-/forge-cli-2.2.0.tgz",
+      "integrity": "sha512-9kIdVBdkKBvYXuxSjeiou7wvS8EVJ+B3KxJWToS+mm4aIfmB6YcodFbusrgFPJXP7e9FDLvwTHWBvj7vDK/XSQ==",
       "dev": true,
       "requires": {
         "@tylertech/forge-build-tools": "^2.0.0",
@@ -2564,9 +2564,9 @@
       }
     },
     "@types/eslint-scope": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
-      "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+      "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
       "dev": true,
       "requires": {
         "@types/eslint": "*",
@@ -5230,9 +5230,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.174",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.174.tgz",
-      "integrity": "sha512-JER+w+9MV2MBVFOXxP036bLlNOnzbYAWrWU8sNUwoOO69T3w4564WhM5H5atd8VVS8U4vpi0i0kdoYzm1NPQgQ==",
+      "version": "1.4.176",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.176.tgz",
+      "integrity": "sha512-92JdgyRlcNDwuy75MjuFSb3clt6DGJ2IXSpg0MCjKd3JV9eSmuUAIyWiGAp/EtT0z2D4rqbYqThQLV90maH3Zw==",
       "dev": true
     },
     "emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@commitlint/cli": "^16.2.3",
     "@commitlint/config-conventional": "^16.2.1",
     "@tylertech-eslint/eslint-plugin": "^1.0.9",
-    "@tylertech/forge-cli": "^2.1.0",
+    "@tylertech/forge-cli": "^2.2.0",
     "@tylertech/forge-testing": "^2.0.0",
     "@tylertech/stylelint-rules": "^4.0.0",
     "@types/jasmine": "^3.10.3",

--- a/plugins/auto/forge-prepare-publish.js
+++ b/plugins/auto/forge-prepare-publish.js
@@ -1,0 +1,59 @@
+const path = require('path');
+const { rename, existsSync } = require('@tylertech/forge-build-tools');
+const forgeConfig = require('../../forge.json');
+const ROOT = path.resolve(__dirname, '../../');
+const DIST_PATH = path.join(ROOT, 'dist');
+
+/**
+ * This plugin is used to hook into the `auto` pipeline after the `shipit` command has completed.
+ * 
+ * This hook will allow us to access the new version that was calculated from `Auto` and use that
+ * to update any necessary references in the project to complete deployment process, such as
+ * ensuring that the exact version is used when publishing any subsequent assets for example.
+ */
+module.exports = class ForgePreparePublishPlugin {
+  constructor() {
+    this.name = 'forge-prepare-publish';
+  }
+
+  apply(auto) {
+    // Tap into the `afterShipIt` hook to access the `newVersion` that was calculated.
+    auto.hooks.afterShipIt.tap('ForgePreparePublishPlugin', opts => this.appendVersionNumber(auto, opts));
+  }
+
+  /**
+   * Appends the new release version from Auto shipit to the CDN deployment directory
+   */
+  async appendVersionNumber(auto, { context, dryRun, newVersion }) {
+    // We only run this plugin when creating a new "latest" release
+    if (context !== 'latest') {
+      auto.logger.log.info(`Skipping ${this.name}.`);
+      return;
+    }
+
+    // Ensure the deployment path exists
+    const deploymentPath = path.join(forgeConfig.build.static.distPath, forgeConfig.packageOrg, forgeConfig.packageName);
+    if (!existsSync(path.join(DIST_PATH, deploymentPath))) {
+      auto.logger.log.error(`[${this.name}] Deployment path doesn't exist: ${deploymentPath}`);
+      return process.exit(1);
+    }
+  
+    // Concatenate the new version number to the existing deployment path
+    // For example, this will update a path like "dist/path/to/package" to this "dist/path/to/package@1.0.0"
+    const versionNumber = newVersion.replace(/^v?/, ''); // Remove leading "v" if exists
+    const versionPath = `${deploymentPath.replace(/\/?$/, '')}@${versionNumber}`;
+
+    // Stop early if this is a dry run
+    if (dryRun) {
+      auto.logger.log.info(`Would have updated CDN deployment path to: ${versionPath}`);
+      return;
+    }
+
+    // Rename the deployment directory to the new path with the version suffix
+    const currentDeploymentPath = path.join(DIST_PATH, deploymentPath);
+    const newDeploymentPath = path.join(DIST_PATH, versionPath);
+    await rename(currentDeploymentPath, newDeploymentPath);
+
+    auto.logger.log.success(`Renamed deployment path to: ${versionPath}`);
+  }
+};

--- a/src/stories/main.ts
+++ b/src/stories/main.ts
@@ -2,6 +2,7 @@ module.exports = {
   features: {
     postcss: false,
   },
+  staticDirs: ['./src/assets'],
   stories: ['./src/**/*.stories.*'],
   logLevel: 'debug',
   core: {

--- a/src/stories/package.json
+++ b/src/stories/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "start-storybook -p 6006 -c ./ -s ./src/assets",
+    "start": "start-storybook -p 6006 -c ./",
     "build": "build-storybook -c ./ -o ./dist/storybook",
     "debug": "cross-env NODE_OPTIONS=--inspect-brk STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true start-storybook -p 6006 -c ./",
-    "ci:build": "build-storybook --quiet -c ./ -s ./src/assets -o ../../dist/storybook"
+    "ci:build": "build-storybook --quiet -c ./ -o ../../dist/storybook"
   },
   "dependencies": {
     "@storybook/addon-a11y": "^6.5.7",

--- a/src/stories/src/guides/getting-started.stories.mdx
+++ b/src/stories/src/guides/getting-started.stories.mdx
@@ -31,6 +31,10 @@ Let's get started.
 
 You have a couple ways to use Forge within your application. You can install it via npm, or use it via loading ES modules that are distributed via CDN.
 
+### Versioning strategy
+
+The Forge component library follows [semver](https://semver.org/) to ensure that consumers can rely on a standard versioning scheme when using Forge components.
+
 ### npm
 
 To install the package through npm, you can simply run the following command:
@@ -71,19 +75,37 @@ certainly make your life easier when using these frameworks and we definitely re
 - [React](https://github.com/tyler-technologies/forge-react)
 - Svelte (coming soon)
 
+#### Package format
+
+The `@tylertech/forge` package follows the following format:
+
+- `dist/`: Contains all pre-built static distribution sources.
+  - `<component name>/`: pre-built CSS stylesheets for specific components.
+  - `esm/`: Contains the bundled ESM JavaScript sources (includes dependencies as code-split chunks)
+  - `forge-core.css`: The optional Forge core stylesheet. Typically useful when using the `<forge-scaffold>` for your outer page layout.
+  - `forge-dark.css`: The default Forge dark theme (must be loaded after `forge.css`).
+  - `forge.css`: The pre-built Forge global stylesheet. Contains all required component-specific stylesheets. You should prefer to load individual stylesheets instead of this global stylesheet in production.
+- `esm/`: Contains the unbundled ESM JavaScript sources as the main entry to the package (includes bare module specifiers)
+- `styles/`: Contains all Sass stylesheets as a copy directly from the library.
+- `LICENSE`: The Apache 2.0 license.
+- `package.json`: The package specification.
+- `README.md`: This README.md file.
+
 ### CDN
 
-To use Forge via CDN as statically deployed ES module bundles use the following steps.
+To use Forge via CDN as statically deployed ES module bundles and CSS stylesheets follow the guidance outlined below.
+
+> The following information is related to consuming Forge from a public CDN such as [jsdelivr](JSDELIVR).
 
 Reference the library, or a specific component via `<script type="module">` tags:
 
 ```html expanded
 <!-- This will load the whole library of components (not ideal, but good for prototyping) -->
-<script type="module" src="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/index.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/esm/index.js"></script>
 
 <!-- This will load only individual components (recommended) -->
-<script type="module" src="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/button/index.js"></script>
-<script type="module" src="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/text-field/index.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/esm/button/index.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/esm/text-field/index.js"></script>
 ```
 
 > **Note:** the custom elements in Forge are self-defining with the global custom element registry. If you want to disable that, you can set the following
@@ -103,22 +125,78 @@ CSS custom properties for theming, default typography styles and classes, and cl
 We recommend that you only reference the styles your application needs. We also provide bundled StyleSheets that include everything
 which can be nice for prototyping without having to worry about the details. See below for examples.
 
-```html expanded
-<!-- This StyleSheet provide some basic resets and setup for your application. It is optional. -->
-<link rel="stylesheet" href="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/forge-core.css">
+### npm
 
-<!-- The bare minimum StyleSheets for theming and typography. -->
-<link rel="stylesheet" href="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/theme/forge-theme.css">
-<link rel="stylesheet" href="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/typography/forge-typography.css">
+You can import the Forge stylesheets from the npm package as can be seen below:
+
+```scss expanded
+<!-- This StyleSheet provide some basic resets and setup for your application. It is optional. -->
+@use '@tylertech/forge/forge-core.css';
+
+<!-- The bare minimum StyleSheets for theming and typography. These are required. -->
+@use '@tylertech/forge/theme/forge-theme.css';
+@use '@tylertech/forge/typography/forge-typography.css';
 
 <!-- A few components in the library use light DOM (their styles are not ecapsulated by the shadow DOM). You will need to reference these StyleSheets for these components to render properly. -->
-<link rel="stylesheet" href="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/button/forge-button.css">
-<link rel="stylesheet" href="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/icon-button/forge-icon-button.css">
-<link rel="stylesheet" href="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/table/forge-table.css">
+@use '@tylertech/forge/button/forge-button.css';
+@use '@tylertech/forge/icon-button/forge-icon-button.css';
+@use '@tylertech/forge/table/forge-table.css';
 
 <!-- Contains the full Forge StyleSheet which includes styles for all components in the library. -->
-<link rel="stylesheet" href="https://cdn.forge.tylertech.com/v1/libs/@tylertech/forge@v2/forge.css">
+@use '@tylertech/forge/forge.css';
 ```
+
+> **Note:** we always recommend that you include **only** the stylesheets that your application needs instead of referencing the full `forge.css` stylesheet. Below you will
+> find an example of what the full global stylesheets brings in for you. Please copy into your app the lines that represent the stylesheets your app uses:
+>
+> ```sass expanded
+> // Theme styles (required)
+> @use '@tylertech/forge/dist/theme/forge-theme.css';
+> 
+> // Typography styles (required)
+> @use '@tylertech/forge/dist/typography/forge-typography.css';
+> 
+> // Required global component styles (if applicable)
+> @use '@tylertech/forge/dist/button/forge-button.css';
+> @use '@tylertech/forge/dist/floating-action-button/forge-floating-action-button.css';
+> @use '@tylertech/forge/dist/icon-button/forge-icon-button.css';
+> @use '@tylertech/forge/dist/table/forge-table.css';
+> @use '@tylertech/forge/dist/tooltip/forge-tooltip.css';
+> @use '@tylertech/forge/dist/ripple/forge-ripple.css';
+> @use '@tylertech/forge/dist/quantity-field/forge-quantity-field.css';
+> 
+> // Supplemental global component styles (optional but can be useful if applicable)
+> @use '@tylertech/forge/dist/popup/forge-popup.css';
+> @use '@tylertech/forge/dist/busy-indicator/forge-busy-indicator.css';
+> @use '@tylertech/forge/dist/dialog/forge-dialog.css';
+> @use '@tylertech/forge/dist/dialog/forge-dialog-utils.css';
+> @use '@tylertech/forge/dist/expansion-panel/forge-expansion-panel.css';
+> ```
+
+### CDN
+
+If you are referencing the Forge component library from the Forge CDN, you can always reference the pre-built CSS stylesheets as seen below. Again, it's important to only 
+reference the stylesheets your application is actually making use of.
+
+```html expanded
+<!-- This StyleSheet provide some basic resets and setup for your application. It is optional. -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/forge-core.css">
+
+<!-- The bare minimum StyleSheets for theming and typography. -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/theme/forge-theme.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/typography/forge-typography.css">
+
+<!-- A few components in the library use light DOM (their styles are not ecapsulated by the shadow DOM). You will need to reference these StyleSheets for these components to render properly. -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/button/forge-button.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/icon-button/forge-icon-button.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/table/forge-table.css">
+
+<!-- Contains the full Forge StyleSheet which includes styles for all components in the library. -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/forge.css">
+```
+
+> **Important:** be sure to add the `forge-typography` class to your `<body>` element (or the root element where you want Forge typography to inherit from) otherwise your typography
+> will not inherit properly in most cases.
 
 </PageSection>
 
@@ -138,3 +216,4 @@ Forge provides fonts that are distributed via a global CDN. You can easily add t
 
 [WC]: https://developer.mozilla.org/en-US/docs/Web/Web_Components
 [CE]: https://web.dev/custom-elements-v1/
+[JSDELIVR]: https://cdn.jsdelivr.net/npm/@tylertech/forge@2.0.0/dist/esm/


### PR DESCRIPTION
We are no publishing ESM deployments to the Forge CDN on a per-version basis instead of using a "latest" strategy which is error prone. This means that we will never delete or overwrite files in the CDN.

I updated our guidance in this repo and Storybook to reference the jsdelivr CDN to ensure open source consumers know how to use it, but internal guidance will be to always use the Forge CDN so we have more control over the code running in Tyler products.

These changes include a custom Auto plugin to ensure our CDN deployments use the new version generated from Auto's `shipit` command.