### PR TITLE
fix(circular-progress): fixed visibility of component on Firefox and Safari

### DIFF
--- a/src/lib/circular-progress/_variables.scss
+++ b/src/lib/circular-progress/_variables.scss
@@ -24,7 +24,7 @@ $color: tertiary !default; // FORGE (modify): use tertiary theme by default
 $track-color: transparent !default;
 $size: 72px !default; // FORGE (new): added default size
 $stroke-width: 4; // FORGE (new): added default stroke-width
-$radius: 22; // FORGE (new): added default radius
+$radius: 22px; // FORGE (new): added default radius
 
 /// The rotation position of the arcs that corresponds to their fully contracted state
 $base-angle: 135deg !default;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The default radius size has been changed from `22` to `22px` to include the `px` unit for compatibility with Firefox and Safari because those browsers were ignoring the value before. Chrome supports both usages and the component is now properly visible in all browsers with the defaults.

## Additional information
#117 
