### PR TITLE
fix(table): ignore filter row checkboxes when toggling select column state

### DIFF
--- a/src/lib/table/table-utils.ts
+++ b/src/lib/table/table-utils.ts
@@ -840,7 +840,7 @@ export class TableUtils {
    * @param rowElement
    */
   private static _getCheckboxElement(rowElement: HTMLTableRowElement): HTMLInputElement | null {
-    const selectCell = rowElement.querySelector(`.${TABLE_CONSTANTS.classes.TABLE_CELL_SELECT_CHECKBOX_CONTAINER}`);
+    const selectCell = rowElement.querySelector(`.${TABLE_CONSTANTS.classes.TABLE_CELL_SELECT}`);
     if (!selectCell) {
       return null;
     }
@@ -852,7 +852,7 @@ export class TableUtils {
    * @param rowElement
    */
   private static _tryGetSelectAllCheckboxElement(rowElement: HTMLTableRowElement): HTMLInputElement | null {
-    const selectAllCell = rowElement.querySelector(`.${TABLE_CONSTANTS.classes.TABLE_CELL_SELECT_CHECKBOX_CONTAINER}`);
+    const selectAllCell = rowElement.querySelector(`.${TABLE_CONSTANTS.classes.TABLE_CELL_SELECT}`);
     if (!selectAllCell) {
       return null;
     }

--- a/src/lib/table/table-utils.ts
+++ b/src/lib/table/table-utils.ts
@@ -561,7 +561,7 @@ export class TableUtils {
 
   private static _attachRowSelectListener(row: HTMLTableRowElement, clickListener: (evt: Event) => void): void {
     const checkboxElement = TableUtils._getCheckboxElement(row);
-    checkboxElement.addEventListener('click', clickListener);
+    checkboxElement?.addEventListener('click', clickListener);
   }
 
   /**
@@ -572,9 +572,7 @@ export class TableUtils {
   private static _detachRowSelectListeners(tbodyElement: HTMLTableSectionElement, clickListener: (evt: Event) => void): void {
     Array.from(tbodyElement.rows).forEach(row => {
       const checkboxElement = TableUtils._getCheckboxElement(row);
-      if (checkboxElement) {
-        checkboxElement.removeEventListener('click', clickListener);
-      }
+      checkboxElement?.removeEventListener('click', clickListener);
     });
   }
 
@@ -609,7 +607,7 @@ export class TableUtils {
    */
   private static _tryAttachSelectAllTemplateListener(theadElement: HTMLTableSectionElement, listener: (evt: Event) => void): void {
     const lastTheadRow = theadElement.rows[theadElement.rows.length - 1];
-    const checkboxElement = TableUtils._tryGetCheckboxElement(lastTheadRow);
+    const checkboxElement = TableUtils._tryGetSelectAllCheckboxElement(lastTheadRow);
 
     if (checkboxElement) {
       checkboxElement.addEventListener('change', listener);
@@ -623,7 +621,7 @@ export class TableUtils {
    */
   private static _detachSelectAllListener(theadElement: HTMLTableSectionElement, listener: (evt: Event) => void): void {
     const lastTheadRow = theadElement.rows[theadElement.rows.length - 1];
-    const checkboxElement = TableUtils._tryGetCheckboxElement(lastTheadRow);
+    const checkboxElement = TableUtils._tryGetSelectAllCheckboxElement(lastTheadRow);
 
     if (!checkboxElement) {
       return;
@@ -841,16 +839,25 @@ export class TableUtils {
    * Retrieves the checkbox element from the given table row. Used in select mode only.
    * @param rowElement
    */
-  private static _getCheckboxElement(rowElement: HTMLTableRowElement): HTMLInputElement {
-    return rowElement.querySelector(TABLE_CONSTANTS.selectors.CHECKBOX_INPUT) as HTMLInputElement;
+  private static _getCheckboxElement(rowElement: HTMLTableRowElement): HTMLInputElement | null {
+    const selectCell = rowElement.querySelector(`.${TABLE_CONSTANTS.classes.TABLE_CELL_SELECT_CHECKBOX_CONTAINER}`);
+    if (!selectCell) {
+      return null;
+    }
+    return selectCell.querySelector(TABLE_CONSTANTS.selectors.CHECKBOX_INPUT) as HTMLInputElement;
   }
 
   /**
-   * Retrieves the checkbox element from the given table row. Used in select mode only.
+   * Retrieves the select all checkbox element from the given table row. Used in select mode only.
    * @param rowElement
    */
-  private static _tryGetCheckboxElement(rowElement: HTMLTableRowElement): HTMLInputElement {
-    return rowElement.querySelector(TABLE_CONSTANTS.selectors.CHECKBOX_INPUT) as HTMLInputElement || rowElement.querySelector(TABLE_CONSTANTS.selectors.SELECT_ALL_TEMPLATE_CHECKBOX_INPUT) as HTMLInputElement;
+  private static _tryGetSelectAllCheckboxElement(rowElement: HTMLTableRowElement): HTMLInputElement | null {
+    const selectAllCell = rowElement.querySelector(`.${TABLE_CONSTANTS.classes.TABLE_CELL_SELECT_CHECKBOX_CONTAINER}`);
+    if (!selectAllCell) {
+      return null;
+    }
+    return selectAllCell.querySelector(TABLE_CONSTANTS.selectors.CHECKBOX_INPUT) as HTMLInputElement ||
+           selectAllCell.querySelector(TABLE_CONSTANTS.selectors.SELECT_ALL_TEMPLATE_CHECKBOX_INPUT) as HTMLInputElement;
   }
 
   /**
@@ -910,7 +917,10 @@ export class TableUtils {
    */
   public static updateSelectedState(rowElement: HTMLTableRowElement, isSelected: boolean): void {
     TableUtils._setRowSelectedState(rowElement, isSelected);
-    TableUtils._setSelectedCheckboxState(TableUtils._getCheckboxElement(rowElement), isSelected);
+    const selectCheckbox = TableUtils._getCheckboxElement(rowElement);
+    if (selectCheckbox) {
+      TableUtils._setSelectedCheckboxState(selectCheckbox, isSelected);
+    }
   }
 
   /**
@@ -931,7 +941,7 @@ export class TableUtils {
     }
 
     const lastTheadRow = tableElement.tHead.rows[tableElement.tHead.rows.length - 1];
-    const selectAllCheckboxElement = TableUtils._tryGetCheckboxElement(lastTheadRow);
+    const selectAllCheckboxElement = TableUtils._tryGetSelectAllCheckboxElement(lastTheadRow);
 
     if (selectAllCheckboxElement) {
       TableUtils._setSelectedCheckboxState(selectAllCheckboxElement, isAllSelected);
@@ -965,7 +975,10 @@ export class TableUtils {
         const existingSelection = findWhere(selectedRows, createPredicate(key, rowData));
         if (existingSelection) {
           TableUtils._setRowSelectedState(row, true);
-          TableUtils._setSelectedCheckboxState(TableUtils._getCheckboxElement(row), true);
+          const selectCheckbox = TableUtils._getCheckboxElement(row);
+          if (selectCheckbox) {
+            TableUtils._setSelectedCheckboxState(selectCheckbox, true);
+          }
           selectedRowCount++;
         }
       });
@@ -985,7 +998,10 @@ export class TableUtils {
     const nonExpandedRows = TableUtils._getNonExpandedRows(tableElement.tBodies[0].rows);
     nonExpandedRows.forEach(row => {
       TableUtils._setRowSelectedState(row, false);
-      TableUtils._setSelectedCheckboxState(TableUtils._getCheckboxElement(row), false);
+      const selectCheckbox = TableUtils._getCheckboxElement(row);
+      if (selectCheckbox) {
+        TableUtils._setSelectedCheckboxState(selectCheckbox, false);
+      }
     });
   }
 

--- a/src/stories/src/components/table/table.mdx
+++ b/src/stories/src/components/table/table.mdx
@@ -30,9 +30,13 @@ in the functionality it provides. This component is configuration-based, and it 
 
 ### Using column filters
 
-To add column filters you will need to specify a `filterDelegate` for each column that needs it. You can use the built-in component delegate classes (see example below) for the common filter input types, or you can build your own delegate class that represents the component you would like to render in the filter cell.
+To add column filters you will need to specify a `filterDelegate` for each column that needs it. You can use the built-in component delegate classes
+(see example below) for the common filter input types, or you can build your own delegate class that represents the component you would like to render
+in the filter cell.
 
-A component delegate is a flexible API that allows you to define a class that extends an `AbstractComponentDelegate`. This class defines a common interface to use for dynamic components that require the ability to get/set values, set invalid, disabled, required... etc. You can then communicate with your component through this delegate instance.
+A component delegate is a flexible API that allows you to define a class that extends an `BaseComponentDelegate` or `FormFieldComponentDelegate`. These
+classes define a common interface to use for dynamic components that require the ability to get/set values, set invalid, disabled, required... etc. You
+can then communicate with your component through this delegate instance.
 
 ```ts
 import { TextFieldComponentDelegate, SelectComponentDelegate } from '@tylertech/forge';
@@ -47,8 +51,15 @@ table.columnConfigurations = [
 
 ### Mapping Boolean outputs
 
-To map the output for Boolean (true/false) values, use the `transform` method in your `IColumnConfiguration` for those
-columns where you want to show something other than `true` and `false`.
+To map the output for boolean values, use the `transform` method in your `IColumnConfiguration` for those columns where you want to show something other than `true` and `false`.
+
+```typescript
+{
+  transform: value =>  value ? 'Enabled' : 'Disabled',
+}
+```
+
+> Note: You would use the `template` property to render custom HTML elements instead of plain text.
 
 </PageSection>
 
@@ -255,7 +266,7 @@ export class TableExampleComponent implements OnInit {
 
   Sets the callback to return a custom template for the select all cell in the table header.
 
-  The default select all functionality will automatically wire up to an `<input type="checkbox"/>` if it is present in the template unless the attribute `forge-ignore` resides on the `input`
+  The default select all functionality will automatically wire up to an `<input type="checkbox">` if it is present in the template unless the attribute `forge-ignore` resides on the `<input>`.
 
 </PropertyDef>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The table will now properly scope its queries for `<input type="checkbox">` elements to only the selection column cells. This will allow any checkboxes to be used in the filter row in non-select column cells.

## Additional information
Fixes #133 (this change removes the need for the `forge-ignore` attribute on checkbox filter elements)
