### PR TITLE
fix(theme): use hex value without opacity for `border-color` theme style

### DIFF
--- a/src/lib/theme/_theme-values.scss
+++ b/src/lib/theme/_theme-values.scss
@@ -223,7 +223,7 @@ $property-values-dark: (
 
   // forge-specific theme properties
   tertiary: #{mdc-color-palette.$amber-200},
-  border-color: rgba(255, 255, 255, 0.12),
+  border-color: #464646,
   form-field-icon-disabled-on-background: rgba(255, 255, 255, 0.26),
   form-field-disabled-on-background: #353535,
   form-field-text-disabled-on-background: rgba(255, 255, 255, 0.6),

--- a/src/stories/src/core/theme-color-grid.tsx
+++ b/src/stories/src/core/theme-color-grid.tsx
@@ -1,105 +1,105 @@
 import React, { FC } from 'react';
 
 const colors = {
-  primary: {
+  '--mdc-theme-primary': {
     value: '#3f51b5'
   },
-  secondary: {
+  '--mdc-theme-secondary': {
     value: '#ffc107'
   },
-  tertiary: {
+  '--forge-theme-tertiary': {
     value: '#3d5afe'
   },
-  background: {
+  '--mdc-theme-background': {
     value: '#fafafa'
   },
-  error: {
+  '--mdc-theme-error': {
     value: '#b00020'
   },
-  'on-primary': {
+  '--mdc-theme-on-primary': {
     value: '#ffffff'
   },
-  'on-secondary': {
+  '--mdc-theme-on-secondary': {
     value: '#000000'
   },
-  'on-tertiary': {
+  '--forge-theme-on-tertiary': {
     value: '#ffffff'
   },
-  surface: {
+  '--mdc-theme-surface': {
     value: '#ffffff'
   },
-  'on-surface': {
+  '--mdc-theme-on-surface': {
     value: '#000000'
   },
-  'on-error': {
+  '--mdc-theme-on-error': {
     value: '#ffffff'
   },
-  'text-primary-on-background': {
+  '--mdc-theme-text-primary-on-background': {
     value: 'rgba(0, 0, 0, 0.87)'
   },
-  'text-secondary-on-background': {
+  '--mdc-theme-text-secondary-on-background': {
     value: 'rgba(0, 0, 0, 0.54)'
   },
-  'text-hint-on-background': {
+  '--mdc-theme-text-hint-on-background': {
     value: 'rgba(0, 0, 0, 0.38)'
   },
-  'text-disabled-on-background': {
+  '--mdc-theme-text-disabled-on-background': {
     value: 'rgba(0, 0, 0, 0.12)'
   },
 
   // Forge-specific
-  'border-color': {
+  '--forge-theme-border-color': {
     value: '#e0e0e0'
   },
-  danger: {
+  '--forge-theme-danger': {
     value: '#b00020'
   },
-  'error-hover': {
+  '--forge-theme-error-hover': {
     value: '#db8a98'
   },
-  warning: {
+  '--forge-theme-warning': {
     value: '#d14900'
   },
-  success: {
+  '--forge-theme-success': {
     value: '#2e7d32'
   },
-  info: {
+  '--forge-theme-info': {
     value: '#424242'
   },
-  'icon-color': {
+  '--forge-theme-icon-color': {
     value: '#757575'
   },
-  'form-field-label-on-background': {
+  '--forge-theme-form-field-label-on-background': {
     value: 'rgba(0, 0, 0, 0.65)'
   },
-  'form-field-icon-disabled-on-background': {
+  '--forge-theme-form-field-icon-disabled-on-background': {
     value: 'rgba(0, 0, 0, 0.26)'
   },
-  'form-field-text-disabled-on-background': {
+  '--forge-theme-form-field-text-disabled-on-background': {
     value: 'rgba(0, 0, 0, 0.6)'
   },
-  'form-field-disabled-on-background': {
+  '--forge-theme-form-field-disabled-on-background': {
     value: '#f5f5f5'
   },
-  'label-disabled-on-background': {
+  '--forge-theme-label-disabled-on-background': {
     value: 'rgba(0, 0, 0, 0.38)'
   },
-  'elevated-surface': {
+  '--forge-theme-elevated-surface': {
     value: '#ffffff'
   },
-  'on-elevated-surface': {
+  '--forge-theme-on-elevated-surface': {
     value: 'rgba(0, 0, 0, 0.87)'
   },
-  'scrollbar-thumb': {
+  '--forge-theme-scrollbar-thumb': {
     value: '#bdbdbd'
   },
-  'scrollbar-thumb-hover': {
+  '--forge-theme-scrollbar-thumb-hover': {
     value: '#9e9e9e'
   },
-  'scrollbar-track': {
+  '--forge-theme-scrollbar-track': {
     value: '#f0f0f0'
   },
-  'scrollbar-track-hover': {
+  '--forge-theme-scrollbar-track-hover': {
     value: '#ececec'
   }
 };
@@ -109,23 +109,23 @@ const ThemeColorGrid: FC = () => (
     <thead>
       <tr className="forge-table-row forge-table-head__row">
         <th className="forge-table-cell forge-table-head__cell">Theme</th>
-        <th className="forge-table-cell forge-table-head__cell">Value</th>
+        <th className="forge-table-cell forge-table-head__cell">Value (light theme)</th>
         <th className="forge-table-cell forge-table-head__cell">Example</th>
       </tr>
     </thead>
     <tbody>
       {Object.keys(colors).map(theme => {
-        const { value, description } = colors[theme];
+        const { value } = colors[theme];
         return (
           <tr key={theme} className="forge-table-row forge-table-body__row">
             <td className="forge-table-cell forge-table-body__cell">
-              <code className="forge-typography--caption">{theme}</code>
+              <code className="forge-docs-core__inline-code">{theme}</code>
             </td>
             <td className="forge-table-cell forge-table-body__cell">
               <code className="forge-docs-core__inline-code">{value}</code>
             </td>
             <td className="forge-table-cell forge-table-body__cell">
-              <div style={{ backgroundColor: value, height: '24px', width: '24px', borderRadius: '4px', border: '1px solid var(--forge-theme-border-color)' }}></div>
+              <div style={{ backgroundColor: `var(${theme}, ${value})`, height: '24px', width: '24px', borderRadius: '4px', border: '1px solid var(--forge-theme-border-color)' }}></div>
             </td>
           </tr>
         );

--- a/src/stories/src/guides/theming.stories.mdx
+++ b/src/stories/src/guides/theming.stories.mdx
@@ -34,7 +34,9 @@ properties, you can always target internal elements directly using the [CSS Shad
 
 ## Colors
 
-Below you will find an example of the default theme colors provided by Forge, and their corresponding semantic names and values.
+Below you will find an example of the default theme colors provided by Forge, and their corresponding semantic CSS custom property names and values.
+
+> **Note:** the example colors will change automatically based on whether dark/light theme is currently being used.
 
 <ThemeColorGrid />
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The `border-color` style will now use a hex color without an opacity to ensure that the color is properly rendered without the background color affecting the result and potentially causing unintended artifacts.

I included a separate change to the theming guide as well to ensure that the CSS custom property names are documented to help reduce confusion.

## Additional information
Fixes #123 
