### PR TITLE
docs(chip-field): add missing slot docs

### DIFF
--- a/src/stories/src/components/chip-field/chip-field.mdx
+++ b/src/stories/src/components/chip-field/chip-field.mdx
@@ -121,12 +121,16 @@ Controls the floating state of the label. Call this to manually float the label.
 
 ## Slots
 
+> A default (unnamed) slot exists, and it is intended that an `<input>` element will be placed in this slot.
+
 | Name                           | Description
 | :------------------------------| :----------------
 | `label`                        | Projects the label element into the correct location with the proper typography.
 | `member`                       | Projects each element with this slot to the collection area of the component. This slot will be present on each element comprising your collection.
-| `default`                      | The default (unnamed) slot is the input. Projects the input into the correct location.
 | `helper-text`                  | Places content below the component with the proper typography.
+| `leading`                      | Places content such as icons before the input.
+| `trailing`                     | Places content such as icons after the input.
+| `addon-end`                    | Places an element (such as icon button for example) after the input.
 
 </PageSection>
 


### PR DESCRIPTION
Fixes #132 

Adds the missing inherited "field" slot names to the chip-field docs. I did not update the constants file because this component inherits from the abstract field implementation (the shared slot names are located in the field constants file).