### PR TITLE
feat: showHourOptions for time-picker

### DIFF
--- a/src/demo/scripts/time-picker.js
+++ b/src/demo/scripts/time-picker.js
@@ -7,6 +7,7 @@
   var maskedCheckbox = example.querySelector('#time-picker-masked');
   var showMaskFormatCheckbox = example.querySelector('#time-picker-show-mask-format');
   var showNowCheckbox = example.querySelector('#time-picker-show-now');
+  var showNowOnlyCheckbox = example.querySelector('#time-picker-show-now-only');
   var useCustomOptionsCheckbox = example.querySelector('#time-picker-custom-options');
   var useCustomCallbacksCheckbox = example.querySelector('#time-picker-custom-callbacks');
   var allowDropdownCheckbox = example.querySelector('#time-picker-allow-dropdown');
@@ -69,6 +70,9 @@
   });
   showNowCheckbox.addEventListener('change', function() {
     timePicker.showNow = showNowCheckbox.checked;
+  });
+  showNowOnlyCheckbox.addEventListener('change', function() {
+    timePicker.showNowOnly = showNowOnlyCheckbox.checked;
   });
   useCustomOptionsCheckbox.addEventListener('change', function() {
     timePicker.customOptions = useCustomOptionsCheckbox.checked ? CUSTOM_OPTIONS : [];

--- a/src/demo/scripts/time-picker.js
+++ b/src/demo/scripts/time-picker.js
@@ -7,7 +7,7 @@
   var maskedCheckbox = example.querySelector('#time-picker-masked');
   var showMaskFormatCheckbox = example.querySelector('#time-picker-show-mask-format');
   var showNowCheckbox = example.querySelector('#time-picker-show-now');
-  var showNowOnlyCheckbox = example.querySelector('#time-picker-show-now-only');
+  var showHourOptionsCheckbox = example.querySelector('#time-picker-show-now-only');
   var useCustomOptionsCheckbox = example.querySelector('#time-picker-custom-options');
   var useCustomCallbacksCheckbox = example.querySelector('#time-picker-custom-callbacks');
   var allowDropdownCheckbox = example.querySelector('#time-picker-allow-dropdown');
@@ -71,8 +71,8 @@
   showNowCheckbox.addEventListener('change', function() {
     timePicker.showNow = showNowCheckbox.checked;
   });
-  showNowOnlyCheckbox.addEventListener('change', function() {
-    timePicker.showNowOnly = showNowOnlyCheckbox.checked;
+  showHourOptionsCheckbox.addEventListener('change', function() {
+    timePicker.showHourOptions = showHourOptionsCheckbox.checked;
   });
   useCustomOptionsCheckbox.addEventListener('change', function() {
     timePicker.customOptions = useCustomOptionsCheckbox.checked ? CUSTOM_OPTIONS : [];

--- a/src/demo/scripts/time-picker.js
+++ b/src/demo/scripts/time-picker.js
@@ -7,7 +7,7 @@
   var maskedCheckbox = example.querySelector('#time-picker-masked');
   var showMaskFormatCheckbox = example.querySelector('#time-picker-show-mask-format');
   var showNowCheckbox = example.querySelector('#time-picker-show-now');
-  var showHourOptionsCheckbox = example.querySelector('#time-picker-show-now-only');
+  var showHourOptionsCheckbox = example.querySelector('#time-picker-show-hour-option');
   var useCustomOptionsCheckbox = example.querySelector('#time-picker-custom-options');
   var useCustomCallbacksCheckbox = example.querySelector('#time-picker-custom-callbacks');
   var allowDropdownCheckbox = example.querySelector('#time-picker-allow-dropdown');

--- a/src/lib/time-picker/time-picker-constants.ts
+++ b/src/lib/time-picker/time-picker-constants.ts
@@ -19,6 +19,7 @@ const attributes = {
   STEP: 'step',
   ALLOW_INPUT: 'allow-input',
   SHOW_NOW: 'show-now',
+  SHOW_NOW_ONLY: 'show-now-only',
   DISABLED: 'disabled',
   POPUP_CLASSES: 'popup-classes',
   ALLOW_DROPDOWN: 'allow-dropdown'

--- a/src/lib/time-picker/time-picker-constants.ts
+++ b/src/lib/time-picker/time-picker-constants.ts
@@ -19,7 +19,7 @@ const attributes = {
   STEP: 'step',
   ALLOW_INPUT: 'allow-input',
   SHOW_NOW: 'show-now',
-  SHOW_NOW_ONLY: 'show-now-only',
+  SHOW_HOUR_OPTIONS: 'show-hour-options',
   DISABLED: 'disabled',
   POPUP_CLASSES: 'popup-classes',
   ALLOW_DROPDOWN: 'allow-dropdown'

--- a/src/lib/time-picker/time-picker-foundation.ts
+++ b/src/lib/time-picker/time-picker-foundation.ts
@@ -655,7 +655,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
 
     // Append all leading options
     if (leadingOptions.length) {
-      if (times.length > 0) {
+      if (times.length !== 0) {
         times.splice(0, 0, { label: '', value: null, divider: true });
       }
       leadingOptions.forEach((o, index) => times.splice(index, 0, o));

--- a/src/lib/time-picker/time-picker-foundation.ts
+++ b/src/lib/time-picker/time-picker-foundation.ts
@@ -545,7 +545,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
     let activeStartIndex: number | undefined;
     
     // Find closest match in list of time options and activate/select it
-    if(options.length) {
+    if (options.length) {
       if (this._value !== null) {
         const optionIndex = this._findClosestOptionIndex(this._value, selectableOptions);
         if (optionIndex >= 0) {

--- a/src/lib/time-picker/time-picker-foundation.ts
+++ b/src/lib/time-picker/time-picker-foundation.ts
@@ -642,9 +642,20 @@ export class TimePickerFoundation implements ITimePickerFoundation {
     }
 
     // Check if we need to show the Hours options
-    if (this._showHourOptions) {
-      const value: ITimePickerOptionValue = { time: null, metadata: 'now' };
-      leadingOptions.push({ label: 'Hours Options', value });
+    if (!this._showHourOptions) {
+      // while loop
+      // while(times.length > 0) {
+      //   times.pop();
+      // }
+
+      // splice time
+      times.splice(0, times.length);
+
+      // override length
+      // times.length = 0;
+
+      // Requires times to not be a constant
+      // times = [];
     }
 
     // Check for any custom provided options to prepend

--- a/src/lib/time-picker/time-picker-foundation.ts
+++ b/src/lib/time-picker/time-picker-foundation.ts
@@ -618,22 +618,25 @@ export class TimePickerFoundation implements ITimePickerFoundation {
     const times: IListDropdownOption[] = [];
     let leadingOptions: IListDropdownOption[] = [];
     
-    for (let totalMinutes = minMinutes; totalMinutes <= maxMinutes; totalMinutes += minuteStep) {
-      if (totalMinutes === TIME_PICKER_CONSTANTS.numbers.MAX_DAY_MINUTES) {
-        break;
+    if (this._showHourOptions) {
+      for (let totalMinutes = minMinutes; totalMinutes <= maxMinutes; totalMinutes += minuteStep) {
+        if (totalMinutes === TIME_PICKER_CONSTANTS.numbers.MAX_DAY_MINUTES) {
+          break;
+        }
+        const millis = minutesToMillis(totalMinutes);
+        const disabled = this._restrictedTimes.includes(millis);
+        const label = millisToTimeString(millis, this._use24HourTime, false) || '';
+        const value: ITimePickerOptionValue = { time: millis };
+        times.push({ label, value, disabled });
       }
-      const millis = minutesToMillis(totalMinutes);
-      const disabled = this._restrictedTimes.includes(millis);
-      const label = millisToTimeString(millis, this._use24HourTime, false) || '';
-      const value: ITimePickerOptionValue = { time: millis };
-      times.push({ label, value, disabled });
+
+      // Add divider between AM/PM times
+      const firstPmIndex = times.findIndex(t => t.value.time / 1000 / 60 >= 720);
+      if (firstPmIndex >= 0 && firstPmIndex < times.length - 1) {
+        times.splice(firstPmIndex, 0, { label: '', value: null, divider: true });
+      }
     }
 
-    // Add divider between AM/PM times
-    const firstPmIndex = times.findIndex(t => t.value.time / 1000 / 60 >= 720);
-    if (firstPmIndex >= 0 && firstPmIndex < times.length - 1) {
-      times.splice(firstPmIndex, 0, { label: '', value: null, divider: true });
-    }
 
     // Check if we need to prepend a "Now" option
     if (this._showNow) {
@@ -652,14 +655,10 @@ export class TimePickerFoundation implements ITimePickerFoundation {
 
     // Append all leading options
     if (leadingOptions.length) {
-      times.splice(0, 0, { label: '', value: null, divider: true });
+      if (times.length > 0) {
+        times.splice(0, 0, { label: '', value: null, divider: true });
+      }
       leadingOptions.forEach((o, index) => times.splice(index, 0, o));
-    }
-
-    // Check if we need to show the Hours options
-    if (!this._showHourOptions) {
-      // empty times array
-      times.splice(0, times.length);
     }
 
     return times;

--- a/src/lib/time-picker/time-picker-foundation.ts
+++ b/src/lib/time-picker/time-picker-foundation.ts
@@ -531,7 +531,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
   }
 
   private _openDropdown(): void {
-    if (!this.allowDropdown) {
+    if (!this.allowDropdown || this._generateTimeOptions.length) {
       return;
     }
 
@@ -545,20 +545,22 @@ export class TimePickerFoundation implements ITimePickerFoundation {
     let activeStartIndex: number | undefined;
     
     // Find closest match in list of time options and activate/select it
-    if (this._value !== null) {
-      const optionIndex = this._findClosestOptionIndex(this._value, selectableOptions);
-      if (optionIndex >= 0) {
-        const isExactMatch = selectableOptions[optionIndex].value.time === this._value;
-        if (isExactMatch) {
-          selectedValues = [selectableOptions[optionIndex].value];
-        } else {
+    if(options.length) {
+      if (this._value !== null) {
+        const optionIndex = this._findClosestOptionIndex(this._value, selectableOptions);
+        if (optionIndex >= 0) {
+          const isExactMatch = selectableOptions[optionIndex].value.time === this._value;
+          if (isExactMatch) {
+            selectedValues = [selectableOptions[optionIndex].value];
+          } else {
+            activeStartIndex = optionIndex;
+          }
+        }
+      } else if (typeof this._startTime === 'number') {
+        const optionIndex = this._findClosestOptionIndex(this._startTime, selectableOptions);
+        if (optionIndex >= 0 && optionIndex < selectableOptions.length) {
           activeStartIndex = optionIndex;
         }
-      }
-    } else if (typeof this._startTime === 'number') {
-      const optionIndex = this._findClosestOptionIndex(this._startTime, selectableOptions);
-      if (optionIndex >= 0 && optionIndex < selectableOptions.length) {
-        activeStartIndex = optionIndex;
       }
     }
 
@@ -590,10 +592,14 @@ export class TimePickerFoundation implements ITimePickerFoundation {
   }
 
   private _findClosestOptionIndex(value: number, options: Array<IListDropdownOption<ITimePickerOptionValue>>): number {
-    const closestItem = options.reduce((prev, curr) => {
+    if (options.length) {
+      const closestItem = options.reduce((prev, curr) => {
                           return Math.abs((curr.value.time || 0) - value) < Math.abs((prev.value.time || 0) - value) ? curr : prev;
                         });
-    return options.indexOf(closestItem);
+      return options.indexOf(closestItem);
+    } else {
+      return 0;
+    }
   }
 
   private _formatInputValue(emitEvents = true): void {
@@ -655,7 +661,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
 
     // Append all leading options
     if (leadingOptions.length) {
-      if (times.length !== 0) {
+      if (times.length) {
         times.splice(0, 0, { label: '', value: null, divider: true });
       }
       leadingOptions.forEach((o, index) => times.splice(index, 0, o));

--- a/src/lib/time-picker/time-picker-foundation.ts
+++ b/src/lib/time-picker/time-picker-foundation.ts
@@ -30,7 +30,7 @@ export interface ITimePickerFoundation extends ICustomElementFoundation {
   step: number;
   allowInput: boolean;
   showNow: boolean;
-  showNowOnly: boolean;
+  showHourOptions: boolean;
   customOptions: ITimePickerOption[];
   validationCallback: TimePickerValidationCallback;
   parseCallback: TimePickerParseCallback;
@@ -60,7 +60,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
   private _allowInvalidTime = false;
   private _popupTarget: string;
   private _showNow = false;
-  private _showNowOnly = false;
+  private _showHourOptions = true;
   private _customOptions: ITimePickerOption[] = [];
   private _validationCallback: TimePickerValidationCallback;
   private _parseCallback: TimePickerParseCallback;
@@ -641,10 +641,10 @@ export class TimePickerFoundation implements ITimePickerFoundation {
       leadingOptions.push({ label: 'Now', value });
     }
 
-    // Check if we need to show only a "Now" option
-    if (this._showNowOnly) {
+    // Check if we need to show the Hours options
+    if (this._showHourOptions) {
       const value: ITimePickerOptionValue = { time: null, metadata: 'now' };
-      leadingOptions.push({ label: 'Now Only', value });
+      leadingOptions.push({ label: 'Hours Options', value });
     }
 
     // Check for any custom provided options to prepend
@@ -893,12 +893,12 @@ export class TimePickerFoundation implements ITimePickerFoundation {
     }
   }
 
-  public get showNowOnly(): boolean {
-    return this._showNowOnly;
+  public get showHourOptions(): boolean {
+    return this._showHourOptions;
   }
-  public set showNowOnly(value: boolean) {
-    if (this._showNowOnly !== value) {
-      this._showNowOnly = value;
+  public set showHourOptions(value: boolean) {
+    if (this._showHourOptions !== value) {
+      this._showHourOptions = value;
     }
   }
 

--- a/src/lib/time-picker/time-picker-foundation.ts
+++ b/src/lib/time-picker/time-picker-foundation.ts
@@ -641,23 +641,6 @@ export class TimePickerFoundation implements ITimePickerFoundation {
       leadingOptions.push({ label: 'Now', value });
     }
 
-    // Check if we need to show the Hours options
-    if (!this._showHourOptions) {
-      // while loop
-      // while(times.length > 0) {
-      //   times.pop();
-      // }
-
-      // splice time
-      times.splice(0, times.length);
-
-      // override length
-      // times.length = 0;
-
-      // Requires times to not be a constant
-      // times = [];
-    }
-
     // Check for any custom provided options to prepend
     if (Array.isArray(this._customOptions) && this._customOptions.length) {
       const options = this._customOptions.map(o => {
@@ -671,6 +654,12 @@ export class TimePickerFoundation implements ITimePickerFoundation {
     if (leadingOptions.length) {
       times.splice(0, 0, { label: '', value: null, divider: true });
       leadingOptions.forEach((o, index) => times.splice(index, 0, o));
+    }
+
+    // Check if we need to show the Hours options
+    if (!this._showHourOptions) {
+      // empty times array
+      times.splice(0, times.length);
     }
 
     return times;

--- a/src/lib/time-picker/time-picker-foundation.ts
+++ b/src/lib/time-picker/time-picker-foundation.ts
@@ -30,6 +30,7 @@ export interface ITimePickerFoundation extends ICustomElementFoundation {
   step: number;
   allowInput: boolean;
   showNow: boolean;
+  showNowOnly: boolean;
   customOptions: ITimePickerOption[];
   validationCallback: TimePickerValidationCallback;
   parseCallback: TimePickerParseCallback;
@@ -59,6 +60,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
   private _allowInvalidTime = false;
   private _popupTarget: string;
   private _showNow = false;
+  private _showNowOnly = false;
   private _customOptions: ITimePickerOption[] = [];
   private _validationCallback: TimePickerValidationCallback;
   private _parseCallback: TimePickerParseCallback;
@@ -639,6 +641,12 @@ export class TimePickerFoundation implements ITimePickerFoundation {
       leadingOptions.push({ label: 'Now', value });
     }
 
+    // Check if we need to show only a "Now" option
+    if (this._showNowOnly) {
+      const value: ITimePickerOptionValue = { time: null, metadata: 'now' };
+      leadingOptions.push({ label: 'Now Only', value });
+    }
+
     // Check for any custom provided options to prepend
     if (Array.isArray(this._customOptions) && this._customOptions.length) {
       const options = this._customOptions.map(o => {
@@ -882,6 +890,15 @@ export class TimePickerFoundation implements ITimePickerFoundation {
   public set showNow(value: boolean) {
     if (this._showNow !== value) {
       this._showNow = value;
+    }
+  }
+
+  public get showNowOnly(): boolean {
+    return this._showNowOnly;
+  }
+  public set showNowOnly(value: boolean) {
+    if (this._showNowOnly !== value) {
+      this._showNowOnly = value;
     }
   }
 

--- a/src/lib/time-picker/time-picker-foundation.ts
+++ b/src/lib/time-picker/time-picker-foundation.ts
@@ -531,15 +531,16 @@ export class TimePickerFoundation implements ITimePickerFoundation {
   }
 
   private _openDropdown(): void {
-    if (!this.allowDropdown || this._generateTimeOptions.length) {
+    const options = this._generateTimeOptions();
+
+    if (!this.allowDropdown || !options.length) {
       return;
     }
-
+    
     this._formatInputValue();
     this._open = true;
     this._adapter.setHostAttribute(TIME_PICKER_CONSTANTS.attributes.OPEN);
-
-    const options = this._generateTimeOptions();
+    
     const selectableOptions = options.filter(o => !o.divider && !o.disabled);
     let selectedValues: ITimePickerOptionValue[] = [];
     let activeStartIndex: number | undefined;
@@ -592,14 +593,10 @@ export class TimePickerFoundation implements ITimePickerFoundation {
   }
 
   private _findClosestOptionIndex(value: number, options: Array<IListDropdownOption<ITimePickerOptionValue>>): number {
-    if (options.length) {
-      const closestItem = options.reduce((prev, curr) => {
-                          return Math.abs((curr.value.time || 0) - value) < Math.abs((prev.value.time || 0) - value) ? curr : prev;
-                        });
-      return options.indexOf(closestItem);
-    } else {
-      return 0;
-    }
+    const closestItem = options.reduce((prev, curr) => {
+                        return Math.abs((curr.value.time || 0) - value) < Math.abs((prev.value.time || 0) - value) ? curr : prev;
+                      });
+    return options.indexOf(closestItem);
   }
 
   private _formatInputValue(emitEvents = true): void {

--- a/src/lib/time-picker/time-picker.ts
+++ b/src/lib/time-picker/time-picker.ts
@@ -222,6 +222,7 @@ export class TimePickerComponent extends BaseComponent implements ITimePickerCom
   @FoundationProperty()
   public showNow: boolean;
 
+  /** Whether or not to display hour options in dropdown */
   @FoundationProperty()
   public showHourOptions: boolean;
 

--- a/src/lib/time-picker/time-picker.ts
+++ b/src/lib/time-picker/time-picker.ts
@@ -37,7 +37,7 @@ export interface ITimePickerComponent extends IBaseComponent {
   step: number;
   allowInput: boolean;
   showNow: boolean;
-  showNowOnly: boolean;
+  showHourOptions: boolean;
   customOptions: ITimePickerOption[];
   validationCallback: TimePickerValidationCallback;
   parseCallback: TimePickerParseCallback;
@@ -96,7 +96,7 @@ export class TimePickerComponent extends BaseComponent implements ITimePickerCom
       TIME_PICKER_CONSTANTS.attributes.STEP,
       TIME_PICKER_CONSTANTS.attributes.ALLOW_INPUT,
       TIME_PICKER_CONSTANTS.attributes.SHOW_NOW,
-      TIME_PICKER_CONSTANTS.attributes.SHOW_NOW_ONLY,
+      TIME_PICKER_CONSTANTS.attributes.SHOW_HOUR_OPTIONS,
       TIME_PICKER_CONSTANTS.attributes.DISABLED,
       TIME_PICKER_CONSTANTS.attributes.POPUP_CLASSES,
       TIME_PICKER_CONSTANTS.attributes.ALLOW_DROPDOWN
@@ -150,8 +150,8 @@ export class TimePickerComponent extends BaseComponent implements ITimePickerCom
       case TIME_PICKER_CONSTANTS.attributes.SHOW_NOW:
         this.showNow = coerceBoolean(newValue);
         break;
-      case TIME_PICKER_CONSTANTS.attributes.SHOW_NOW_ONLY:
-        this.showNowOnly = coerceBoolean(newValue);
+      case TIME_PICKER_CONSTANTS.attributes.SHOW_HOUR_OPTIONS:
+        this.showHourOptions = coerceBoolean(newValue);
         break;
       case TIME_PICKER_CONSTANTS.attributes.MIN:
         this.min = newValue;
@@ -223,7 +223,7 @@ export class TimePickerComponent extends BaseComponent implements ITimePickerCom
   public showNow: boolean;
 
   @FoundationProperty()
-  public showNowOnly: boolean;
+  public showHourOptions: boolean;
 
   @FoundationProperty()
   public customOptions: ITimePickerOption[];

--- a/src/lib/time-picker/time-picker.ts
+++ b/src/lib/time-picker/time-picker.ts
@@ -37,6 +37,7 @@ export interface ITimePickerComponent extends IBaseComponent {
   step: number;
   allowInput: boolean;
   showNow: boolean;
+  showNowOnly: boolean;
   customOptions: ITimePickerOption[];
   validationCallback: TimePickerValidationCallback;
   parseCallback: TimePickerParseCallback;
@@ -95,6 +96,7 @@ export class TimePickerComponent extends BaseComponent implements ITimePickerCom
       TIME_PICKER_CONSTANTS.attributes.STEP,
       TIME_PICKER_CONSTANTS.attributes.ALLOW_INPUT,
       TIME_PICKER_CONSTANTS.attributes.SHOW_NOW,
+      TIME_PICKER_CONSTANTS.attributes.SHOW_NOW_ONLY,
       TIME_PICKER_CONSTANTS.attributes.DISABLED,
       TIME_PICKER_CONSTANTS.attributes.POPUP_CLASSES,
       TIME_PICKER_CONSTANTS.attributes.ALLOW_DROPDOWN
@@ -147,6 +149,9 @@ export class TimePickerComponent extends BaseComponent implements ITimePickerCom
         break;
       case TIME_PICKER_CONSTANTS.attributes.SHOW_NOW:
         this.showNow = coerceBoolean(newValue);
+        break;
+      case TIME_PICKER_CONSTANTS.attributes.SHOW_NOW_ONLY:
+        this.showNowOnly = coerceBoolean(newValue);
         break;
       case TIME_PICKER_CONSTANTS.attributes.MIN:
         this.min = newValue;
@@ -216,6 +221,9 @@ export class TimePickerComponent extends BaseComponent implements ITimePickerCom
 
   @FoundationProperty()
   public showNow: boolean;
+
+  @FoundationProperty()
+  public showNowOnly: boolean;
 
   @FoundationProperty()
   public customOptions: ITimePickerOption[];

--- a/src/stories/src/components/time-picker/time-picker-args.ts
+++ b/src/stories/src/components/time-picker/time-picker-args.ts
@@ -8,6 +8,7 @@ export interface ITimePickerProps {
   allowInput: boolean;
   allowDropdown: boolean;
   showNow: boolean;
+  showNowOnly: boolean;
   disabled: boolean;
 }
 
@@ -69,6 +70,13 @@ export const argTypes = {
     },
   },
   showNow: {
+    control: 'boolean',
+    description: '',
+    table: {
+      category: 'Properties',
+    },
+  },
+  showNowOnly: {
     control: 'boolean',
     description: '',
     table: {

--- a/src/stories/src/components/time-picker/time-picker-args.ts
+++ b/src/stories/src/components/time-picker/time-picker-args.ts
@@ -8,7 +8,7 @@ export interface ITimePickerProps {
   allowInput: boolean;
   allowDropdown: boolean;
   showNow: boolean;
-  showNowOnly: boolean;
+  showHourOptions: boolean;
   disabled: boolean;
 }
 
@@ -76,7 +76,7 @@ export const argTypes = {
       category: 'Properties',
     },
   },
-  showNowOnly: {
+  showHourOptions: {
     control: 'boolean',
     description: '',
     table: {

--- a/src/stories/src/components/time-picker/time-picker.mdx
+++ b/src/stories/src/components/time-picker/time-picker.mdx
@@ -156,6 +156,12 @@ Gets/sets whether an option called "Now" (for setting the value to the current t
 
 </PropertyDef>
 
+<PropertyDef name="showHourOptions" type="boolean" defaultValue="true">
+
+Gets/sets whether to display the hour options in the dropdown list.
+
+</PropertyDef>
+
 <PropertyDef name="customOptions" type="ITimePickerOption[]" attr={false} defaultValue="[]">
 
 Gets/sets the custom options that are displayed at the top of the dropdown list.

--- a/src/stories/src/components/time-picker/time-picker.stories.tsx
+++ b/src/stories/src/components/time-picker/time-picker.stories.tsx
@@ -57,5 +57,6 @@ Default.args = {
   allowInput: true,
   allowDropdown: true,
   showNow: false,
+  showHourOptions: true,
   disabled: false
 } as ITimePickerProps;

--- a/src/stories/src/components/time-picker/time-picker.stories.tsx
+++ b/src/stories/src/components/time-picker/time-picker.stories.tsx
@@ -25,6 +25,7 @@ export const Default: Story<ITimePickerProps> = ({
   allowInput = true,
   allowDropdown = true,
   showNow = false,
+  showNowOnly = false,
   disabled = false
 }) => (
   <ForgeTimePicker 
@@ -38,6 +39,7 @@ export const Default: Story<ITimePickerProps> = ({
     allowInput={allowInput}
     allowDropdown={allowDropdown}
     showNow={showNow}
+    showNowOnly={showNowOnly}
     disabled={disabled}>
     <ForgeTextField>
       <input autoComplete="off" type="text" id="time-picker" placeholder={`hh:mm${allowSeconds ? ':ss' : ''}${use24HourTime ? '' : ' AM'}`} />

--- a/src/stories/src/components/time-picker/time-picker.stories.tsx
+++ b/src/stories/src/components/time-picker/time-picker.stories.tsx
@@ -25,7 +25,7 @@ export const Default: Story<ITimePickerProps> = ({
   allowInput = true,
   allowDropdown = true,
   showNow = false,
-  showNowOnly = false,
+  showHourOptions = true,
   disabled = false
 }) => (
   <ForgeTimePicker 
@@ -39,7 +39,7 @@ export const Default: Story<ITimePickerProps> = ({
     allowInput={allowInput}
     allowDropdown={allowDropdown}
     showNow={showNow}
-    showNowOnly={showNowOnly}
+    showHourOptions={showHourOptions}
     disabled={disabled}>
     <ForgeTextField>
       <input autoComplete="off" type="text" id="time-picker" placeholder={`hh:mm${allowSeconds ? ':ss' : ''}${use24HourTime ? '' : ' AM'}`} />

--- a/src/test/spec/time-picker/time-picker.spec.ts
+++ b/src/test/spec/time-picker/time-picker.spec.ts
@@ -973,7 +973,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
 
     const listItems = this.context.getListItems();
 
-    expect(listItems.length === 1).toBeTrue();
+    expect(listItems.length).toBe(1);
     expect(listItems[0].value.time).toBeNull();
     expect(listItems[0].innerText).toBe('Now');
     expect(listItems[0].value.metadata).toBe('now');
@@ -989,7 +989,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
 
     const listItems = this.context.getListItems();
 
-    expect(!listItems.length).toBeTrue();
+    expect(listItems.length).toBeFalsy();
   });
 
   it('should show custom options', async function(this: ITestContext) {

--- a/src/test/spec/time-picker/time-picker.spec.ts
+++ b/src/test/spec/time-picker/time-picker.spec.ts
@@ -963,11 +963,12 @@ describe('TimePickerComponent', function(this: ITestContext) {
     expect(listItems[0].value.metadata).toBe('now');
   });
 
-  it('should show "now" as the only option in the dropdown', async function(this: ITestContext) {
+  it('should show "now" as the only option in the dropdown when showHourOptions is false and showNow is true and customOptions is empty', async function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
     this.context.component.showNow = true;
     this.context.component.showHourOptions = false;
+    this.context.component.customOptions = [];
     this.context.component.open = true;
     await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
 
@@ -979,17 +980,16 @@ describe('TimePickerComponent', function(this: ITestContext) {
     expect(listItems[0].value.metadata).toBe('now');
   });
 
-  it('should show no options in the dropdown', async function(this: ITestContext) {
+  it('should should not show dropdown when showNow is false and showHourOptions is false and customOptions is empty', async function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
     this.context.component.showNow = false;
     this.context.component.showHourOptions = false;
+    this.context.component.customOptions = [];
     this.context.component.open = true;
     await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
 
-    const listItems = this.context.getListItems();
-
-    expect(listItems.length).toBeFalsy();
+    expect(this.context.getPopup()).toBeFalsy();
   });
 
   it('should show custom options', async function(this: ITestContext) {

--- a/src/test/spec/time-picker/time-picker.spec.ts
+++ b/src/test/spec/time-picker/time-picker.spec.ts
@@ -459,6 +459,12 @@ describe('TimePickerComponent', function(this: ITestContext) {
     expect(this.context.component.showNow).toBeTrue();
   });
 
+  it('should set showNowOnly via attribute', function(this: ITestContext) {
+    this.context = _createTimePickerContext();
+    this.context.component.setAttribute(TIME_PICKER_CONSTANTS.attributes.SHOW_NOW_ONLY, '');
+    expect(this.context.component.showNowOnly).toBeTrue();
+  });
+
   it('should set min via attribute', function(this: ITestContext) {
     this.context = _createTimePickerContext();
     const expectedTimeValue = '19:32';

--- a/src/test/spec/time-picker/time-picker.spec.ts
+++ b/src/test/spec/time-picker/time-picker.spec.ts
@@ -989,7 +989,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
 
     const listItems = this.context.getListItems();
 
-    expect(listItems.length).toBeTrue();
+    expect(!listItems.length).toBeTrue();
   });
 
   it('should show custom options', async function(this: ITestContext) {

--- a/src/test/spec/time-picker/time-picker.spec.ts
+++ b/src/test/spec/time-picker/time-picker.spec.ts
@@ -963,6 +963,35 @@ describe('TimePickerComponent', function(this: ITestContext) {
     expect(listItems[0].value.metadata).toBe('now');
   });
 
+  it('should show "now" as the only option in the dropdown', async function(this: ITestContext) {
+    this.context = _createTimePickerContext();
+
+    this.context.component.showNow = true;
+    this.context.component.showHourOptions = false;
+    this.context.component.open = true;
+    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+
+    const listItems = this.context.getListItems();
+
+    expect(listItems.length === 1).toBeTrue();
+    expect(listItems[0].value.time).toBeNull();
+    expect(listItems[0].innerText).toBe('Now');
+    expect(listItems[0].value.metadata).toBe('now');
+  });
+
+  it('should show no options in the dropdown', async function(this: ITestContext) {
+    this.context = _createTimePickerContext();
+
+    this.context.component.showNow = false;
+    this.context.component.showHourOptions = false;
+    this.context.component.open = true;
+    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+
+    const listItems = this.context.getListItems();
+
+    expect(listItems.length === 0).toBeTrue();
+  });
+
   it('should show custom options', async function(this: ITestContext) {
     this.context = _createTimePickerContext();
 

--- a/src/test/spec/time-picker/time-picker.spec.ts
+++ b/src/test/spec/time-picker/time-picker.spec.ts
@@ -989,7 +989,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
 
     const listItems = this.context.getListItems();
 
-    expect(listItems.length === 0).toBeTrue();
+    expect(listItems.length).toBeTrue();
   });
 
   it('should show custom options', async function(this: ITestContext) {

--- a/src/test/spec/time-picker/time-picker.spec.ts
+++ b/src/test/spec/time-picker/time-picker.spec.ts
@@ -459,10 +459,10 @@ describe('TimePickerComponent', function(this: ITestContext) {
     expect(this.context.component.showNow).toBeTrue();
   });
 
-  it('should set showNowOnly via attribute', function(this: ITestContext) {
+  it('should set showHourOptions via attribute', function(this: ITestContext) {
     this.context = _createTimePickerContext();
-    this.context.component.setAttribute(TIME_PICKER_CONSTANTS.attributes.SHOW_NOW_ONLY, '');
-    expect(this.context.component.showNowOnly).toBeTrue();
+    this.context.component.setAttribute(TIME_PICKER_CONSTANTS.attributes.SHOW_HOUR_OPTIONS, 'false');
+    expect(this.context.component.showHourOptions).toBeFalse();
   });
 
   it('should set min via attribute', function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: [Y]
- Docs have been added / updated: [Y]
- Does this PR introduce a breaking change? [N]
- I have linked any related GitHub issues to be closed when this PR is merged? [N]

## Describe the new behavior?
Remove hours from the time picker dropdown, so "Now" is the only menu item. This will prevent the issue where a user types in a value with minute (e.g. 11:21) then opens the dropdown, the hour rounded down (11:00) gets selected, then tabbing off removes the minutes.

## Additional information
[NWARCH-1135](https://tylerjira.tylertech.com/browse/NWARCH-1135)
