### PR TITLE
fix(drawer): fixes drawer initialization state when defaulting to closed

### DIFF
--- a/src/lib/drawer/base/base-drawer-foundation.ts
+++ b/src/lib/drawer/base/base-drawer-foundation.ts
@@ -19,7 +19,12 @@ export class BaseDrawerFoundation implements IBaseDrawerFoundation {
   }
 
   public connect(): void {
-    this._applyOpen();
+    if (this._open) {
+      this._setOpened();
+    } else {
+      this._setClosed();
+    }
+
     this._applyDirection();
     this._adapter.proxyScrollEvent();
     this._hasInitialized = true;
@@ -39,6 +44,7 @@ export class BaseDrawerFoundation implements IBaseDrawerFoundation {
     if (!this._open) {
       return;
     }
+    this._setOpened();
     this._adapter.emitHostEvent(BASE_DRAWER_CONSTANTS.events.AFTER_OPEN);
   }
   
@@ -46,33 +52,37 @@ export class BaseDrawerFoundation implements IBaseDrawerFoundation {
     if (this._open) {
       return;
     }
-    this._adapter.removeDrawerClass(BASE_DRAWER_CONSTANTS.classes.CLOSING);
-    this._adapter.removeDrawerClass(BASE_DRAWER_CONSTANTS.classes.NO_TRANSITION);
-    this._adapter.setDrawerClass(BASE_DRAWER_CONSTANTS.classes.CLOSED);
+    this._setClosed();
     this._adapter.emitHostEvent(BASE_DRAWER_CONSTANTS.events.AFTER_CLOSE);
+  }
+
+  private _setOpened(): void {
+    this._adapter.removeDrawerClass([BASE_DRAWER_CONSTANTS.classes.CLOSED, BASE_DRAWER_CONSTANTS.classes.CLOSING]);
+    this._adapter.setHostAttribute(BASE_DRAWER_CONSTANTS.attributes.OPEN);
+  }
+
+  private _setClosed(): void {
+    this._adapter.removeDrawerClass([BASE_DRAWER_CONSTANTS.classes.CLOSING, BASE_DRAWER_CONSTANTS.classes.NO_TRANSITION]);
+    this._adapter.setDrawerClass(BASE_DRAWER_CONSTANTS.classes.CLOSED);
+    this._adapter.removeHostAttribute(BASE_DRAWER_CONSTANTS.attributes.OPEN);
   }
 
   protected _applyOpen(): void {
     if (this._open) {
-      this._setDrawerOpenState();
-    } else {
-      this._setDrawerClosedState();
-    }
-    
-    if (this._open) {
+      this._triggerDrawerOpen();
       this._adapter.setHostAttribute(BASE_DRAWER_CONSTANTS.attributes.OPEN);
     } else {
+      this._triggerDrawerClose();
       this._adapter.removeHostAttribute(BASE_DRAWER_CONSTANTS.attributes.OPEN);
     }
   }
 
-  protected _setDrawerOpenState(): void {
+  protected _triggerDrawerOpen(): void {
     this._adapter.listenTransitionComplete(this._openAnimationListener);
-    this._adapter.removeDrawerClass(BASE_DRAWER_CONSTANTS.classes.CLOSED);
-    this._adapter.removeDrawerClass(BASE_DRAWER_CONSTANTS.classes.CLOSING);
+    this._adapter.removeDrawerClass([BASE_DRAWER_CONSTANTS.classes.CLOSED, BASE_DRAWER_CONSTANTS.classes.CLOSING]);
   }
 
-  protected _setDrawerClosedState(): void {
+  protected _triggerDrawerClose(): void {
     this._adapter.listenTransitionComplete(this._closeAnimationListener);
     this._adapter.setDrawerClass(BASE_DRAWER_CONSTANTS.classes.CLOSING);
   }

--- a/src/lib/drawer/modal-drawer/modal-drawer-foundation.ts
+++ b/src/lib/drawer/modal-drawer/modal-drawer-foundation.ts
@@ -27,13 +27,13 @@ export class ModalDrawerFoundation extends BaseDrawerFoundation implements IModa
     this._isInitialized = false;
   }
 
-  protected _setDrawerOpenState(): void {
-    super._setDrawerOpenState();
+  protected _triggerDrawerOpen(): void {
+    super._triggerDrawerOpen();
     this._setBackdrop(true);
   }
 
-  protected _setDrawerClosedState(): void {
-    super._setDrawerClosedState();
+  protected _triggerDrawerClose(): void {
+    super._triggerDrawerClose();
     this._setBackdrop(false);
   }
 

--- a/src/test/spec/drawer/modal-drawer.spec.ts
+++ b/src/test/spec/drawer/modal-drawer.spec.ts
@@ -124,6 +124,7 @@ describe('ModalDrawerComponent', function(this: ITestContext) {
 
   it('should emit after close event when close animation completes', async function(this: ITestContext) {
     this.context = setupTestContext(true);
+    this.context.component.setAttribute(BASE_DRAWER_CONSTANTS.attributes.OPEN, '');
 
     const afterCloseSpy = jasmine.createSpy('after close');
     this.context.component.addEventListener(BASE_DRAWER_CONSTANTS.events.AFTER_CLOSE, afterCloseSpy);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? Y
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The initialization logic has been updated to remove the ability for animations to execute. This ensures that the appropriate CSS classes are applied based on the default open state of the component when added to the DOM.

## Additional information
Fixes #148 
