### PR TITLE
fix(chip): change default `height` style to use `auto` to accommodate content height

### DIFF
--- a/src/lib/chip-field/_base.scss
+++ b/src/lib/chip-field/_base.scss
@@ -162,11 +162,11 @@
 
   // Default
   @if $layout-state == default or $layout-state == shape-rounded {
-    --forge-chip-height: #{map.get(variables.$member, height, default)};
+    --forge-chip-min-height: #{map.get(variables.$member, min-height, default)};
   }
   // Dense
   @else if $layout-state == dense or $layout-state == shape-rounded-dense {
-    --forge-chip-height: #{map.get(variables.$member, height, dense)};
+    --forge-chip-min-height: #{map.get(variables.$member, min-height, dense)};
   }
   // Roomy uses the default chip height
   @include field-utils.error-layout-state(member-height, $layout-state);

--- a/src/lib/chip-field/_variables.scss
+++ b/src/lib/chip-field/_variables.scss
@@ -23,7 +23,7 @@ $input-container: (
 ) !default;
 
 $member: (
-  height: (
+  min-height: (
     default: 20px,
     dense: 16px
   ),

--- a/src/lib/chips/chip/_mixins.scss
+++ b/src/lib/chips/chip/_mixins.scss
@@ -133,7 +133,7 @@
       @include dense;
 
       &.forge-chip--field {
-        @include theme.css-custom-property(height, --forge-chip-height, 20px);
+        @include theme.css-custom-property(min-height, --forge-chip-min-height, variables.$dense-field-min-height);
         padding: 0;
         margin: 0;
         display: flex;
@@ -187,7 +187,8 @@
   @include button-mixins.outlined;
   @include mdc-chip-theme.shape-radius(50%);
   @include theme.css-custom-property(width, --forge-chip-width, auto);
-  @include theme.css-custom-property(height, --forge-chip-height, variables.$height);
+  @include theme.css-custom-property(height, --forge-chip-height, auto);
+  @include theme.css-custom-property(min-height, --forge-chip-min-height, variables.$min-height);
 
   box-sizing: border-box;
   transition: mdc-animation.enter(background-color, 150ms);
@@ -268,5 +269,5 @@
 }
 
 @mixin dense() {
-  @include theme.css-custom-property(height, --forge-chip-height, variables.$dense-height);
+  @include theme.css-custom-property(min-height, --forge-chip-min-height, variables.$dense-min-height);
 }

--- a/src/lib/chips/chip/_variables.scss
+++ b/src/lib/chips/chip/_variables.scss
@@ -1,2 +1,3 @@
-$height: 36px !default;
-$dense-height: 28px !default;
+$min-height: 36px !default;
+$dense-min-height: 28px !default;
+$dense-field-min-height: 20px !default;

--- a/src/stories/src/components/chips/chips.mdx
+++ b/src/stories/src/components/chips/chips.mdx
@@ -212,10 +212,13 @@ Controls the invalid state.
 | `--forge-chip-set-spacing`                   | Sets the gap spacing between chips
 
 
-### Chips
+### Chip
 
 | Name                                       | Description
 | :------------------------------------------| :----------------
+| `--forge-chip-height`                      | Sets the `height` of the element. Default is `auto`.
+| `--forge-chip-width`                       | Sets the `width` of the element. Default is `auto`.
+| `--forge-chip-min-height`                  | Sets the `min-height` of the element. Default varies based on type and density.
 | `--mdc-theme-primary`                      | Sets the primary theme throughout the component
 | `--mdc-theme-on-primary`                   | Sets the contrasting color of the primary theme through the component.
 | `--forge-theme-border-color`               | Sets the border color.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Chips will now expand in height to accommodate their content by using `height: auto` instead of static pixel values on a per-density basis. The pixel values are still applied, but these are now set as a `min-height` style for each density.

This shouldn't introduce a breaking change since anyone who was previously overriding `--forge-chip-height` can still do so and it will function as it did before. It's unlikely any applications were allowing for multi-line text to be clipped on purpose, in which case their layout may grow in height if so.

This is how chips will look in the chip-field now for reference to the linked issue:
![image](https://user-images.githubusercontent.com/2653457/196520663-4f576954-52ff-4c89-908e-eaf6a207b7fa.png)

## Additional information
Fixes #153 
