### PR TITLE
fix(date-picker): _onToday zeros out time values

### DIFF
--- a/src/lib/date-picker/date-picker-foundation.ts
+++ b/src/lib/date-picker/date-picker-foundation.ts
@@ -39,7 +39,9 @@ export class DatePickerFoundation extends BaseDatePickerFoundation<IDatePickerAd
   }
 
   protected _onToday(): void {
-    this._onDateSelected({ date: new Date(), selected: true, type: 'date' });
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    this._onDateSelected({ date: today, selected: true, type: 'date' });
   }
 
   protected _onClear(): void {

--- a/src/test/spec/date-picker/date-picker.spec.ts
+++ b/src/test/spec/date-picker/date-picker.spec.ts
@@ -1073,12 +1073,48 @@ describe('DatePickerComponent', function(this: ITestContext) {
       await tick();
 
       const popup = getPopup(this.context.component);
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
 
       expect(changeSpy).toHaveBeenCalledTimes(1);
       expect(this.context.component.open).toBeFalse();
       expect(popup).toBeNull('Expected popup to be removed');
       expect(this.context.component.value).toBeInstanceOf(Date);
-      expect((this.context.component.value as Date).getDate()).toEqual(new Date().getDate());
+      expect((this.context.component.value as Date)).toEqual(today);
+    });
+
+    it('should set date to todays date when clicking today button a second time', async function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      this.context.component.showToday = true;
+      const changeSpy = jasmine.createSpy('change spy');
+      this.context.component.addEventListener(DATE_PICKER_CONSTANTS.events.CHANGE, changeSpy);
+      openPopup(this.context.component);
+
+      clickTodayButton(this.context.component);
+      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await tick();
+
+      const popup = getPopup(this.context.component);
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      expect(changeSpy).toHaveBeenCalledTimes(1);
+      expect(this.context.component.open).toBeFalse();
+      expect(popup).toBeNull('Expected popup to be removed');
+      expect(this.context.component.value).toBeInstanceOf(Date);
+      expect((this.context.component.value as Date)).toEqual(today);
+      
+      openPopup(this.context.component);
+      
+      clickTodayButton(this.context.component);
+      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await tick();
+      
+      expect(changeSpy).toHaveBeenCalledTimes(2);
+      expect(this.context.component.open).toBeFalse();
+      expect(popup).toBeNull('Expected popup to be removed');
+      expect(this.context.component.value).toBeInstanceOf(Date);
+      expect((this.context.component.value as Date)).toEqual(today);
     });
 
     it('should remove value when clicking clear button', async function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: [Y]
- Docs have been added / updated: [N]
- Does this PR introduce a breaking change? [N]
- I have linked any related GitHub issues to be closed when this PR is merged? [Y]

## Describe the new behavior?
Fixed bug when Today was clicked the second time, time data was associated with the date-picker value. Second click and further clicks will zero out the time values of the date.

## Additional information
[Related issue to be closed](https://github.com/tyler-technologies-oss/forge/issues/159)
