### PR TITLE
fix(select): fix a11y when navigating options via keyboard and screen reader

### DIFF
--- a/src/lib/select/select/select-adapter.ts
+++ b/src/lib/select/select/select-adapter.ts
@@ -66,10 +66,13 @@ export class SelectAdapter extends BaseSelectAdapter implements ISelectAdapter {
 
   public initializeAccessibility(): void {
     this._component.setAttribute('role', 'combobox');
-    this._component.setAttribute('aria-live', 'assertive');
-    this._component.setAttribute('aria-atomic', 'true');
     this._component.setAttribute('aria-haspopup', 'true');
     this._component.setAttribute('aria-expanded', 'false');
+
+    // We need to ensure the host element receives a non-negative tabindex for our interactions to work properly
+    if (!this._component.hasAttribute('tabindex') || this._component.tabIndex === -1) {
+      this._component.tabIndex = 0;
+    }
   }
 
   public initializeFloatingLabel(): IFloatingLabel {
@@ -96,27 +99,27 @@ export class SelectAdapter extends BaseSelectAdapter implements ISelectAdapter {
   }
 
   public addClickListener(listener: (evt: Event) => void): void {
-    this._selectElement.addEventListener('click', listener);
+    this._component.addEventListener('click', listener);
   }
 
   public removeClickListener(listener: (evt: Event) => void): void {
-    this._selectElement.removeEventListener('click', listener);
+    this._component.removeEventListener('click', listener);
   }
 
   public addMouseDownListener(listener: (evt: MouseEvent) => void): void {
-    this._selectElement.addEventListener('mousedown', listener);
+    this._component.addEventListener('mousedown', listener);
   }
 
   public removeMouseDownListener(listener: (evt: MouseEvent) => void): void {
-    this._selectElement.removeEventListener('mousedown', listener);
+    this._component.removeEventListener('mousedown', listener);
   }
 
   public addTargetListener(type: string, listener: (evt: Event) => void): void {
-    this._selectedTextElement.addEventListener(type, listener);
+    this._component.addEventListener(type, listener);
   }
 
   public removeTargetListener(type: string, listener: (evt: Event) => void): void {
-    this._selectedTextElement.removeEventListener(type, listener);
+    this._component.removeEventListener(type, listener);
   }
 
   public open(config: IListDropdownConfig): void {
@@ -165,7 +168,7 @@ export class SelectAdapter extends BaseSelectAdapter implements ISelectAdapter {
   public setDisabled(isDisabled: boolean): void {
     toggleClass(this._selectElement, isDisabled, FIELD_CONSTANTS.classes.DISABLED);
     toggleAttribute(this._component, isDisabled, 'aria-disabled', 'true');
-    this._selectedTextElement.tabIndex = isDisabled ? -1 : 0;
+    this._component.tabIndex = isDisabled ? -1 : 0;
   }
 
   public setInvalid(isInvalid: boolean): void {
@@ -218,7 +221,7 @@ export class SelectAdapter extends BaseSelectAdapter implements ISelectAdapter {
   }
 
   public setFocus(): void {
-    this._selectedTextElement.focus();
+    this._component.focus();
   }
 
   public isWithinSelf(element: HTMLElement): boolean {

--- a/src/lib/select/select/select-foundation.ts
+++ b/src/lib/select/select/select-foundation.ts
@@ -174,8 +174,7 @@ export class SelectFoundation extends BaseSelectFoundation<ISelectAdapter> imple
     if (this._disabled) {
       return;
     }
-    this._adapter.addRootClass(FIELD_CONSTANTS.classes.FOCUSED);
-    this._floatLabel(true);
+    this._setFocused();
     super._onFocus(evt);
   }
 
@@ -226,6 +225,12 @@ export class SelectFoundation extends BaseSelectFoundation<ISelectAdapter> imple
       }
     }
     return result;
+  }
+
+  /** Updates the state of the component to contain focus. */
+  private _setFocused(): void {
+    this._adapter.addRootClass(FIELD_CONSTANTS.classes.FOCUSED);
+    this._floatLabel(true);
   }
 
   /** Updates the state of the component to not contain focus. */

--- a/src/lib/select/select/select.html
+++ b/src/lib/select/select/select.html
@@ -5,8 +5,8 @@
         <slot name="leading"></slot>
       </div>
       <div class="forge-field__label-input-container" part="label-input-container">
-        <div id="selected-text" class="forge-select__selected-text" tabindex="0" part="text"></div>
-        <label id="select-label" part="label"></label>
+        <div id="selected-text" class="forge-select__selected-text" part="text"></div>
+        <label id="select-label" aria-hidden="true" part="label"></label>
       </div>
       <forge-icon class="forge-select__dropdown-icon" name="arrow_drop_down" part="icon"></forge-icon>
       <div class="forge-field__addon-end-container" part="addon-end-container">

--- a/src/lib/select/select/select.scss
+++ b/src/lib/select/select/select.scss
@@ -7,6 +7,10 @@
   @include mixins.host;
 }
 
+:host(:focus) {
+  outline: none;
+}
+
 :host([hidden]) {
   display: none;
 }

--- a/src/lib/select/select/select.ts
+++ b/src/lib/select/select/select.ts
@@ -148,9 +148,4 @@ export class SelectComponent extends BaseSelectComponent<SelectFoundation> imple
   /** Gets/sets the placeholder text. */
   @FoundationProperty()
   public placeholder: string;
-
-  /** Sets focus to the internal button element. */
-  public override focus(): void {
-    this._foundation.setFocus();
-  }
 }

--- a/src/test/spec/select/select-component-delegate.spec.ts
+++ b/src/test/spec/select/select-component-delegate.spec.ts
@@ -120,10 +120,9 @@ describe('SelectComponentDelegate', function(this: ITestContext) {
 
     const value = `${DEFAULT_OPTIONS[0].value}`;
     this.context.component.open = true;
-    
-    const selectedTextElement = getShadowElement(this.context.component, SELECT_CONSTANTS.selectors.SELECTED_TEXT);
-    dispatchKeyEvent(selectedTextElement, 'keydown', 'ArrowDown');
-    dispatchKeyEvent(selectedTextElement, 'keydown', 'Enter');
+
+    dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
+    dispatchKeyEvent(this.context.component, 'keydown', 'Enter');
 
     expect(changeSpy).toHaveBeenCalledOnceWith(value);
   });
@@ -133,9 +132,7 @@ describe('SelectComponentDelegate', function(this: ITestContext) {
 
     const focusSpy = jasmine.createSpy('focus spy');
     this.context.delegate.onFocus(focusSpy);
-
-    const selectedTextElement = getShadowElement(this.context.component, SELECT_CONSTANTS.selectors.SELECTED_TEXT);
-    selectedTextElement.focus();
+    this.context.component.focus();
 
     expect(focusSpy).toHaveBeenCalledTimes(1);
   });
@@ -146,9 +143,8 @@ describe('SelectComponentDelegate', function(this: ITestContext) {
     const blurSpy = jasmine.createSpy('blur spy');
     this.context.delegate.onBlur(blurSpy);
 
-    const selectedTextElement = getShadowElement(this.context.component, SELECT_CONSTANTS.selectors.SELECTED_TEXT);
-    selectedTextElement.focus();
-    selectedTextElement.blur();
+    this.context.component.focus();
+    this.context.component.blur();
 
     expect(blurSpy).toHaveBeenCalledTimes(1);
   });

--- a/src/test/spec/select/select.spec.ts
+++ b/src/test/spec/select/select.spec.ts
@@ -14,7 +14,7 @@ import {
 } from '@tylertech/forge/select';
 import { POPUP_CONSTANTS, IPopupComponent } from '@tylertech/forge/popup';
 import { LIST_ITEM_CONSTANTS, IListItemComponent } from '@tylertech/forge/list/list-item';
-import { removeElement, getShadowElement, getActiveElement } from '@tylertech/forge-core';
+import { removeElement, getShadowElement } from '@tylertech/forge-core';
 import { tick, dispatchNativeEvent, dispatchKeyEvent, timer, deepCopy } from '@tylertech/forge-testing';
 import { FLOATING_LABEL_CONSTANTS } from '@tylertech/forge/floating-label';
 import { LIST_DROPDOWN_CONSTANTS, ListDropdownHeaderBuilder, ListDropdownFooterBuilder } from '@tylertech/forge/list-dropdown/list-dropdown-constants';
@@ -253,7 +253,7 @@ describe('SelectComponent', function(this: ITestContext) {
       this.context = setupTestContext(true);
       
       await tick();
-      dispatchNativeEvent(this.context.selectedTextElement, 'focus');
+      dispatchNativeEvent(this.context.component, 'focus');
       await floatTick();
       expect(this.context.rootElement.classList.contains(FIELD_CONSTANTS.classes.FOCUSED)).toBe(true);
       expect(this.context.label.classList.contains(FLOATING_LABEL_CONSTANTS.classes.FLOAT_ABOVE)).toBe(true);
@@ -276,9 +276,9 @@ describe('SelectComponent', function(this: ITestContext) {
       
         this.context.component.options = DEFAULT_OPTIONS;
         await tick();
-        dispatchNativeEvent(this.context.selectedTextElement, 'focus');
+        dispatchNativeEvent(this.context.component, 'focus');
         await tick();
-        dispatchKeyEvent(this.context.selectedTextElement, 'keydown', key);
+        dispatchKeyEvent(this.context.component, 'keydown', key);
         await tick();
         expect(this.context.component.popupElement).toBeDefined();
         expect(this.context.component.popupElement!.isConnected).toBe(true);
@@ -292,9 +292,9 @@ describe('SelectComponent', function(this: ITestContext) {
       this.context.component.options = DEFAULT_OPTIONS;
       this.context.component.multiple = true;
       await tick();
-      dispatchNativeEvent(this.context.selectedTextElement, 'focus');
+      dispatchNativeEvent(this.context.component, 'focus');
       await tick();
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
       await tick();
       expect(this.context.component.open).toBe(true);
       expect(this.context.component.popupElement).toBeDefined();
@@ -445,10 +445,8 @@ describe('SelectComponent', function(this: ITestContext) {
       await tick();
       
       this.context.component.focus();
-      const deepActiveElement = getActiveElement();
       
       expect(document.activeElement).toBe(this.context.component);
-      expect(deepActiveElement).toBe(this.context.selectedTextElement);
     });
 
     it('should handle removing label by destroying floating label instance', async function(this: ITestContext) {
@@ -466,7 +464,7 @@ describe('SelectComponent', function(this: ITestContext) {
       await tick();
       
       this.context.component.disabled = true;
-      this.context.selectedTextElement.click();
+      this.context.component.click();
 
       expect(document.activeElement).not.toBe(this.context.component);
     });
@@ -477,7 +475,7 @@ describe('SelectComponent', function(this: ITestContext) {
       
       await _triggerPopupOpen(this.context.component);
 
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Escape');
+      dispatchKeyEvent(this.context.component, 'keydown', 'Escape');
       await _popupAnimation();
       
       _expectPopupVisibility(this.context.component.popupElement, false);
@@ -487,8 +485,8 @@ describe('SelectComponent', function(this: ITestContext) {
       this.context = setupTestContext(true);
       await tick();
       
-      this.context.selectedTextElement.focus();
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Space');
+      this.context.component.focus();
+      dispatchKeyEvent(this.context.component, 'keydown', 'Space');
       await _popupAnimation();
 
       _expectPopupVisibility(this.context.component.popupElement, true);
@@ -500,7 +498,7 @@ describe('SelectComponent', function(this: ITestContext) {
       
       await _triggerPopupOpen(this.context.component);
 
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Space');
+      dispatchKeyEvent(this.context.component, 'keydown', 'Space');
       await _popupAnimation();
 
       _expectPopupVisibility(this.context.component.popupElement, false);
@@ -513,8 +511,8 @@ describe('SelectComponent', function(this: ITestContext) {
       await _triggerPopupOpen(this.context.component);
       expect(this.context.component.value).toBeUndefined();
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Enter');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'Enter');
       await _popupAnimation();
 
       expect(this.context.component.value).toBe(DEFAULT_OPTIONS[0].value);
@@ -528,8 +526,8 @@ describe('SelectComponent', function(this: ITestContext) {
       await _triggerPopupOpen(this.context.component);
       expect(this.context.component.value).toBeUndefined();
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Tab');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'Tab');
       await _popupAnimation();
 
       expect(this.context.component.value).toBe(DEFAULT_OPTIONS[0].value);
@@ -544,8 +542,8 @@ describe('SelectComponent', function(this: ITestContext) {
       await _triggerPopupOpen(this.context.component);
       expect(this.context.component.value).toEqual([]);
 
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Tab');
-      this.context.selectedTextElement.blur();
+      dispatchKeyEvent(this.context.component, 'keydown', 'Tab');
+      this.context.component.blur();
       await _popupAnimation();
 
       expect(this.context.component.value).toEqual([]);
@@ -559,7 +557,7 @@ describe('SelectComponent', function(this: ITestContext) {
       await _triggerPopupOpen(this.context.component);
       expect(this.context.component.value).toBeUndefined();
 
-      this.context.selectedTextElement.blur();
+      this.context.component.blur();
       await _popupAnimation();
 
       expect(this.context.component.value).toBeUndefined();
@@ -574,8 +572,8 @@ describe('SelectComponent', function(this: ITestContext) {
       await _triggerPopupOpen(this.context.component);
       expect(this.context.component.value).toBeUndefined();
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Enter');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'Enter');
       await _popupAnimation();
 
       expect(this.context.component.value).toBeUndefined();
@@ -591,8 +589,8 @@ describe('SelectComponent', function(this: ITestContext) {
       this.context.component.addEventListener(BASE_SELECT_CONSTANTS.events.CHANGE, changeSpy);
       await _triggerPopupOpen(this.context.component);
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Enter');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'Enter');
       await _popupAnimation();
 
       expect(eventTargetValue).toBe(DEFAULT_OPTIONS[0].value);
@@ -606,8 +604,8 @@ describe('SelectComponent', function(this: ITestContext) {
       await _triggerPopupOpen(this.context.component);
       expect(this.context.component.value).toBeUndefined();
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Enter');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'Enter');
       await _popupAnimation();
 
       expect(this.context.component.value).toBeUndefined();
@@ -622,7 +620,8 @@ describe('SelectComponent', function(this: ITestContext) {
       this.context.component.multiple = true;
       await _triggerPopupOpen(this.context.component);
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Enter');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'Enter');
       await _popupAnimation();
 
       expect(this.context.component.value).toEqual([]);
@@ -640,8 +639,8 @@ describe('SelectComponent', function(this: ITestContext) {
       await _triggerPopupOpen(this.context.component);
       expect(this.context.component.value).toBeUndefined();
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Enter');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'Enter');
       await _popupAnimation();
       await timer();
 
@@ -656,8 +655,8 @@ describe('SelectComponent', function(this: ITestContext) {
       const beforeChangeSpy = jasmine.createSpy('beforeValueChange spy', evt => {}).and.callThrough();
       this.context.component.addEventListener(BASE_SELECT_CONSTANTS.events.CHANGE, beforeChangeSpy);
       await _triggerPopupOpen(this.context.component);
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Enter');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'Enter');
 
       expect(beforeChangeSpy).toHaveBeenCalledWith(jasmine.objectContaining({ detail: DEFAULT_OPTIONS[0].value }));
     });
@@ -669,8 +668,8 @@ describe('SelectComponent', function(this: ITestContext) {
       const beforeChangeSpy = jasmine.createSpy('beforeValueChange spy', value => true).and.callThrough();
       this.context.component.beforeValueChange = beforeChangeSpy;
       await _triggerPopupOpen(this.context.component);
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Enter');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'Enter');
 
       expect(beforeChangeSpy).toHaveBeenCalledWith(DEFAULT_OPTIONS[0].value);
     });
@@ -697,17 +696,17 @@ describe('SelectComponent', function(this: ITestContext) {
       expect(this.context.component.value).toEqual([]);
       
       // First we check to see if pressing enter selects the active option and keeps the popup open
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Enter');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'Enter');
       await _popupAnimation();
       
       expect(this.context.component.value).toEqual([DEFAULT_OPTIONS[0].value]);
       _expectPopupVisibility(this.context.component.popupElement, true);
       
       // Now we check to see if pressing enter deselects the active option
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowUp');
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Enter');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowUp');
+      dispatchKeyEvent(this.context.component, 'keydown', 'Enter');
       await _popupAnimation();
 
       expect(this.context.component.value).toEqual([]);
@@ -721,7 +720,7 @@ describe('SelectComponent', function(this: ITestContext) {
       await _triggerPopupOpen(this.context.component);
       _expectActiveOption(this.context.component.popupElement!, -1);
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
       _expectActiveOption(this.context.component.popupElement!, 0);
     });
 
@@ -731,10 +730,10 @@ describe('SelectComponent', function(this: ITestContext) {
       
       await _triggerPopupOpen(this.context.component);
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
       _expectActiveOption(this.context.component.popupElement!, 0);
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowUp');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowUp');
       _expectActiveOption(this.context.component.popupElement!, DEFAULT_OPTIONS.length - 1);
     });
 
@@ -744,7 +743,7 @@ describe('SelectComponent', function(this: ITestContext) {
 
       await _triggerPopupOpen(this.context.component);
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowUp');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowUp');
 
       const optionContext = _getOptionContext(this.context.component.popupElement);
       _expectActiveOption(this.context.component.popupElement, optionContext.options.length - 1);
@@ -755,9 +754,9 @@ describe('SelectComponent', function(this: ITestContext) {
       await tick();
       
       await _triggerPopupOpen(this.context.component);
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'End');
+      dispatchKeyEvent(this.context.component, 'keydown', 'End');
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
 
       _expectActiveOption(this.context.component.popupElement, 0);
     });
@@ -768,7 +767,7 @@ describe('SelectComponent', function(this: ITestContext) {
       
       await _triggerPopupOpen(this.context.component);
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'End');
+      dispatchKeyEvent(this.context.component, 'keydown', 'End');
 
       const optionContext = _getOptionContext(this.context.component.popupElement);
       _expectActiveOption(this.context.component.popupElement, optionContext.options.length - 1);
@@ -779,10 +778,10 @@ describe('SelectComponent', function(this: ITestContext) {
       await tick();
       
       await _triggerPopupOpen(this.context.component);
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'End');
+      dispatchKeyEvent(this.context.component, 'keydown', 'End');
       _expectActiveOption(this.context.component.popupElement, 2);
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'Home');
+      dispatchKeyEvent(this.context.component, 'keydown', 'Home');
 
       _expectActiveOption(this.context.component.popupElement, 0);
     });
@@ -797,8 +796,8 @@ describe('SelectComponent', function(this: ITestContext) {
       this.context.component.options = opts;
 
       await _triggerPopupOpen(this.context.component);
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
       
       _expectActiveOption(this.context.component.popupElement, 2);
     });
@@ -813,10 +812,10 @@ describe('SelectComponent', function(this: ITestContext) {
       this.context.component.options = opts;
 
       await _triggerPopupOpen(this.context.component);
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'End');
+      dispatchKeyEvent(this.context.component, 'keydown', 'End');
       _expectActiveOption(this.context.component.popupElement, 2);
 
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowUp');      
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowUp');      
       _expectActiveOption(this.context.component.popupElement, 0);
     });
 
@@ -826,7 +825,7 @@ describe('SelectComponent', function(this: ITestContext) {
       
       await _triggerPopupOpen(this.context.component);
       
-      _sendFilterKey(this.context.selectedTextElement, 't', 84);
+      _sendFilterKey(this.context.component, 't', 84);
       await timer();
 
       _expectActiveOption(this.context.component.popupElement, 1);
@@ -839,8 +838,8 @@ describe('SelectComponent', function(this: ITestContext) {
       
       await _triggerPopupOpen(this.context.component);
       
-      _sendFilterKey(this.context.selectedTextElement, 't', 84);
-      _sendFilterKey(this.context.selectedTextElement, 'h', 72);
+      _sendFilterKey(this.context.component, 't', 84);
+      _sendFilterKey(this.context.component, 'h', 72);
       await timer();
 
       _expectActiveOption(this.context.component.popupElement, 2);
@@ -850,7 +849,7 @@ describe('SelectComponent', function(this: ITestContext) {
       this.context = setupTestContext(true);
       await tick();
       
-      _sendFilterKey(this.context.selectedTextElement, 't', 84);
+      _sendFilterKey(this.context.component, 't', 84);
       await timer();
       
       expect(this.context.component.value).toBe(DEFAULT_OPTIONS[1].value);
@@ -860,8 +859,8 @@ describe('SelectComponent', function(this: ITestContext) {
       this.context = setupTestContext(true);
       await tick();
       
-      _sendFilterKey(this.context.selectedTextElement, 't', 84);
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'End');
+      _sendFilterKey(this.context.component, 't', 84);
+      dispatchKeyEvent(this.context.component, 'keydown', 'End');
       await timer();
       
       expect(this.context.foundation['_filterTimeout']).toBeUndefined();
@@ -871,7 +870,7 @@ describe('SelectComponent', function(this: ITestContext) {
       this.context = setupTestContext(true);
       await tick();
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
       await timer();
       
       expect(this.context.component.value).toBe(DEFAULT_OPTIONS[0].value);
@@ -881,7 +880,7 @@ describe('SelectComponent', function(this: ITestContext) {
       this.context = setupTestContext(true);
       await tick();
       
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowUp');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowUp');
       await timer();
       
       expect(this.context.component.value).toBe(DEFAULT_OPTIONS[2].value);
@@ -892,8 +891,8 @@ describe('SelectComponent', function(this: ITestContext) {
       await tick();
       
       this.context.component.multiple = true;
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowUp');
-      dispatchKeyEvent(this.context.selectedTextElement, 'keydown', 'ArrowDown');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowUp');
+      dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
       await timer();
       
       expect(this.context.component.value).toEqual([]);
@@ -1001,14 +1000,14 @@ describe('SelectComponent', function(this: ITestContext) {
       this.context = setupTestContext(true);
       await tick();
       
-      this.context.selectedTextElement.focus();
+      this.context.component.focus();
       _openDropdown(this.context.component);
       
       await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
       _expectPopupVisibility(this.context.component.popupElement, true);
 
-      this.context.selectedTextElement.blur();
-      this.context.selectedTextElement.dispatchEvent(new Event('blur'));
+      this.context.component.blur();
+      this.context.component.dispatchEvent(new Event('blur'));
       await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
 
       _expectPopupVisibility(this.context.component.popupElement, false);
@@ -1265,11 +1264,10 @@ describe('SelectComponent', function(this: ITestContext) {
       document.body.appendChild(this.context.fixture);
       await tick();
 
-      const selectedTextElement = getShadowElement(this.context.component, SELECT_CONSTANTS.selectors.SELECTED_TEXT);
       await tick();
       this.context.component.selectedIndex = 1;
       expect(this.context.component.value).toBe('two');
-      expect(selectedTextElement.innerText).toBe('Two');
+      expect(this.context.selectedTextElement.innerText).toBe('Two');
     });
   });
 
@@ -1438,8 +1436,7 @@ describe('SelectComponent', function(this: ITestContext) {
   }
 
   function _openDropdown(component: ISelectComponent): void {
-    const element = getShadowElement(component, SELECT_CONSTANTS.selectors.SELECTED_TEXT);
-    element.click();
+    component.click();
   }
 
   function setupTestContext(append?: boolean): ITestSelectContext {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N/A

## Describe the new behavior?
Fixes the accessibility of the component by ensuring that options and state are announced properly by screen readers. The focus has been moved from the internal selected text element to the host element to ensure that the options are announced properly.

## Additional information
Migrated these changes from TCW:
https://github.com/tyler-technologies/tyler-components-web/pull/768

