### PR TITLE
fix(table): fixed default select height in column filter

### DIFF
--- a/src/lib/table/_mixins.scss
+++ b/src/lib/table/_mixins.scss
@@ -360,6 +360,8 @@
 
 @mixin head-filter() {
   --forge-text-field-height: 2.5rem;
+  --forge-select-height: 2.5rem;
+
   .forge-table-head__cell-container {
     padding: 8px 0;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The `<forge-select>` was using its default height when placed in a table column filter. This was inconsistent with the height adjustment that is applied to the `<forge-text-field>` by the `<forge-table>` component styles. This change adds a CSS custom property to override the `<forge-select>` height to match that of the `<forge-text-field>`.
