### PR TITLE
fix(theme): Fix elevation references in shadow mixin

### DIFF
--- a/src/lib/theme/_theme.scss
+++ b/src/lib/theme/_theme.scss
@@ -4,6 +4,7 @@
 @use '@material/theme/theme-color' as mdc-theme-color;
 @use '@material/theme/replace';
 @use '@material/theme/keys' as mdc-keys;
+@use '@material/elevation/elevation-theme' as elevation-theme;
 @use './custom-properties';
 @use './keys';
 @use './theme-values';
@@ -251,7 +252,7 @@
   @return #{$umbra-z-value} #{$umbra-color}, #{$penumbra-z-value} #{$penumbra-color}, #{$ambient-z-value} #{$ambient-color};
 }
 
-@mixin shadow($z-value, $color: $mdc-elevation-baseline-color, $opacity-boost: 0) {
+@mixin shadow($z-value, $color: elevation-theme.$baseline-color, $opacity-boost: 0) {
   box-shadow: elevation($z-value, $color, $opacity-boost);
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: n/a
- Docs have been added / updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?
Fixing the following errors:

```
SassError: Undefined variable.
    ╷
259 │ @mixin shadow($z-value, $color: $mdc-elevation-baseline-color, $opacity-boost: 0) {
    │                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
  node_modules/@tylertech/forge/styles/theme/_theme.scss 259:33   shadow()
```

```
SassError: There is no module with the namespace "elevation-theme".
    ╷
237 │ @function elevation($z-value, $color: elevation-theme.$baseline-color, $opacity-boost: 0) {
    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
  node_modules/@tylertech/forge/styles/theme/_theme.scss 237:39    elevation()
```
