### PR TITLE
chore(docs): fix css custom prop docs for floating action button

### DIFF
--- a/src/stories/src/components/fab/fab.mdx
+++ b/src/stories/src/components/fab/fab.mdx
@@ -94,7 +94,7 @@ Controls the exited state. This animates the FAB in/out with a transition while 
 | Name                                | Description
 | :-----------------------------------| :----------------------
 | `--mdc-theme-secondary`             | Controls the background color.
-| `--mdc-theme-text-primary-on-light` | Controls the font color.
+| `--mdc-theme-on-secondary`          | Controls the font color.
 
 </PageSection>
 


### PR DESCRIPTION
The FAB docs were not updated to reflect the latest CSS custom property changes between TCW 1.x and Forge 2.0. This change fixes one of CSS custom properties that is documented incorrectly.

We really need to automate the docs generation soon...