### PR TITLE
fix(label-value): fixed label and value alignment

### DIFF
--- a/src/lib/label-value/_mixins.scss
+++ b/src/lib/label-value/_mixins.scss
@@ -1,10 +1,197 @@
-@use './core';
+@use '@material/theme/theme' as mdc-theme;
+@use '@material/typography/typography' as mdc-typography;
+@use './variables';
 
 @mixin host() {
   display: block;
   min-width: 0;
 }
 
+@mixin base() {
+  display: flex;
+  min-height: variables.$height;
+}
+
+@mixin container() {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+@mixin icon-container() {
+  display: flex;
+  align-items: flex-start;
+}
+
+@mixin ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@mixin align-center() {
+  align-items: center;
+}
+
+@mixin align-right() {
+  align-items: flex-end;
+}
+
+@mixin label() {
+  @include mdc-typography.typography(caption);
+  @include mdc-theme.property(color, text-secondary-on-background);
+
+  font-size: 13px;
+  line-height: 1.9rem;
+}
+
+@mixin value() {
+  @include mdc-typography.typography(body1);
+
+  line-height: 0.6rem;
+}
+
+@mixin roomy() {
+  min-height: variables.$roomy-height;
+}
+
+@mixin dense() {
+  min-height: variables.$dense-height;
+}
+
+@mixin container-dense() {
+  flex-direction: row;
+  align-items: center;
+}
+
+@mixin dense-label() {
+  line-height: 1.25rem;
+  margin-right: 8px;
+}
+
+@mixin dense-value() {
+  line-height: 1.25rem;
+  font-size: 0.875rem;
+}
+
+@mixin roomy-label() {
+  line-height: 2.1rem;
+}
+
+@mixin roomy-value() {
+  line-height: 0.6rem;
+}
+
+@mixin empty-value() {
+  @include mdc-theme.property(color, text-secondary-on-background);
+
+  font-style: italic;
+}
+
+@mixin icon() {
+  @include mdc-theme.property(color, text-primary-on-background);
+
+  font-size: 1.25rem !important;
+  margin-right: 8px;
+  margin-top: 4px;
+}
+
+@mixin dense-icon() {
+  margin-top: 2px;
+}
+
+@mixin roomy-icon() {
+  margin-top: 6px;
+}
+
 @mixin core-styles() {
-  @include core.core-styles;
+  .forge-label-value {
+    @include base;
+
+    &__container {
+      @include container;
+    }
+
+    &__icon-container {
+      @include icon-container;
+
+      ::slotted([slot='icon']) {
+        @include icon;
+      }
+    }
+
+    &--align-center {
+      .forge-label-value__container {
+        @include align-center;
+      }
+    }
+
+    &--align-right {
+      .forge-label-value__container {
+        @include align-right;
+      }
+    }
+
+    &__label {
+      @include label;
+    }
+
+    &__value {
+      @include value;
+    }
+
+    &--roomy {
+      @include roomy;
+
+      .forge-label-value__label {
+        @include roomy-label;
+      }
+
+      .forge-label-value__value {
+        @include roomy-value;
+      }
+
+      ::slotted([slot='icon']) {
+        @include roomy-icon;
+      }
+    }
+
+    &--dense {
+      @include dense;
+
+      .forge-label-value__container {
+        @include container-dense;
+
+        .forge-label-value__label {
+          @include dense-label;
+        }
+
+        .forge-label-value__value {
+          @include dense-value;
+        }
+
+      }
+      
+      ::slotted([slot='icon']) {
+        @include dense-icon;
+      }
+    }
+
+    &--empty {
+      .forge-label-value__value {
+        @include empty-value;
+      }
+    }
+
+    &--ellipsis {
+      .forge-label-value__container {
+        overflow: hidden;
+
+        .forge-label-value__label,
+        .forge-label-value__value {
+          @include ellipsis;
+        }
+      }
+    }
+  }
 }

--- a/src/lib/label-value/_variables.scss
+++ b/src/lib/label-value/_variables.scss
@@ -1,32 +1,6 @@
-$root: (
-  padding: (
-    top: ( // adjusts label position from top of field, in raster space
-      default: 5px,
-      roomy: 7px
-    )
-  )
-) !default;
+@use '../theme/theme-values';
 
-$label: (
-  transform: (
-    translate: (
-      x: ( // moves label back to keyline after scaling, in vector space
-        default: -6.8%,
-        roomy: -7.2%
-      ),
-      y: ( // moves label back to baseline after scaling, in vector space
-        default: -2%,
-        roomy: 1%
-      )
-    )
-  ),
-  margin: (
-    right: (
-      single-line: 8px
-    ),
-    bottom: ( // adjust value position from bottom of label, in raster space
-      default: -1px,
-      roomy: 5px
-    )
-  )
-) !default;
+$color: rgba(theme-values.$on-surface, 0.6);
+$height: 3rem;
+$dense-height: 1.5rem;
+$roomy-height: 3.5rem;

--- a/src/lib/label-value/label-value.scss
+++ b/src/lib/label-value/label-value.scss
@@ -1,7 +1,5 @@
 @use './mixins';
 
-@include mixins.core-styles;
-
 :host {
   @include mixins.host;
 }
@@ -10,3 +8,4 @@
   display: none;
 }
 
+@include mixins.core-styles;

--- a/src/stories/src/components/text-field/text-field.mdx
+++ b/src/stories/src/components/text-field/text-field.mdx
@@ -117,7 +117,7 @@ The `default` variant is intended to be used in desktop applications.
 
 <PageSection>
 
-## CSS custom properties
+## CSS parts
 
 | Name                              | Description
 | :---------------------------------| :----------------


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The label-value previously underwent a style refactor back when the field styles were encapsulated and shared between the text-field, select, and chip-field. The label-value component is intended to match the dimensions and alignment of those other components, so we refactored it to utilize the shared styles. This introduced too much complexity for this simple component, specifically around using a `transform` on the label which is unnecessary.

This change reverts that original style refactor back to its more simple implementation of styles, and adjusts the `font-size` to properly match that of the other field-related components, as well as ensures the dimensions and alignment match for each density.

The following screenshot of the changes shows that the dimensions and location of elements are properly aligned Left side is label-value, right side is text-field. First is default density, second is roomy density. The dense density was also adjusted slightly to match the 24px height but is not shown here.

![image](https://user-images.githubusercontent.com/2653457/179079723-e47c0dbc-accb-4a78-8cba-ec3087c1507b.png)


## Additional information
Fixes #111 
