### PR TITLE
fix(select): fix to ensure `--forge-select-font-size` CSS custom prop…

### DIFF
--- a/src/lib/chip-field/_selector.scss
+++ b/src/lib/chip-field/_selector.scss
@@ -120,7 +120,7 @@
 @mixin input {
   // Base
   // chip-field input should have no padding, so we exclude padding from the base.
-  @include field-selector.input('::slotted(input)', $exclude: (padding, padding-top, padding-right, padding-bottom, padding-left));
+  @include field-selector.input('::slotted(input)', $exclude: (padding, padding-top, padding-right, padding-bottom, padding-left), $component-name: 'forge-chip-field');
   // Core
   ::slotted(input) {
     @include base.input-core;

--- a/src/lib/field/_base.scss
+++ b/src/lib/field/_base.scss
@@ -375,18 +375,30 @@
   @include utils.error-theme-state(input-color, $theme-state);
 }
 
-@mixin input-font-size($layout-state) {
+@mixin input-font-size($layout-state, $custom-prop-font-size) {
   // Default
   @if $layout-state == default or $layout-state == shape-rounded {
-    font-size: map.get(variables.$input, font-size, default);
+    @include theme.css-custom-property(
+      font-size,
+      $custom-prop-font-size,
+      map.get(variables.$input, font-size, default)
+    );
   }
   // Roomy
   @else if $layout-state == roomy or $layout-state == shape-rounded-roomy {
-    font-size: map.get(variables.$input, font-size, roomy);
+    @include theme.css-custom-property(
+      font-size,
+      $custom-prop-font-size,
+      map.get(variables.$input, font-size, roomy)
+    );
   }
   // Dense
   @else if $layout-state == dense or $layout-state == shape-rounded-dense {
-    font-size: map.get(variables.$input, font-size, dense);
+    @include theme.css-custom-property(
+      font-size,
+      $custom-prop-font-size,
+      map.get(variables.$input, font-size, dense)
+    );
   }
   @include utils.error-layout-state(input-font-size, $layout-state);
 }

--- a/src/lib/field/_selector.scss
+++ b/src/lib/field/_selector.scss
@@ -267,7 +267,7 @@
   }
 }
 
-@mixin input($input-selector: '::slotted(input)', $exclude: ()) {
+@mixin input($input-selector: '::slotted(input)', $exclude: (), $component-name: 'forge-field') {
   // Core
   @if list.index($exclude, core) == null {
     #{$input-selector} {
@@ -291,17 +291,17 @@
   @if list.index($exclude, font-size) == null {
     &:not(.forge-field--dense):not(.forge-field--roomy) {
       #{$input-selector} {
-        @include base.input-font-size(default);
+        @include base.input-font-size(default, --#{$component-name}-font-size);
       }
     }
     &--roomy:not(.forge-field--dense) {
       #{$input-selector} {
-        @include base.input-font-size(roomy);
+        @include base.input-font-size(roomy, --#{$component-name}-font-size);
       }
     }
     &--dense:not(.forge-field--roomy) {
       #{$input-selector} {
-        @include base.input-font-size(dense);
+        @include base.input-font-size(dense, --#{$component-name}-font-size);
       }
     }
   }

--- a/src/lib/select/select/_selector.scss
+++ b/src/lib/select/select/_selector.scss
@@ -16,7 +16,7 @@
   }
 
   // Field Input Styles
-  @include field-selector.input('.forge-select__selected-text', $exclude: (core, padding-right));
+  @include field-selector.input('.forge-select__selected-text', $exclude: (core, padding-right), $component-name: 'forge-select');
 
   // Line Height
   &:not(.forge-field--label) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Updates the shared field styles to ensure that the `font-size` that is set on the "input" portion of the component (selected-text element in the case of the select) uses a CSS custom property that works across all densities.

## Additional information
Fixes #158 
