### PR TITLE
feat(app-bar-profile-button): allow for customizing the text on the sign out and profile buttons

### DIFF
--- a/src/demo/index.html
+++ b/src/demo/index.html
@@ -160,7 +160,14 @@
                 <forge-app-bar-notification-button slot="end"></forge-app-bar-notification-button>
                 <forge-app-bar-app-launcher-button slot="end"></forge-app-bar-app-launcher-button>
 
-                <forge-profile-button slot="end" avatar-text="First Last" full-name="First Last" email="first.last@tylertech.com"></forge-profile-button>
+                <forge-app-bar-profile-button
+                  slot="end"
+                  avatar-text="First Last"
+                  full-name="First Last"
+                  email="first.last@tylertech.com"
+                  profile-button
+                  profile-button-text="Some cool profile"
+                  sign-out-button-text="Yay sign out"></forge-app-bar-profile-button>
 
                 <forge-tab-bar layout-mode="clustered" slot="bottom">
                   <forge-tab>Tab 1</forge-tab>

--- a/src/lib/app-bar/profile-button/app-bar-profile-button-adapter.ts
+++ b/src/lib/app-bar/profile-button/app-bar-profile-button-adapter.ts
@@ -16,12 +16,15 @@ export interface IAppBarProfileButtonAdapter extends IBaseAdapter {
   setAvatarText(value: string): void;
   setAvatarLetterCount(value: number): void;
   setAvatarImageUrl(value: string): void;
+  setSignOutButtonText(value: string): void;
+  setProfileButtonText(value: string): void;
 }
 
 export class AppBarProfileButtonAdapter extends BaseAdapter<IAppBarProfileButtonComponent> implements IAppBarProfileButtonAdapter {
   private _avatarElement: IAvatarComponent;
-  private _popupElement: IPopupComponent;
   private _buttonElement: HTMLButtonElement;
+  private _popupElement?: IPopupComponent;
+  private _profileCardElement?: IProfileCardComponent;
 
   constructor(component: IAppBarProfileButtonComponent) {
     super(component);
@@ -41,25 +44,28 @@ export class AppBarProfileButtonAdapter extends BaseAdapter<IAppBarProfileButton
   }
 
   public openPopup(profileCardConfig: IAppBarProfileCardConfig, dismissListener: () => void, profileListener: () => void, signOutListener: () => void, profileCardContent?: HTMLElement): () => void {
-    const profileCardElement = document.createElement(PROFILE_CARD_CONSTANTS.elementName) as IProfileCardComponent;
-    profileCardElement.fullName = profileCardConfig.fullName;
-    profileCardElement.email = profileCardConfig.email;
-    profileCardElement.signOut = profileCardConfig.signOut;
-    profileCardElement.profile = profileCardConfig.profile;
-    profileCardElement.avatarText = profileCardConfig.avatarText;
-    profileCardElement.avatarImageUrl = profileCardConfig.avatarImageUrl;
-    profileCardElement.avatarLetterCount = profileCardConfig.avatarLetterCount;
-    profileCardElement.addEventListener(PROFILE_CARD_CONSTANTS.events.PROFILE, () => profileListener());
-    profileCardElement.addEventListener(PROFILE_CARD_CONSTANTS.events.SIGN_OUT, () => signOutListener());
+    this._profileCardElement = document.createElement(PROFILE_CARD_CONSTANTS.elementName);
+    this._profileCardElement.fullName = profileCardConfig.fullName;
+    this._profileCardElement.email = profileCardConfig.email;
+    this._profileCardElement.signOut = profileCardConfig.signOut;
+    this._profileCardElement.profile = profileCardConfig.profile;
+    this._profileCardElement.signOutText = profileCardConfig.signOutButtonText;
+    this._profileCardElement.profileText = profileCardConfig.profileButtonText;
+    this._profileCardElement.avatarText = profileCardConfig.avatarText;
+    this._profileCardElement.avatarImageUrl = profileCardConfig.avatarImageUrl;
+    this._profileCardElement.avatarLetterCount = profileCardConfig.avatarLetterCount;
+    this._profileCardElement.addEventListener(PROFILE_CARD_CONSTANTS.events.PROFILE, () => profileListener());
+    this._profileCardElement.addEventListener(PROFILE_CARD_CONSTANTS.events.SIGN_OUT, () => signOutListener());
+
     if (profileCardContent) {
-      profileCardElement.appendChild(profileCardContent);
+      this._profileCardElement.appendChild(profileCardContent);
     }
 
-    this._popupElement = document.createElement(POPUP_CONSTANTS.elementName) as IPopupComponent;
+    this._popupElement = document.createElement(POPUP_CONSTANTS.elementName);
     this._popupElement.targetElement = this._component;
     this._popupElement.placement = 'bottom-end';
     this._popupElement.animationType = PopupAnimationType.Menu;
-    this._popupElement.appendChild(profileCardElement);
+    this._popupElement.appendChild(this._profileCardElement);
     this._popupElement.open = true;
 
     return notChildEventListener(this._popupElement, activeElement => {
@@ -75,6 +81,8 @@ export class AppBarProfileButtonAdapter extends BaseAdapter<IAppBarProfileButton
   public closePopup(): void {
     if (this._popupElement) {
       this._popupElement.open = false;
+      this._popupElement = undefined;
+      this._profileCardElement = undefined;
     }
   }
 
@@ -92,5 +100,19 @@ export class AppBarProfileButtonAdapter extends BaseAdapter<IAppBarProfileButton
 
   public setAvatarImageUrl(value: string): void {
     this._avatarElement.imageUrl = value;
+  }
+
+  public setSignOutButtonText(value: string): void {
+    if (this._profileCardElement) {
+      this._profileCardElement.signOutText = value;
+      this._popupElement?.position();
+    }
+  }
+
+  public setProfileButtonText(value: string): void {
+    if (this._profileCardElement) {
+      this._profileCardElement.profileText = value;
+      this._popupElement?.position();
+    }
   }
 }

--- a/src/lib/app-bar/profile-button/app-bar-profile-button-constants.ts
+++ b/src/lib/app-bar/profile-button/app-bar-profile-button-constants.ts
@@ -10,6 +10,8 @@ const attributes = {
   AVATAR_TEXT: 'avatar-text',
   SIGN_OUT_BUTTON: 'sign-out-button',
   PROFILE_BUTTON: 'profile-button',
+  SIGN_OUT_BUTTON_TEXT: 'sign-out-button-text',
+  PROFILE_BUTTON_TEXT: 'profile-button-text',
   OPEN: 'open'
 };
 
@@ -28,6 +30,8 @@ export interface IAppBarProfileCardConfig {
   email: string;
   signOut: boolean;
   profile: boolean;
+  signOutButtonText: string;
+  profileButtonText: string;
   avatarText: string;
   avatarImageUrl: string;
   avatarLetterCount: number;

--- a/src/lib/app-bar/profile-button/app-bar-profile-button-foundation.ts
+++ b/src/lib/app-bar/profile-button/app-bar-profile-button-foundation.ts
@@ -12,6 +12,8 @@ export interface IAppBarProfileButtonFoundation extends ICustomElementFoundation
   avatarText: string;
   signOutButton: boolean;
   profileButton: boolean;
+  signOutButtonText: string;
+  profileButtonText: string;
   open: boolean;
   profileCardBuilder: AppBarProfileButtonProfileCardBuilder;
 }
@@ -24,6 +26,8 @@ export class AppBarProfileButtonFoundation implements IAppBarProfileButtonFounda
   private _avatarText: string;
   private _showSignOutButton = PROFILE_CARD_CONSTANTS.defaults.SHOW_SIGN_OUT_BUTTON;
   private _showProfileButton = PROFILE_CARD_CONSTANTS.defaults.SHOW_PROFILE_BUTTON;
+  private _signOutButtonText = PROFILE_CARD_CONSTANTS.defaults.SIGN_OUT_BUTTON_TEXT;
+  private _profileButtonText = PROFILE_CARD_CONSTANTS.defaults.PROFILE_BUTTON_TEXT;
   private _profileCardBuilder: AppBarProfileButtonProfileCardBuilder;
   private _open = false;
   private _isInitialized = false;
@@ -108,6 +112,8 @@ export class AppBarProfileButtonFoundation implements IAppBarProfileButtonFounda
       email: this._email,
       signOut: this._showSignOutButton,
       profile: this._showProfileButton,
+      signOutButtonText: this._signOutButtonText,
+      profileButtonText: this._profileButtonText,
       avatarText: this._avatarText,
       avatarImageUrl: this._avatarImageUrl,
       avatarLetterCount: this._avatarLetterCount
@@ -211,6 +217,26 @@ export class AppBarProfileButtonFoundation implements IAppBarProfileButtonFounda
     if (this._showProfileButton !== value) {
       this._showProfileButton = value;
       this._adapter.setHostAttribute(APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.PROFILE_BUTTON, this._showProfileButton as any);
+    }
+  }
+
+  public get signOutButtonText(): string {
+    return this._signOutButtonText;
+  }
+  public set signOutButtonText(value: string) {
+    if (this._signOutButtonText !== value) {
+      this._signOutButtonText = value;
+      this._adapter.setSignOutButtonText(value);
+    }
+  }
+
+  public get profileButtonText(): string {
+    return this._profileButtonText;
+  }
+  public set profileButtonText(value: string) {
+    if (this._profileButtonText !== value) {
+      this._profileButtonText = value;
+      this._adapter.setProfileButtonText(value);
     }
   }
 

--- a/src/lib/app-bar/profile-button/app-bar-profile-button.ts
+++ b/src/lib/app-bar/profile-button/app-bar-profile-button.ts
@@ -19,6 +19,8 @@ export interface IAppBarProfileButtonComponent extends IBaseComponent {
   email: string;
   signOutButton: boolean;
   profileButton: boolean;
+  signOutButtonText: string;
+  profileButtonText: string;
   open: boolean;
   profileCardBuilder: (fn: AppBarProfileButtonProfileCardBuilder) => void;
 }
@@ -54,6 +56,8 @@ export class AppBarProfileButtonComponent extends BaseComponent implements IAppB
       APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.AVATAR_TEXT,
       APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.SIGN_OUT_BUTTON,
       APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.PROFILE_BUTTON,
+      APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.SIGN_OUT_BUTTON_TEXT,
+      APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.PROFILE_BUTTON_TEXT,
       APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.OPEN
     ];
   }
@@ -100,6 +104,12 @@ export class AppBarProfileButtonComponent extends BaseComponent implements IAppB
       case APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.PROFILE_BUTTON:
         this.profileButton = coerceBoolean(newValue);
         break;
+      case APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.SIGN_OUT_BUTTON_TEXT:
+        this.signOutButtonText = newValue;
+        break;
+      case APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.PROFILE_BUTTON_TEXT:
+        this.profileButtonText = newValue;
+        break;
       case APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.OPEN:
         this.open = coerceBoolean(newValue);
         break;
@@ -126,6 +136,12 @@ export class AppBarProfileButtonComponent extends BaseComponent implements IAppB
 
   @FoundationProperty()
   public profileButton: boolean;
+
+  @FoundationProperty()
+  public signOutButtonText: string;
+
+  @FoundationProperty()
+  public profileButtonText: string;
 
   @FoundationProperty()
   public open: boolean;

--- a/src/lib/profile-card/profile-card-adapter.ts
+++ b/src/lib/profile-card/profile-card-adapter.ts
@@ -14,6 +14,8 @@ export interface IProfileCardAdapter extends IBaseAdapter {
   setActionToolbarVisibility(isVisible: boolean): void;
   setProfileButtonVisibility(isVisible: boolean): void;
   setSignOutButtonVisibility(isVisible: boolean): void;
+  setSignOutButtonText(value: string): void;
+  setProfileButtonText(value: string): void;
   setProfileButtonListener(listener: (evt: Event) => void): void;
   setSignOutButtonListener(listener: (evt: Event) => void): void;
   removeProfileButtonListener(listener: (evt: Event) => void): void;
@@ -87,6 +89,14 @@ export class ProfileCardAdapter extends BaseAdapter<IProfileCardComponent> imple
     } else {
       this._signOutButton.style.display = 'none';
     }
+  }
+
+  public setSignOutButtonText(value: string): void {
+    this._signOutButton.textContent = value;
+  }
+  
+  public setProfileButtonText(value: string): void {
+    this._profileButton.textContent = value;
   }
 
   public setProfileButtonListener(listener: (evt: Event) => void): void {

--- a/src/lib/profile-card/profile-card-constants.ts
+++ b/src/lib/profile-card/profile-card-constants.ts
@@ -7,6 +7,8 @@ const attributes = {
   EMAIL: 'email',
   SIGN_OUT: 'sign-out',
   PROFILE: 'profile',
+  SIGN_OUT_TEXT: 'sign-out-text',
+  PROFILE_TEXT: 'profile-text',
   AVATAR_TEXT: 'avatar-text',
   AVATAR_IMAGE_URL: 'avatar-image-url',
   AVATAR_LETTER_COUNT: 'avatar-letter-count'
@@ -23,7 +25,9 @@ const selectors = {
 
 const defaults = {
   SHOW_SIGN_OUT_BUTTON: true,
-  SHOW_PROFILE_BUTTON: false
+  SHOW_PROFILE_BUTTON: false,
+  SIGN_OUT_BUTTON_TEXT: 'Sign out',
+  PROFILE_BUTTON_TEXT: 'Profile'
 };
 
 const events = {

--- a/src/lib/profile-card/profile-card-foundation.ts
+++ b/src/lib/profile-card/profile-card-foundation.ts
@@ -21,6 +21,8 @@ export class ProfileCardFoundation implements IProfileCardFoundation {
   private _avatarLetterCount: number;
   private _showSignOutButton = PROFILE_CARD_CONSTANTS.defaults.SHOW_SIGN_OUT_BUTTON;
   private _showProfileButton = PROFILE_CARD_CONSTANTS.defaults.SHOW_PROFILE_BUTTON;
+  private _signOutButtonText = PROFILE_CARD_CONSTANTS.defaults.SIGN_OUT_BUTTON_TEXT;
+  private _profileButtonText = PROFILE_CARD_CONSTANTS.defaults.PROFILE_BUTTON_TEXT;
   private _profileListener: (evt: Event) => void;
   private _signOutListener: (evt: Event) => void;
 
@@ -38,6 +40,8 @@ export class ProfileCardFoundation implements IProfileCardFoundation {
     }
 
     this._setActionVisibility();
+    this._adapter.setSignOutButtonText(this._signOutButtonText);
+    this._adapter.setProfileButtonText(this._profileButtonText);
   }
 
   private _requestInitialFocus(): void {
@@ -132,6 +136,26 @@ export class ProfileCardFoundation implements IProfileCardFoundation {
     if (this._showProfileButton !== value) {
       this._showProfileButton = value;
       this._setActionVisibility();
+    }
+  }
+
+  public get signOutText(): string {
+    return this._signOutButtonText;
+  }
+  public set signOutText(value: string) {
+    if (this._signOutButtonText !== value) {
+      this._signOutButtonText = value || PROFILE_CARD_CONSTANTS.defaults.SIGN_OUT_BUTTON_TEXT;
+      this._adapter.setSignOutButtonText(this._signOutButtonText);
+    }
+  }
+
+  public get profileText(): string {
+    return this._profileButtonText;
+  }
+  public set profileText(value: string) {
+    if (this._profileButtonText !== value) {
+      this._profileButtonText = value || PROFILE_CARD_CONSTANTS.defaults.PROFILE_BUTTON_TEXT;
+      this._adapter.setProfileButtonText(this._profileButtonText);
     }
   }
 }

--- a/src/lib/profile-card/profile-card.html
+++ b/src/lib/profile-card/profile-card.html
@@ -15,7 +15,7 @@
         <button type="button" id="profile-button" aria-label="View profile" part="profile-button-element">Profile</button>
       </forge-button>
       <forge-button slot="end" part="sign-out-button">
-        <button type="button" id="sign-out-button" part="sign-out-button-element">Sign out</button>
+        <button type="button" id="sign-out-button" aria-label="Sign out" part="sign-out-button-element">Sign out</button>
       </forge-button>
     </forge-toolbar>
   </div>

--- a/src/lib/profile-card/profile-card.ts
+++ b/src/lib/profile-card/profile-card.ts
@@ -15,6 +15,8 @@ export interface IProfileCardComponent extends IBaseComponent {
   email: string;
   signOut: boolean;
   profile: boolean;
+  signOutText: string;
+  profileText: string;
   avatarText: string;
   avatarImageUrl: string;
   avatarLetterCount: number;
@@ -51,6 +53,8 @@ export class ProfileCardComponent extends BaseComponent implements IProfileCardC
       PROFILE_CARD_CONSTANTS.attributes.EMAIL,
       PROFILE_CARD_CONSTANTS.attributes.SIGN_OUT,
       PROFILE_CARD_CONSTANTS.attributes.PROFILE,
+      PROFILE_CARD_CONSTANTS.attributes.SIGN_OUT_TEXT,
+      PROFILE_CARD_CONSTANTS.attributes.PROFILE_TEXT,
       PROFILE_CARD_CONSTANTS.attributes.AVATAR_TEXT,
       PROFILE_CARD_CONSTANTS.attributes.AVATAR_IMAGE_URL,
       PROFILE_CARD_CONSTANTS.attributes.AVATAR_LETTER_COUNT
@@ -83,6 +87,12 @@ export class ProfileCardComponent extends BaseComponent implements IProfileCardC
       case PROFILE_CARD_CONSTANTS.attributes.PROFILE:
         this.profile = coerceBoolean(PROFILE_CARD_CONSTANTS.attributes.PROFILE);
         break;
+      case PROFILE_CARD_CONSTANTS.attributes.SIGN_OUT_TEXT:
+        this.signOutText = PROFILE_CARD_CONSTANTS.attributes.SIGN_OUT_TEXT;
+        break;
+      case PROFILE_CARD_CONSTANTS.attributes.PROFILE_TEXT:
+        this.profileText = PROFILE_CARD_CONSTANTS.attributes.PROFILE_TEXT;
+        break;
       case PROFILE_CARD_CONSTANTS.attributes.AVATAR_TEXT:
         this.avatarText = newValue;
         break;
@@ -106,6 +116,12 @@ export class ProfileCardComponent extends BaseComponent implements IProfileCardC
 
   @FoundationProperty()
   public profile: boolean;
+
+  @FoundationProperty()
+  public signOutText: string;
+
+  @FoundationProperty()
+  public profileText: string;
 
   @FoundationProperty()
   public avatarText: string;

--- a/src/stories/src/components/app-bar-profile/app-bar-profile.mdx
+++ b/src/stories/src/components/app-bar-profile/app-bar-profile.mdx
@@ -98,6 +98,18 @@ profileButton.profileCardBuilder = () => {
 
 </PropertyDef>
 
+<PropertyDef name="signOutButtonText" type="string" defaultValue="'Sign out'">
+
+  Gets/sets the sign out button text.
+
+</PropertyDef>
+
+<PropertyDef name="profileButtonText" type="string" defaultValue="'Profile'">
+
+  Gets/sets the profile button text.
+
+</PropertyDef>
+
 <PropertyDef name="profileCardBuilder" type="AppBarProfileButtonProfileCardBuilder" defaultValue="undefined">
 
   The callback that can be used to provide custom content within the profile card.
@@ -161,6 +173,8 @@ interface IAppBarProfileCardConfig {
   email: string;
   signOut: boolean;
   profile: boolean;
+  signOutButtonText: string;
+  profileButtonText: string;
   avatarText: string;
   avatarImageUrl: string;
   avatarLetterCount: number;

--- a/src/test/spec/app-bar/profile-button/app-bar-profile-button.spec.ts
+++ b/src/test/spec/app-bar/profile-button/app-bar-profile-button.spec.ts
@@ -283,6 +283,106 @@ describe('AppBarProfileButtonComponent', function(this: ITestContext) {
       expect(popup).toBeNull();
       expect(profileCard).toBeNull();
     });
+
+    it('should show default sign out text', async function(this: ITestContext) {
+      this.context = setupTestContext();
+
+      this.context.component.open = true;
+      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await tick();
+      
+      const popup = document.querySelector(POPUP_CONSTANTS.elementName) as PopupComponent;
+      const profileCard = popup.querySelector(PROFILE_CARD_CONSTANTS.elementName) as ProfileCardComponent;
+      const signOutButton = getShadowElement(profileCard, PROFILE_CARD_CONSTANTS.selectors.SIGN_OUT_BUTTON) as HTMLButtonElement;
+
+      expect(signOutButton.textContent).toBe(PROFILE_CARD_CONSTANTS.defaults.SIGN_OUT_BUTTON_TEXT);
+    });
+
+    it('should show default profile text', async function(this: ITestContext) {
+      this.context = setupTestContext();
+
+      this.context.component.open = true;
+      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await tick();
+      
+      const popup = document.querySelector(POPUP_CONSTANTS.elementName) as PopupComponent;
+      const profileCard = popup.querySelector(PROFILE_CARD_CONSTANTS.elementName) as ProfileCardComponent;
+      const profileButton = getShadowElement(profileCard, PROFILE_CARD_CONSTANTS.selectors.PROFILE_BUTTON) as HTMLButtonElement;
+
+      expect(profileButton.textContent).toBe(PROFILE_CARD_CONSTANTS.defaults.PROFILE_BUTTON_TEXT);
+    });
+
+    it('should show custom sign out text', async function(this: ITestContext) {
+      this.context = setupTestContext();
+
+      const expectedSignOutText = 'Custom sign out text';
+      this.context.component.signOutButtonText = expectedSignOutText;
+      
+      this.context.component.open = true;
+      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await tick();
+      
+      const popup = document.querySelector(POPUP_CONSTANTS.elementName) as PopupComponent;
+      const profileCard = popup.querySelector(PROFILE_CARD_CONSTANTS.elementName) as ProfileCardComponent;
+      const signOutButton = getShadowElement(profileCard, PROFILE_CARD_CONSTANTS.selectors.SIGN_OUT_BUTTON) as HTMLButtonElement;
+
+      expect(signOutButton.textContent).toBe(expectedSignOutText);
+    });
+
+    it('should show custom profile text', async function(this: ITestContext) {
+      this.context = setupTestContext();
+
+      const expectedProfileText = 'Custom profile text';
+      this.context.component.profileButtonText = expectedProfileText;
+
+      this.context.component.open = true;
+      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await tick();
+      
+      const popup = document.querySelector(POPUP_CONSTANTS.elementName) as PopupComponent;
+      const profileCard = popup.querySelector(PROFILE_CARD_CONSTANTS.elementName) as ProfileCardComponent;
+      const profileButton = getShadowElement(profileCard, PROFILE_CARD_CONSTANTS.selectors.PROFILE_BUTTON) as HTMLButtonElement;
+
+      expect(profileButton.textContent).toBe(expectedProfileText);
+    });
+
+    it('should change custom sign out text while open', async function(this: ITestContext) {
+      this.context = setupTestContext();
+
+      this.context.component.open = true;
+      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await tick();
+
+      const popup = document.querySelector(POPUP_CONSTANTS.elementName) as PopupComponent;
+      const profileCard = popup.querySelector(PROFILE_CARD_CONSTANTS.elementName) as ProfileCardComponent;
+      const signOutButton = getShadowElement(profileCard, PROFILE_CARD_CONSTANTS.selectors.SIGN_OUT_BUTTON) as HTMLButtonElement;
+
+      expect(signOutButton.textContent).toBe(PROFILE_CARD_CONSTANTS.defaults.SIGN_OUT_BUTTON_TEXT);
+
+      const expectedSignOutText = 'Custom sign out text';
+      this.context.component.signOutButtonText = expectedSignOutText;
+
+      expect(signOutButton.textContent).toBe(expectedSignOutText);
+    });
+
+    it('should show custom profile text', async function(this: ITestContext) {
+      this.context = setupTestContext();
+
+      this.context.component.open = true;
+      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await tick();
+      
+      const popup = document.querySelector(POPUP_CONSTANTS.elementName) as PopupComponent;
+      const profileCard = popup.querySelector(PROFILE_CARD_CONSTANTS.elementName) as ProfileCardComponent;
+      const profileButton = getShadowElement(profileCard, PROFILE_CARD_CONSTANTS.selectors.PROFILE_BUTTON) as HTMLButtonElement;
+
+      expect(profileButton.textContent).toBe(PROFILE_CARD_CONSTANTS.defaults.PROFILE_BUTTON_TEXT);
+
+      const expectedProfileText = 'Custom profile text';
+      this.context.component.profileButtonText = expectedProfileText;
+
+      expect(profileButton.textContent).toBe(expectedProfileText);
+    });
   });
 
   function setupTestContext(): ITestAppBarProfileButtonContext {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Added new `signOutButtonText` and `profileButtonText` properties/attributes to the `<forge-app-bar-profile-button>` element and new `signOutText` and `profileText` properties/attributes to the `<forge-profile-card>` element. This enables developers to override the default text (unchanged) and implement i18n.

## Additional information
Closes #165 
