### PR TITLE
fix: fixed duplicate asterisk characters on required form field labels in Safari

### DIFF
--- a/src/lib/chip-field/chip-field-adapter.ts
+++ b/src/lib/chip-field/chip-field-adapter.ts
@@ -30,8 +30,8 @@ export class ChipFieldAdapter extends FieldAdapter implements IChipFieldAdapter 
     super(component);
   }
 
-  public initialize(required: boolean): void {
-    super.initialize(required, CHIP_FIELD_CONSTANTS.selectors.ROOT);
+  public initialize(): void {
+    super.initialize(CHIP_FIELD_CONSTANTS.selectors.ROOT);
     this._memberSlot = getShadowElement(this._component, CHIP_FIELD_CONSTANTS.selectors.MEMBER_SLOT) as HTMLSlotElement;
     this._inputContainerElement = getShadowElement(this._component, CHIP_FIELD_CONSTANTS.selectors.INPUT_CONTAINER) as HTMLElement;
   }

--- a/src/lib/field/field-adapter.ts
+++ b/src/lib/field/field-adapter.ts
@@ -48,14 +48,14 @@ export interface IFieldAdapter extends IBaseAdapter {
   getLabelWidth(fontSize: number, fontFamily: string): number;
 
   // state actions
-  initialize(required: boolean, rootSelector: string): void;
+  initialize(rootSelector: string): void;
   initializeFloatingLabel(): IFloatingLabel;
   ensureLabelOrder(): void;
   ensureSlottedLabel(): void;
   destroy(): void;
   setValueChangedListener(context: any, listener: (value: any) => void): void;
   destroyValueChangeListener(): void;
-  detectLabel(required: boolean): void;
+  detectLabel(): void;
   setRoomy(isRoomy: boolean): void;
   setDense(isDense: boolean): void;
   setInputAttributeObserver(listener: (name: string, value: string | null) => void): void;
@@ -76,14 +76,14 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
     super(component);
   }
 
-  public initialize(required: boolean, rootSelector: string): void {
+  public initialize(rootSelector: string): void {
     this._rootElement = getShadowElement(this._component, rootSelector);
     this._labelSlot = getShadowElement(this._component, 'slot[name=label]') as HTMLSlotElement;
     this._leadingSlot = getShadowElement(this._component, 'slot[name=leading]') as HTMLSlotElement;
     this._trailingSlot = getShadowElement(this._component, 'slot[name=trailing]') as HTMLSlotElement;
     this._addonEndSlot = getShadowElement(this._component, 'slot[name=addon-end]') as HTMLSlotElement;
     this._inputElement = this._component.querySelector('input:not([type=checkbox]):not([type=radio])') as HTMLInputElement;
-    this.detectLabel(required);
+    this.detectLabel();
   }
 
   public destroy(): void {
@@ -168,18 +168,8 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
     this._valueChangeListeners.forEach(cb => cb());
   }
 
-  public detectLabel(required: boolean): void {
+  public detectLabel(): void {
     this._labelElement = this._component.querySelector('label') as HTMLLabelElement;
-
-    // Due to a Safari bug with ::slotted::after selectors, we need to manually append the required 'asterisk' to the label text
-    // https://bugs.webkit.org/show_bug.cgi?id=178237
-    if (required && Platform.WEBKIT && this._labelElement && !this._labelElement.innerText.endsWith('*')) {
-      const asterisk = document.createElement('span');
-      asterisk.style.color = 'var(--mdc-theme-error)';
-      asterisk.style.marginLeft = '1px';
-      asterisk.textContent = '*';
-      this._labelElement.appendChild(asterisk);
-    }
   }
 
   public initializeFloatingLabel(): IFloatingLabel {

--- a/src/lib/field/field-foundation.ts
+++ b/src/lib/field/field-foundation.ts
@@ -45,7 +45,7 @@ export class FieldFoundation {
   //
 
   public initialize(): void {
-    this._adapter.initialize(this._required, '');
+    this._adapter.initialize('');
 
     if (this._adapter.hasLabel()) {
       this._adapter.ensureSlottedLabel();
@@ -235,7 +235,7 @@ export class FieldFoundation {
     if (this._floatingLabel) {
       this._floatingLabel.destroy();
     }
-    this._adapter.detectLabel(this._required);
+    this._adapter.detectLabel();
     if (this._adapter.hasLabel() && this._density !== 'dense') {
       this._floatingLabel = this._adapter.initializeFloatingLabel();
       this._adapter.ensureLabelOrder();

--- a/src/lib/quantity-field/_mixins.scss
+++ b/src/lib/quantity-field/_mixins.scss
@@ -72,7 +72,7 @@
   &::before {
     @include mdc-theme.property(color, error);
     content: '*';
-    margin-right: 1px;
+    margin-right: 4px;
   }
 }
 

--- a/src/lib/quantity-field/quantity-field-adapter.ts
+++ b/src/lib/quantity-field/quantity-field-adapter.ts
@@ -24,7 +24,6 @@ export interface IQuantityFieldAdapter extends IBaseAdapter {
   addTextFieldAttribute(name: string, value?: string): void;
   removeTextFieldAttribute(name: string): void;
   removeInputDisabledAttributeChangeListener(): void;
-  setLabelAsRequired(required: boolean): void;
   increment(): void;
   decrement(): void;
 }
@@ -128,20 +127,6 @@ export class QuantityFieldAdapter extends BaseAdapter<IQuantityFieldComponent> i
 
   public removeDecrementButtonAttribute(name: string): void {
     this._decrementButtonElement.removeAttribute(name);
-  }
-
-  public setLabelAsRequired(required: boolean): void {
-    const labelElement = this._component.querySelector(QUANTITY_FIELD_CONSTANTS.selectors.LABEL) as HTMLLabelElement;
-
-    // Due to a Safari bug with ::slotted::after selectors, we need to manually append the required "asterisk" to the label text
-    // https://bugs.webkit.org/show_bug.cgi?id=178237
-    if (required && Platform.WEBKIT && labelElement && !labelElement.innerText.endsWith('*')) {
-      const asterisk = document.createElement('span');
-      asterisk.style.color = 'var(--mdc-theme-error)';
-      asterisk.style.marginLeft = '1px';
-      asterisk.textContent = '*';
-      labelElement.appendChild(asterisk);
-    }
   }
 
   public increment(): void {

--- a/src/lib/quantity-field/quantity-field-foundation.ts
+++ b/src/lib/quantity-field/quantity-field-foundation.ts
@@ -98,8 +98,6 @@ export class QuantityFieldFoundation implements IQuantityFieldFoundation {
       this._adapter.removeHostAttribute(QUANTITY_FIELD_CONSTANTS.attributes.REQUIRED);
       this._adapter.removeRootClass(QUANTITY_FIELD_CONSTANTS.classes.REQUIRED);
     }
-
-    this._adapter.setLabelAsRequired(this._required);
   }
 
   public get invalid(): boolean {

--- a/src/lib/text-field/text-field-adapter.ts
+++ b/src/lib/text-field/text-field-adapter.ts
@@ -16,8 +16,8 @@ export class TextFieldAdapter extends FieldAdapter implements ITextFieldAdapter 
     super(component);
   }
 
-  public initialize(required: boolean): void {
-    super.initialize(required, TEXT_FIELD_CONSTANTS.selectors.ROOT);
+  public initialize(): void {
+    super.initialize(TEXT_FIELD_CONSTANTS.selectors.ROOT);
     this._inputElements = Array.from(this._component.querySelectorAll('input:not([type=checkbox]):not([type=radio]), textarea'));
     if (this._inputElements.length > 1) {
       this._handleMultiInputs();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The original bug where `::before` and `::after` pseudo elements were not supported on `::slotted` selectors such as `::slotted(label)::before` in WebKit was fixed in 2021 (introduced in Safari 15). See ticket [here](https://bugs.webkit.org/show_bug.cgi?id=178237).

Our workaround was to use JavaScript in Safari to manually add the asterisk character to form field labels, but now that this has been fixed it was causing duplicate asterisks. We can safely remove this and tell consumers to use the latest Safari browser version.

In cases where consumers are still using an older version of Safari where this bug exists, the asterisks on the label will not display at all. Developers should use the previous version that supports that functionality in that case.

## Additional information
Fixes #146 
