### PR TITLE
fix(circular-progress): fixed default radius of circle to fill available height and width

### DIFF
--- a/src/lib/circular-progress/_mixins.scss
+++ b/src/lib/circular-progress/_mixins.scss
@@ -73,9 +73,10 @@
       transition: mdc-animation-functions.exit-temporary(opacity, 250ms);
     }
 
-    // FORGE (new): added custom property for setting stroke-width
+    // FORGE (new): added custom properties for setting stroke-width and radius
     circle {
       @include theme.css-custom-property(stroke-width, --forge-circular-progress-stroke-width, variables.$stroke-width);
+      @include theme.css-custom-property(r, --forge-circular-progress-radius, variables.$radius);
     }
 
     ::slotted(*) {

--- a/src/lib/circular-progress/_variables.scss
+++ b/src/lib/circular-progress/_variables.scss
@@ -24,6 +24,7 @@ $color: tertiary !default; // FORGE (modify): use tertiary theme by default
 $track-color: transparent !default;
 $size: 72px !default; // FORGE (new): added default size
 $stroke-width: 4; // FORGE (new): added default stroke-width
+$radius: 22; // FORGE (new): added default radius
 
 /// The rotation position of the arcs that corresponds to their fully contracted state
 $base-angle: 135deg !default;

--- a/src/stories/src/components/circular-progress/circular-progress.mdx
+++ b/src/stories/src/components/circular-progress/circular-progress.mdx
@@ -94,10 +94,11 @@ Gets/sets the progress percentage. Valid values are between 0 and 1.
 
 | Name                                            | Description
 | :-----------------------------------------------| :----------
-| `--forge-theme-tertiary`                          | Sets the stroke color.
-| `--forge-circular-progress-track-color`           | Sets the track (background) color.
-| `--forge-circular-progress-size`                  | Sets the diameter of the circle. Default is `72px`.
-| `--forge-circular-progress-stroke-width`          | Sets the stroke width of the outline. Default is `4`.
+| `--forge-theme-tertiary`                        | Sets the stroke color.
+| `--forge-circular-progress-track-color`         | Sets the track (background) color.
+| `--forge-circular-progress-size`                | Sets the diameter of the circle. Default is `72px`.
+| `--forge-circular-progress-stroke-width`        | Sets the stroke width of the outline. Default is `4`.
+| `--forge-circular-progress-radius`              | Sets the radius (`r` style) of the circle within the internal `<svg>`. Default is `22`.
 
 </PageSection>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Added a new `--forge-circular-progress-radius` CSS custom property to control the `r` style of the `<circle>` element when non-default `stroke-width` values are used. This custom property uses a new default radius of `22` (instead of `18` which is the default in the template that MDC was using) and now allows for consumers to easily adjust the radius as needed.

![image](https://user-images.githubusercontent.com/2653457/179236538-6397dd69-59d9-4fd7-8edb-f78a21ca1dc0.png)


## Additional information
Fixes #112 
