### PR TITLE
chore: optimize pr-check workflow to limit dependency installation to

### DIFF
--- a/.github/workflows/auto-pr-check.yml
+++ b/.github/workflows/auto-pr-check.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   release:
     name: Pull Request Validation
-    uses: tyler-technologies-oss/forge-automation-shared/.github/workflows/wf-auto-pr-check.yml@v2.2.0
+    uses: tyler-technologies-oss/forge-automation-shared/.github/workflows/wf-auto-pr-check.yml@v2.2.1
     with:
       NPM_INSTALL_COMMAND: "ci --ignore-scripts"

--- a/.github/workflows/auto-pr-check.yml
+++ b/.github/workflows/auto-pr-check.yml
@@ -6,8 +6,10 @@ on:
       - main
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
-    
+
 jobs:
   release:
     name: Pull Request Validation
-    uses: tyler-technologies-oss/forge-automation-shared/.github/workflows/wf-auto-pr-check.yml@v2.1.1
+    uses: tyler-technologies-oss/forge-automation-shared/.github/workflows/wf-auto-pr-check.yml@v2.2.0
+    with:
+      NPM_INSTALL_COMMAND: "ci --ignore-scripts"


### PR DESCRIPTION
Add `ci --ignore-scripts` to pr-check workflow installation to avoid installing unnecessary Storybook deps by default