### PR TITLE
fix(table): add checkbox to component dependencies

### DIFF
--- a/src/lib/table/table.ts
+++ b/src/lib/table/table.ts
@@ -1,6 +1,7 @@
 import { coerceBoolean, coerceNumber, CustomElement, FoundationProperty } from '@tylertech/forge-core';
 import { tylIconArrowDownward } from '@tylertech/tyler-icons/standard';
 import { ExpansionPanelComponent } from '../expansion-panel';
+import { CheckboxComponent } from '../checkbox';
 import { TableAdapter } from './table-adapter';
 import { TABLE_CONSTANTS } from './table-constants';
 import { TableFoundation } from './table-foundation';
@@ -90,7 +91,8 @@ declare global {
   name: TABLE_CONSTANTS.elementName,
   dependencies: [
     ExpansionPanelComponent,
-    IconComponent
+    IconComponent,
+    CheckboxComponent
   ]
 })
 export class TableComponent extends BaseComponent implements ITableComponent {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The table will now automatically import and define the checkbox component as a dependency when it is used. This fixes an issue where if a developer was not using the checkbox previously that it would get defined and the select column would operate properly.

## Additional information
Fixes #147 
