### PR TITLE
fix(button-toggle-group): allow falsy values in change event

### DIFF
--- a/src/lib/button-toggle/button-toggle-group/button-toggle-group-foundation.ts
+++ b/src/lib/button-toggle/button-toggle-group/button-toggle-group-foundation.ts
@@ -89,7 +89,7 @@ export class ButtonToggleGroupFoundation implements IButtonToggleGroupFoundation
 
   private _getValue(): any {
     const selections = this._adapter.getSelectedValues();
-    return this._multiple ? Array.from(new Set(selections)) : selections.slice(0, 1)[0] || null;
+    return this._multiple ? Array.from(new Set(selections)) : selections.slice(0, 1)[0] ?? null;
   }
 
   private _applyValue(value: any): void {

--- a/src/test/spec/button-toggle/button-toggle.spec.ts
+++ b/src/test/spec/button-toggle/button-toggle.spec.ts
@@ -196,6 +196,19 @@ describe('ButtonToggleComponent', function(this: ITestContext) {
       expect(changeSpy).toHaveBeenCalledWith(jasmine.objectContaining({ detail: [DEFAULT_OPTIONS[1].value, DEFAULT_OPTIONS[2].value] }));
     });
 
+    it('should emit change event from group with falsy values', function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      
+      const selectSpy = jasmine.createSpy('select listener');
+      this.context.component.addEventListener(BUTTON_TOGGLE_GROUP_CONSTANTS.events.CHANGE, selectSpy);
+
+      const buttonToggles = _getButtonToggles(this.context.component);
+      buttonToggles[0].value = 0;
+      _clickToggle(buttonToggles[0]);
+
+      expect(selectSpy).toHaveBeenCalledOnceWith(jasmine.objectContaining({ detail: 0 }));
+    });
+
     it('should emit select event', function(this: ITestContext) {
       this.context = setupTestContext(true);
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The button-toggle-group change event was coercing falsy values (such as `0`) to `null` instead of explicitly checking for `null` or `undefined`. This change allows falsy values to flow through from the button-toggle component.
