### PR TITLE
fix(file-picker): fix helper text slotted styles and dimensions

### DIFF
--- a/src/lib/file-picker/_mixins.scss
+++ b/src/lib/file-picker/_mixins.scss
@@ -26,7 +26,9 @@
     }
 
     &__helper-text {
-      @include helper-text;
+      ::slotted([slot='helper-text']) {
+        @include helper-text;
+      }
     }
 
     &[disabled] {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Move the helper text styles to the slotted element to ensure that the dimensions only apply if there are nodes assigned to the slot.

## Additional information
Fixes #140 
