### PR TITLE
fix(drawer): fixed popup positioning within scrollable drawer content

### DIFF
--- a/src/lib/core/utils/event-utils.ts
+++ b/src/lib/core/utils/event-utils.ts
@@ -1,0 +1,11 @@
+/**
+ * Proxies a `scroll` event from an element and dispatches it from another element.
+ * Typically used when proxying the event from an element within a shadow root from its host element in the light dom.
+ * @param originalEl The element that the `scroll` event originated from.
+ * @param targetEl The element to manually dispatch (proxy) the `scroll` event from.
+ */
+export function proxyShadowScrollEvent(shadowEl: Node, proxyEl: Node): () => void {
+  const scrollListenerFn = (): boolean => proxyEl.dispatchEvent(new Event('scroll'));
+  shadowEl.addEventListener('scroll', scrollListenerFn, true);
+  return () => shadowEl.removeEventListener('scroll', scrollListenerFn, true);
+}

--- a/src/lib/core/utils/index.ts
+++ b/src/lib/core/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './date-utils';
+export * from './event-utils';
 export * from './svg-utils';
 export * from './time-utils';
 export * from './utils';

--- a/src/lib/drawer/base/base-drawer-adapter.ts
+++ b/src/lib/drawer/base/base-drawer-adapter.ts
@@ -1,9 +1,12 @@
 import { addClass, getShadowElement, removeClass } from '@tylertech/forge-core';
+import { proxyShadowScrollEvent } from '../../core/utils/event-utils';
 import { BaseAdapter, IBaseAdapter } from '../../core/base/base-adapter';
 import { IBaseDrawerComponent } from './base-drawer';
 import { DrawerDirection, BASE_DRAWER_CONSTANTS } from './base-drawer-constants';
 
 export interface IBaseDrawerAdapter extends IBaseAdapter {
+  proxyScrollEvent(): void;
+  tryUnproxyScrollEvent(): void;
   setDirection(direction: DrawerDirection): void;
   removeDrawerClass(className: string | string[]): void;
   setDrawerClass(className: string | string[]): void;
@@ -13,10 +16,25 @@ export interface IBaseDrawerAdapter extends IBaseAdapter {
 export class BaseDrawerAdapter extends BaseAdapter<IBaseDrawerComponent> implements IBaseDrawerAdapter {
   protected _drawerElement: HTMLElement;
   private _activeTransitionListener: ((evt: TransitionEvent) => void) | undefined;
+  private _unproxyScrollEventCb: (() => void) | undefined;
 
   constructor(protected _component: IBaseDrawerComponent) {
     super(_component);
     this._drawerElement = getShadowElement(this._component, BASE_DRAWER_CONSTANTS.selectors.DRAWER);
+  }
+
+  public proxyScrollEvent(): void {
+    // We proxy the scroll event because our internal scroll container does not dispatch this event outside of the shadow root to any listeners.
+    // This is a problem because if we have any components that need to react to the scroll event, such as our popup elements, they will not be
+    // notified. This will ensure we always proxy this event out from the host. 
+    this.tryUnproxyScrollEvent();
+    this._unproxyScrollEventCb = proxyShadowScrollEvent(this._component.shadowRoot as ShadowRoot, this._component);
+  }
+
+  public tryUnproxyScrollEvent(): void {
+    if (this._unproxyScrollEventCb) {
+      this._unproxyScrollEventCb();
+    }
   }
 
   public setDirection(direction: DrawerDirection): void {

--- a/src/lib/drawer/base/base-drawer-foundation.ts
+++ b/src/lib/drawer/base/base-drawer-foundation.ts
@@ -21,10 +21,12 @@ export class BaseDrawerFoundation implements IBaseDrawerFoundation {
   public connect(): void {
     this._applyOpen();
     this._applyDirection();
+    this._adapter.proxyScrollEvent();
     this._hasInitialized = true;
   }
 
   public disconnect(): void {
+    this._adapter.tryUnproxyScrollEvent();
     this._hasInitialized = false;
   }
 


### PR DESCRIPTION
Fixes #130  

It was discovered that because the scroll container for this element is within the shadow dom of the drawer that the `scroll` event was not making it past the shadow root of the element. This is standard browser functionality.

The fix is to capture the scroll event from within the shadow dom and then manually dispatch a new `scroll` event from the drawer host element. This allows the capturing window scroll listener on the popup component to execute and fix the anchored positioning.