### PR TITLE
fix(slider): fixed propagation to underlying implementation state for `min`, `max`, and `step` properties

### DIFF
--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -1,4 +1,4 @@
-import { MDCSlider } from '@material/slider';
+import { MDCSlider, MDCSliderFoundation } from '@material/slider';
 import { CustomElement, coerceBoolean, coerceNumber, emitEvent, attachShadowTemplate, getShadowElement, isDefined, removeAllChildren, replaceShadowTemplate } from '@tylertech/forge-core';
 import { BaseComponent, IBaseComponent } from '../core/base/base-component';
 import { SLIDER_CONSTANTS, SliderType, ISliderChangeEventData, ISliderInputEventData } from './slider-constants';
@@ -54,6 +54,7 @@ export class SliderComponent extends BaseComponent implements ISliderComponent {
   }
 
   private _mdcSlider: MDCSlider;
+  private _mdcSliderFoundation: MDCSliderFoundation;
 
   // State
   private _type: SliderType = 'continuous';
@@ -61,7 +62,7 @@ export class SliderComponent extends BaseComponent implements ISliderComponent {
   private _valueStart = 0;
   private _min = 0;
   private _max = 100;
-  private _step = 0;
+  private _step = 1;
   private _disabled = false;
 
   // Listeners
@@ -155,18 +156,23 @@ export class SliderComponent extends BaseComponent implements ISliderComponent {
 
     // We need to initialize MDCSlider in the next cycle after our template has been placed in the DOM
     window.setTimeout(() => {
-      if (!this._rootElement) {
-        return;
-      }
-      if (this._mdcSlider) {
-        this._mdcSlider.destroy();
-      }
-      this._mdcSlider = new MDCSlider(this._rootElement);
-      this._syncToSlider();
-      this._mdcSlider.initialize();
-      this._rootElement.addEventListener(SLIDER_CONSTANTS.events.MDC_INPUT, this._mdcSliderUpdateListener);
-      this._rootElement.addEventListener(SLIDER_CONSTANTS.events.MDC_CHANGE, this._mdcSliderUpdateListener);
+      this._initializeMdcSlider();
+      this._rootElement?.addEventListener(SLIDER_CONSTANTS.events.MDC_INPUT, this._mdcSliderUpdateListener);
+      this._rootElement?.addEventListener(SLIDER_CONSTANTS.events.MDC_CHANGE, this._mdcSliderUpdateListener);
     });
+  }
+
+  private _initializeMdcSlider(): void {
+    if (!this._rootElement) {
+      return;
+    }
+    if (this._mdcSlider) {
+      this._mdcSlider.destroy();
+    }
+    this._mdcSlider = new MDCSlider(this._rootElement);
+    this._mdcSliderFoundation = (this._mdcSlider as any).foundation as MDCSliderFoundation;
+    this._syncToSlider();
+    this._mdcSlider.initialize();
   }
 
   private _onSliderUpdate(evt: CustomEvent): void {
@@ -204,6 +210,7 @@ export class SliderComponent extends BaseComponent implements ISliderComponent {
     if (this._inputElementStart) {
       this._inputElementStart.min = `${min}`;
     }
+    this._mdcSliderFoundation?.setMin(min);
     this._mdcSlider?.layout();
   }
 
@@ -214,6 +221,7 @@ export class SliderComponent extends BaseComponent implements ISliderComponent {
     if (this._inputElementStart) {
       this._inputElementStart.max = `${max}`;
     }
+    this._mdcSliderFoundation?.setMax(max);
     this._mdcSlider?.layout();
   }
 
@@ -224,6 +232,7 @@ export class SliderComponent extends BaseComponent implements ISliderComponent {
     if (this._inputElementStart) {
       this._inputElementStart.step = `${step}`;
     }
+    this._mdcSliderFoundation?.setStep(step);
     this._mdcSlider?.layout();
   }
 

--- a/src/test/spec/slider/slider.spec.ts
+++ b/src/test/spec/slider/slider.spec.ts
@@ -1,7 +1,7 @@
 import { defineSliderComponent, ISliderComponent, SLIDER_CONSTANTS, SliderComponent } from '@tylertech/forge/slider';
 import { removeElement, getShadowElement, emitEvent } from '@tylertech/forge-core';
 import { tick, timer } from '@tylertech/forge-testing';
-import { MDCSlider } from '@material/slider';
+import { MDCSlider, MDCSliderFoundation } from '@material/slider';
 
 interface ITestContext {
   context: ITestSliderContext;
@@ -10,6 +10,7 @@ interface ITestContext {
 interface ITestSliderContext {
   component: ISliderComponent;
   getMDCSlider(): MDCSlider;
+  getMDCSliderFoundation(): MDCSliderFoundation;
   getStep(): number;
   getMin(): number;
   getMax(): number;
@@ -156,6 +157,7 @@ describe('SliderComponent', function(this: ITestContext) {
 
     expect(this.context.getMax()).toBe(75, 'Expected MDC slider to be set to 75');
     expect(this.context.component.getAttribute(SLIDER_CONSTANTS.attributes.MAX)).toBe('75');
+    expect(this.context.getMDCSliderFoundation().getMax()).toBe(75);
   });
 
   it('should set max via attribute', async function(this: ITestContext) {
@@ -166,15 +168,17 @@ describe('SliderComponent', function(this: ITestContext) {
 
     expect(this.context.component.max).toBe(75);
     expect(this.context.getMax()).toBe(75);
+    expect(this.context.getMDCSliderFoundation().getMax()).toBe(75);
   });
 
   it('should set min via attribute when set by default', async function(this: ITestContext) {
     this.context = setupTestContext();
-    this.context.component.setAttribute(SLIDER_CONSTANTS.attributes.MAX, '75');
+    this.context.component.setAttribute(SLIDER_CONSTANTS.attributes.MIN, '75');
     this.context.append();
     await timer();
-    expect(this.context.component.max).toBe(75);
-    expect(this.context.getMax()).toBe(75);
+    expect(this.context.component.min).toBe(75);
+    expect(this.context.getMin()).toBe(75);
+    expect(this.context.getMDCSliderFoundation().getMin()).toBe(75);
   });
 
   it('should set step via property', async function(this: ITestContext) {
@@ -183,6 +187,7 @@ describe('SliderComponent', function(this: ITestContext) {
     this.context.component.step = 2;
     expect(this.context.getStep()).toBe(2);
     expect(this.context.component.getAttribute(SLIDER_CONSTANTS.attributes.STEP)).toBe('2');
+    expect(this.context.getMDCSliderFoundation().getStep()).toBe(2);
   });
 
   it('should set step via attribute', async function(this: ITestContext) {
@@ -193,6 +198,7 @@ describe('SliderComponent', function(this: ITestContext) {
 
     expect(this.context.component.step).toBe(2);
     expect(this.context.getStep()).toBe(2);
+    expect(this.context.getMDCSliderFoundation().getStep()).toBe(2);
   });
 
   it('should set min via attribute when set by default', async function(this: ITestContext) {
@@ -215,6 +221,7 @@ describe('SliderComponent', function(this: ITestContext) {
     return {
       component,
       getMDCSlider: () => component['_mdcSlider'],
+      getMDCSliderFoundation: () => component['_mdcSliderFoundation'],
       getStep: () => {
         const inputElement = getShadowElement(component, SLIDER_CONSTANTS.selectors.VALUE_INPUT) as HTMLInputElement;
         return +inputElement.step;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The slider component will now properly set the `min`, `max`, and `step` values on the underlying `MDCSliderFoundation` instance. The MDC implementation does not expose public APIs for these properties or the foundation, so needing to access with `any` unsafely. This is an interim solution until we provide our own slider implementation in the next major version of the library.

## Additional information
Fixes #179 
