### PR TITLE
fix(select): fixed placeholder text alignment when no label is set

### DIFF
--- a/src/lib/select/select/_selector.scss
+++ b/src/lib/select/select/_selector.scss
@@ -44,8 +44,10 @@
   }
 
   // Padding
-  .forge-select__selected-text {
-    padding-top: 25px; // Override the default field padding styles to align text content
+  .forge-select--label {
+    .forge-select__selected-text {
+      padding-top: 25px; // Override the default field padding styles to align text content
+    }
   }
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The placeholder text is now aligned properly in all densities when no label text is set:
![image](https://user-images.githubusercontent.com/2653457/185147577-af64b29d-4287-469e-b94d-6874e32c19d5.png)

## Additional information
Fixes #128 
