### PR TITLE
revert(circular-progress): reverted changes to radius customization t…

### DIFF
--- a/src/lib/circular-progress/_mixins.scss
+++ b/src/lib/circular-progress/_mixins.scss
@@ -76,7 +76,6 @@
     // FORGE (new): added custom properties for setting stroke-width and radius
     circle {
       @include theme.css-custom-property(stroke-width, --forge-circular-progress-stroke-width, variables.$stroke-width);
-      @include theme.css-custom-property(r, --forge-circular-progress-radius, variables.$radius);
     }
 
     ::slotted(*) {

--- a/src/lib/circular-progress/_variables.scss
+++ b/src/lib/circular-progress/_variables.scss
@@ -24,7 +24,6 @@ $color: tertiary !default; // FORGE (modify): use tertiary theme by default
 $track-color: transparent !default;
 $size: 72px !default; // FORGE (new): added default size
 $stroke-width: 4; // FORGE (new): added default stroke-width
-$radius: 22px; // FORGE (new): added default radius
 
 /// The rotation position of the arcs that corresponds to their fully contracted state
 $base-angle: 135deg !default;

--- a/src/stories/src/components/circular-progress/circular-progress.mdx
+++ b/src/stories/src/components/circular-progress/circular-progress.mdx
@@ -98,7 +98,6 @@ Gets/sets the progress percentage. Valid values are between 0 and 1.
 | `--forge-circular-progress-track-color`         | Sets the track (background) color.
 | `--forge-circular-progress-size`                | Sets the diameter of the circle. Default is `72px`.
 | `--forge-circular-progress-stroke-width`        | Sets the stroke width of the outline. Default is `4`.
-| `--forge-circular-progress-radius`              | Sets the radius (`r` style) of the circle within the internal `<svg>`. Default is `22`.
 
 </PageSection>
 


### PR DESCRIPTION
Reverted the changes in #116 and #118 due to conflicts in how MDC renders its SVG. This will unfortunately require a new JavaScript API to calculate the proper values based on the desired radius which we will not be able to do via CSS due to `viewBox` customization...

We may look to revert back to our TCW 1.x implementation which allows for much easier customization.

We need to revert this change because it is not allowing the `progress` value to render properly.