### PR TITLE
feat: added property on base field component to allows the addon end slot to remain enabled when the field is otherwise disabled

### DIFF
--- a/src/lib/field/_selector.scss
+++ b/src/lib/field/_selector.scss
@@ -1,5 +1,6 @@
 @use 'sass:list';
 @use './base';
+@use '../theme';
 
 @mixin field($component-name: 'forge-field', $exclude: ()) {
   // Core
@@ -527,7 +528,7 @@
         }
       }
     }
-    &.forge-field--disabled {
+    &.forge-field--disabled:not(.forge-field__addon-end-container--enabled) {
       .forge-field__addon-end-container {
         @include base.addon-end-border-left-color(disabled);
       }
@@ -548,6 +549,25 @@
     &--disabled:not(.forge-field__addon-end-container--enabled) {
       ::slotted([slot='addon-end']) {
         @include base.icon-color(disabled);
+      }
+    }
+  }
+
+  // Color
+  @if list.index($exclude, forge-field__addon-end-container--enabled) == null {
+    .forge-field__addon-end-container--enabled {
+      .forge-field__addon-end-container {
+
+        @include theme.property(background-color, var(--mdc-theme-surface));
+        @include theme.property(color, var(--mdc-theme-text-primary-on-background));
+        @include theme.property(border-color, border-color);
+        border-width: 1px;
+        border-style: solid;
+        border-top-right-radius: 4px;
+        border-bottom-right-radius: 4px;
+        box-sizing: border-box;
+        -moz-box-sizing: border-box;
+        -webkit-box-sizing: border-box;
       }
     }
   }

--- a/src/lib/field/_selector.scss
+++ b/src/lib/field/_selector.scss
@@ -564,8 +564,6 @@
       border-top-right-radius: 4px;
       border-bottom-right-radius: 4px;
       box-sizing: border-box;
-      -moz-box-sizing: border-box;
-      -webkit-box-sizing: border-box;
     }
   }
 }

--- a/src/lib/field/_selector.scss
+++ b/src/lib/field/_selector.scss
@@ -553,22 +553,19 @@
     }
   }
 
-  // Color
-  @if list.index($exclude, forge-field__addon-end-container--enabled) == null {
-    .forge-field__addon-end-container--enabled {
-      .forge-field__addon-end-container {
-
-        @include theme.property(background-color, var(--mdc-theme-surface));
-        @include theme.property(color, var(--mdc-theme-text-primary-on-background));
-        @include theme.property(border-color, border-color);
-        border-width: 1px;
-        border-style: solid;
-        border-top-right-radius: 4px;
-        border-bottom-right-radius: 4px;
-        box-sizing: border-box;
-        -moz-box-sizing: border-box;
-        -webkit-box-sizing: border-box;
-      }
+  // Addon End Slot Always Enabled.
+  &.forge-field__addon-end-container--enabled.forge-field--disabled:not(.forge-field--invalid) {
+    .forge-field__addon-end-container {
+      @include theme.property(background-color, surface);
+      @include theme.property(color, text-primary-on-background);
+      @include theme.property(border-color, border-color);
+      border-style: solid;
+      border-width: 1px;
+      border-top-right-radius: 4px;
+      border-bottom-right-radius: 4px;
+      box-sizing: border-box;
+      -moz-box-sizing: border-box;
+      -webkit-box-sizing: border-box;
     }
   }
 }

--- a/src/lib/field/_selector.scss
+++ b/src/lib/field/_selector.scss
@@ -545,7 +545,7 @@
         @include base.icon-color(invalid);
       }
     }
-    &--disabled {
+    &--disabled:not(.forge-field__addon-end-container--enabled) {
       ::slotted([slot='addon-end']) {
         @include base.icon-color(disabled);
       }

--- a/src/lib/field/field-constants.ts
+++ b/src/lib/field/field-constants.ts
@@ -4,9 +4,8 @@ const attributes = {
   SHAPE: 'shape',
   INVALID: 'invalid',
   REQUIRED: 'required',
-  HOST_LABEL_FLOATING: `forge-label-floating`,
-  ADDON_END_ALWAYS_ENABLED: `forge-addon-end-always-enabled`
-
+  ADDON_END_ALWAYS_ENABLED: `addon-end-always-enabled`,
+  HOST_LABEL_FLOATING: `forge-label-floating`
 };
 
 const observedInputAttributes = ['disabled', 'readonly', 'value', 'placeholder'];

--- a/src/lib/field/field-constants.ts
+++ b/src/lib/field/field-constants.ts
@@ -4,7 +4,9 @@ const attributes = {
   SHAPE: 'shape',
   INVALID: 'invalid',
   REQUIRED: 'required',
-  HOST_LABEL_FLOATING: `forge-label-floating`
+  HOST_LABEL_FLOATING: `forge-label-floating`,
+  ADDON_END_ALWAYS_ENABLED: `forge-addon-end-always-enabled`
+
 };
 
 const observedInputAttributes = ['disabled', 'readonly', 'value', 'placeholder'];
@@ -24,7 +26,8 @@ const classes = {
   REQUIRED: 'forge-field--required',
   DENSE: 'forge-field--dense',
   ROOMY: 'forge-field--roomy',
-  LABEL: 'forge-field--label'
+  LABEL: 'forge-field--label',
+  ADDON_END_ALWAYS_ENABLED: 'forge-field__addon-end-container--enabled'
 };
 
 export const FIELD_CONSTANTS = {

--- a/src/lib/field/field-foundation.ts
+++ b/src/lib/field/field-foundation.ts
@@ -214,20 +214,24 @@ export class FieldFoundation {
     }
   }
 
+  public get addonEndAlwaysEnabled(): boolean {
+    return this._addonEndAlwaysEnabled;
+  }
+
   public set addonEndAlwaysEnabled(value: boolean) {
     if (this._addonEndAlwaysEnabled !== value) {
       this._addonEndAlwaysEnabled = value;
 
+      if (this._isInitialized) {
+        this._setAddonEndAlwaysEnabled();
+      }
+
       if (this._addonEndAlwaysEnabled) {
-        this._adapter.setRootClass(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED);
+        this._adapter.setHostAttribute(FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED);
       } else {
-        this._adapter.removeRootClass(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED);
+        this._adapter.removeHostAttribute(FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED);
       }
     }
-  }
-
-  public get addonEndAlwaysEnabled(): boolean {
-    return this._addonEndAlwaysEnabled;
   }
 
   //
@@ -393,6 +397,14 @@ export class FieldFoundation {
       this._adapter.setRootClass(FIELD_CONSTANTS.classes.REQUIRED);
     } else {
       this._adapter.removeRootClass(FIELD_CONSTANTS.classes.REQUIRED);
+    }
+  }
+
+  protected _setAddonEndAlwaysEnabled(): void {
+    if (this._addonEndAlwaysEnabled) {
+      this._adapter.setRootClass(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED);
+    } else {
+      this._adapter.removeRootClass(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED);
     }
   }
 

--- a/src/lib/field/field-foundation.ts
+++ b/src/lib/field/field-foundation.ts
@@ -1,7 +1,8 @@
 import { ICustomElementFoundation } from '@tylertech/forge-core';
+
 import { IFloatingLabel } from '../floating-label/floating-label';
 import { IFieldAdapter } from './field-adapter';
-import { FIELD_CONSTANTS, FieldFloatLabelType, FieldShapeType, FieldDensityType } from './field-constants';
+import { FIELD_CONSTANTS, FieldDensityType, FieldFloatLabelType, FieldShapeType } from './field-constants';
 
 export interface IFieldFoundation extends ICustomElementFoundation {
   density: FieldDensityType;
@@ -9,6 +10,7 @@ export interface IFieldFoundation extends ICustomElementFoundation {
   shape: FieldShapeType;
   invalid: boolean;
   required: boolean;
+  addonEndAlwaysEnabled: boolean;
   floatLabel(value: boolean, alwaysFloat?: boolean): void;
 }
 
@@ -20,6 +22,7 @@ export class FieldFoundation {
   protected _required = false;
   protected _floatLabelType: FieldFloatLabelType = 'auto';
   protected _isInitialized = false;
+  protected _addonEndAlwaysEnabled = false;
   protected _labelSlotListener: (evt: Event) => void;
   protected _leadingSlotListener: (evt: Event) => void;
   protected _trailingSlotListener: (evt: Event) => void;
@@ -209,6 +212,22 @@ export class FieldFoundation {
         this._adapter.removeHostAttribute(FIELD_CONSTANTS.attributes.HOST_LABEL_FLOATING);
       }
     }
+  }
+
+  public set addonEndAlwaysEnabled(value: boolean) {
+    if (this._addonEndAlwaysEnabled !== value) {
+      this._addonEndAlwaysEnabled = value;
+
+      if (this._addonEndAlwaysEnabled) {
+        this._adapter.setRootClass(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED);
+      } else {
+        this._adapter.removeRootClass(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED);
+      }
+    }
+  }
+
+  public get addonEndAlwaysEnabled(): boolean {
+    return this._addonEndAlwaysEnabled;
   }
 
   //

--- a/src/lib/field/field-foundation.ts
+++ b/src/lib/field/field-foundation.ts
@@ -72,6 +72,7 @@ export class FieldFoundation {
     this._applyDensity();
     this._setShapeType();
     this._setValidity();
+    this._applyAddonEndAlwaysEnabled();
 
     if (this._adapter.isDisabled()) {
       this._adapter.setRootClass(FIELD_CONSTANTS.classes.DISABLED);
@@ -221,16 +222,10 @@ export class FieldFoundation {
   public set addonEndAlwaysEnabled(value: boolean) {
     if (this._addonEndAlwaysEnabled !== value) {
       this._addonEndAlwaysEnabled = value;
-
       if (this._isInitialized) {
-        this._setAddonEndAlwaysEnabled();
+        this._applyAddonEndAlwaysEnabled();
       }
-
-      if (this._addonEndAlwaysEnabled) {
-        this._adapter.setHostAttribute(FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED);
-      } else {
-        this._adapter.removeHostAttribute(FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED);
-      }
+      this._adapter.toggleHostAttribute(FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED, this._addonEndAlwaysEnabled);
     }
   }
 
@@ -400,7 +395,7 @@ export class FieldFoundation {
     }
   }
 
-  protected _setAddonEndAlwaysEnabled(): void {
+  protected _applyAddonEndAlwaysEnabled(): void {
     if (this._addonEndAlwaysEnabled) {
       this._adapter.setRootClass(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED);
     } else {

--- a/src/lib/field/field.ts
+++ b/src/lib/field/field.ts
@@ -1,7 +1,8 @@
-import { FieldDensityType, FieldFloatLabelType, FieldShapeType, FIELD_CONSTANTS } from './field-constants';
-import { BaseComponent, IBaseComponent } from '../core/base/base-component';
-import { FieldFoundation } from './field-foundation';
 import { coerceBoolean, ensureChildren, FoundationProperty } from '@tylertech/forge-core';
+
+import { BaseComponent, IBaseComponent } from '../core/base/base-component';
+import { FIELD_CONSTANTS, FieldDensityType, FieldFloatLabelType, FieldShapeType } from './field-constants';
+import { FieldFoundation } from './field-foundation';
 
 export interface IFieldComponent extends IBaseComponent {
   density: FieldDensityType;
@@ -9,6 +10,7 @@ export interface IFieldComponent extends IBaseComponent {
   shape: FieldShapeType;
   invalid: boolean;
   required: boolean;
+  addonEndAlwaysEnabled: boolean;
   floatLabel(value: boolean): void;
 }
 
@@ -19,7 +21,8 @@ export abstract class FieldComponent<T extends FieldFoundation> extends BaseComp
       FIELD_CONSTANTS.attributes.FLOAT_LABEL_TYPE,
       FIELD_CONSTANTS.attributes.SHAPE,
       FIELD_CONSTANTS.attributes.INVALID,
-      FIELD_CONSTANTS.attributes.REQUIRED
+      FIELD_CONSTANTS.attributes.REQUIRED,
+      FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED
     ];
   }
 
@@ -84,6 +87,10 @@ export abstract class FieldComponent<T extends FieldFoundation> extends BaseComp
   /** Gets/sets the required state which controls the visibility of the asterisk in the label. */
   @FoundationProperty()
   public required: boolean;
+
+  /** Gets/sets addonEndAlawysEnabled which controls whether the addon end slot should remain enabled when the control is otherwise disabled.. */
+  @FoundationProperty()
+  public addonEndAlwaysEnabled: boolean;
 
   /**
    * Controls whether the label should be floating or not.

--- a/src/lib/field/field.ts
+++ b/src/lib/field/field.ts
@@ -65,6 +65,9 @@ export abstract class FieldComponent<T extends FieldFoundation> extends BaseComp
       case FIELD_CONSTANTS.attributes.REQUIRED:
         this.required = coerceBoolean(newValue);
         break;
+      case FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED:
+        this.addonEndAlwaysEnabled = coerceBoolean(newValue);
+        break;
     }
   }
 

--- a/src/lib/select/select/select-foundation.ts
+++ b/src/lib/select/select/select-foundation.ts
@@ -13,6 +13,7 @@ export interface ISelectFoundation extends IBaseSelectFoundation {
   required: boolean;
   floatLabelType: FieldFloatLabelType;
   placeholder: string;
+  addonEndAlwaysEnabled: boolean;
 }
 
 /**
@@ -28,6 +29,7 @@ export class SelectFoundation extends BaseSelectFoundation<ISelectAdapter> imple
   private _floatLabelType: FieldFloatLabelType = 'auto';
   private _placeholder: string;
   private _density: FieldDensityType = 'default';
+  private _addonEndAlwaysEnabled = false;
   private _isInitialized = false;
   private _leadingChangeListener: (evt: Event) => void;
   private _addonEndChangeListener: (evt: Event) => void;
@@ -50,6 +52,7 @@ export class SelectFoundation extends BaseSelectFoundation<ISelectAdapter> imple
     this._adapter.setPlaceholderText(this._placeholder);
     this._applyDensity();
     this._setShapeType();
+    this._applyAddonEndAlwaysEnabled();
 
     this._detectLeadingElement();
     this._detectAddonEndContent();
@@ -270,6 +273,14 @@ export class SelectFoundation extends BaseSelectFoundation<ISelectAdapter> imple
     }
   }
 
+  private _applyAddonEndAlwaysEnabled(): void {
+    if (this._addonEndAlwaysEnabled) {
+      this._adapter.addRootClass(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED);
+    } else {
+      this._adapter.removeRootClass(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED);
+    }
+  }
+
   private _applyDensity(): void {
     this._adapter.setRoomy(this._density === 'roomy');
     this._adapter.setDense(this._density === 'dense');
@@ -390,6 +401,20 @@ export class SelectFoundation extends BaseSelectFoundation<ISelectAdapter> imple
       this._placeholder = value;
       this._adapter.setPlaceholderText(this._placeholder);
       this._initializeLabel();
+    }
+  }
+
+  public get addonEndAlwaysEnabled(): boolean {
+    return this._addonEndAlwaysEnabled;
+  }
+
+  public set addonEndAlwaysEnabled(value: boolean) {
+    if (this._addonEndAlwaysEnabled !== value) {
+      this._addonEndAlwaysEnabled = value;
+      if (this._isInitialized) {
+        this._applyAddonEndAlwaysEnabled();
+      }
+      this._adapter.toggleHostAttribute(FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED, this._addonEndAlwaysEnabled);
     }
   }
 }

--- a/src/lib/select/select/select.ts
+++ b/src/lib/select/select/select.ts
@@ -28,6 +28,7 @@ export interface ISelectComponent extends IBaseSelectComponent {
   label: string;
   disabled: boolean;
   placeholder: string;
+  addonEndAlwaysEnabled: boolean;
 }
 
 declare global {
@@ -69,6 +70,7 @@ export class SelectComponent extends BaseSelectComponent<SelectFoundation> imple
       FIELD_CONSTANTS.attributes.SHAPE,
       FIELD_CONSTANTS.attributes.INVALID,
       FIELD_CONSTANTS.attributes.REQUIRED,
+      FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED,
       SELECT_CONSTANTS.attributes.LABEL,
       SELECT_CONSTANTS.attributes.MULTIPLE,
       SELECT_CONSTANTS.attributes.VALUE,
@@ -106,6 +108,9 @@ export class SelectComponent extends BaseSelectComponent<SelectFoundation> imple
       case FIELD_CONSTANTS.attributes.REQUIRED:
         this.required = coerceBoolean(newValue);
         return;
+      case FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED:
+        this.addonEndAlwaysEnabled = coerceBoolean(newValue);
+        break;
       case SELECT_CONSTANTS.attributes.LABEL:
         this.label = newValue;
         return;
@@ -150,4 +155,8 @@ export class SelectComponent extends BaseSelectComponent<SelectFoundation> imple
   /** Gets/sets the placeholder text. */
   @FoundationProperty()
   public placeholder: string;
+
+  /** Gets/sets addonEndAlawysEnabled which controls whether the addon end slot should remain enabled when the control is otherwise disabled.. */
+  @FoundationProperty()
+  public addonEndAlwaysEnabled: boolean;
 }

--- a/src/stories/src/components/chip-field/chip-field-args.ts
+++ b/src/stories/src/components/chip-field/chip-field-args.ts
@@ -14,6 +14,7 @@ export interface IChipFieldProps {
   hasLeading: boolean;
   hasTrailing: boolean;
   hasAddonEnd: boolean;
+  addonEndAlwaysEnabled: boolean;
 }
 
 export const argTypes = {
@@ -89,6 +90,13 @@ export const argTypes = {
     },
   },
   hasPlaceholder: {
+    control: 'boolean',
+    description: '',
+    table: {
+      category: 'Properties',
+    },
+  },
+  addonEndAlwaysEnabled: {
     control: 'boolean',
     description: '',
     table: {

--- a/src/stories/src/components/chip-field/chip-field.mdx
+++ b/src/stories/src/components/chip-field/chip-field.mdx
@@ -74,6 +74,12 @@ Valid values: `auto` (default), `always`.
 
 </PropertyDef>
 
+<PropertyDef name="addonEndAlwaysEnabled" type="boolean" defaultValue="false">
+
+  Prevents the addon end slot content from receiving disabled styles when the rest of the control is otherwise disabled.
+
+</PropertyDef>
+
 </PageSection>
 
 ---

--- a/src/stories/src/components/chip-field/chip-field.stories.tsx
+++ b/src/stories/src/components/chip-field/chip-field.stories.tsx
@@ -1,16 +1,17 @@
 import { Meta, Story } from '@storybook/react';
-import { argTypes, IChipFieldProps } from './chip-field-args';
-import React, { useEffect, useRef, useState, MutableRefObject } from 'react';
-import { ForgeChipField, ForgeIcon, ForgeIconButton, ForgeAutocomplete, ForgeChip } from '@tylertech/forge-react';
+import { AutocompleteFilterCallback, IAutocompleteSelectEventData, IChipComponent, IChipFieldComponent, IconRegistry, IOption } from '@tylertech/forge';
+import { ForgeAutocomplete, ForgeChip, ForgeChipField, ForgeIcon, ForgeIconButton } from '@tylertech/forge-react';
 import { tylIconEvent, tylIconMoreVert, tylIconSend } from '@tylertech/tyler-icons/standard';
-import { IconRegistry, AutocompleteFilterCallback, IAutocompleteSelectEventData, IChipComponent, IOption, IChipFieldComponent } from '@tylertech/forge';
+import React, { MutableRefObject, useEffect, useRef, useState } from 'react';
+
+import { argTypes, IChipFieldProps } from './chip-field-args';
 
 const MDX = require('./chip-field.mdx').default;
 
 export default {
   title: 'Components/Chip Field',
-  parameters: { 
-    docs: { 
+  parameters: {
+    docs: {
       page: MDX
     },
   },
@@ -30,6 +31,7 @@ export const Default: Story<IChipFieldProps> = ({
   hasTrailing = false,
   hasHelperText = false,
   hasAddonEnd = false,
+  addonEndAlwaysEnabled = false,
 }) => {
   const chipFieldRef = useRef<IChipFieldComponent>();
   const addMember = (evt: CustomEvent) => {
@@ -69,7 +71,8 @@ export const Default: Story<IChipFieldProps> = ({
       shape={shape}
       invalid={invalid}
       required={required}
-      style={{width: '559px'}}>
+      style={{width: '559px'}}
+      addonEndAlwaysEnabled={addonEndAlwaysEnabled}>
 
       {hasLeading && <ForgeIcon slot="leading" name="event" />}
       {hasLabel && <label htmlFor="input-text" slot="label">{label}</label>}
@@ -109,6 +112,7 @@ Default.args = {
   hasTrailing: false,
   hasHelperText: false,
   hasAddonEnd: false,
+  addonEndAlwaysEnabled: false,
 } as IChipFieldProps;
 
 export const WithAutocomplete: Story<{}> = () => {

--- a/src/stories/src/components/select/select-args.ts
+++ b/src/stories/src/components/select/select-args.ts
@@ -14,6 +14,7 @@ export interface ISelectProps {
   hasLeadingIcon: boolean;
   hasHelperText: boolean;
   hasAddonEnd: boolean;
+  addonEndAlwaysEnabled: boolean;
 }
 
 export const argTypes = {
@@ -97,6 +98,13 @@ export const argTypes = {
       },
     },
     options: ['default', 'rounded'],
+    description: '',
+    table: {
+      category: 'Properties',
+    },
+  },
+  addonEndAlwaysEnabled: {
+    control: 'boolean',
     description: '',
     table: {
       category: 'Properties',

--- a/src/stories/src/components/select/select.mdx
+++ b/src/stories/src/components/select/select.mdx
@@ -188,6 +188,12 @@ Gets/sets whether the inset label style is used or not.
 
 </PropertyDef>
 
+<PropertyDef name="addonEndAlwaysEnabled" type="boolean" defaultValue="false">
+
+Prevents the addon end slot content from receiving disabled styles when the rest of the control is otherwise disabled.
+
+</PropertyDef>
+
 </PageSection>
 
 ---

--- a/src/stories/src/components/select/select.stories.tsx
+++ b/src/stories/src/components/select/select.stories.tsx
@@ -28,6 +28,7 @@ export const Default: Story<ISelectProps> = ({
   floatLabelType = 'default',
   shape = 'default',
   placeholder = '',
+  addonEndAlwaysEnabled = false,
   hasLeadingIcon = false,
   hasHelperText = false,
   hasAddonEnd = false
@@ -48,6 +49,7 @@ export const Default: Story<ISelectProps> = ({
       floatLabelType={floatLabelType}
       shape={shape}
       placeholder={placeholder}
+      addonEndAlwaysEnabled={addonEndAlwaysEnabled}
       style={{ width: '259px' }}>
       {hasLeadingIcon && <ForgeIcon slot="leading" name="fastfood" />}
       <ForgeOption value="grains">Bread, Cereal, Rice, and Pasta</ForgeOption>
@@ -74,6 +76,7 @@ Default.args = {
   open: false,
   label: 'Food group',
   placeholder: '',
+  addonEndAlwaysEnabled: false,
   hasLeadingIcon: false,
   hasHelperText: false,
   hasAddonEnd: false,

--- a/src/stories/src/components/text-field/text-field-args.ts
+++ b/src/stories/src/components/text-field/text-field-args.ts
@@ -14,6 +14,7 @@ export interface ITextFieldProps {
   hasLeading: boolean;
   hasTrailing: boolean;
   hasAddonEnd: boolean;
+  addonEndAlwaysEnabled: boolean;
 }
 
 export interface ITextFieldTextareaProps {
@@ -92,6 +93,13 @@ export const textFieldArgTypes = {
     },
   },
   disabled: {
+    control: 'boolean',
+    description: '',
+    table: {
+      category: 'Properties',
+    },
+  },
+  addonEndAlwaysEnabled: {
     control: 'boolean',
     description: '',
     table: {

--- a/src/stories/src/components/text-field/text-field.mdx
+++ b/src/stories/src/components/text-field/text-field.mdx
@@ -84,6 +84,12 @@ The `default` variant is intended to be used in desktop applications.
 
 </PropertyDef>
 
+<PropertyDef name="addonEndAlwaysEnabled" type="boolean" defaultValue="false">
+
+  Prevents the addon end slot content from receiving disabled styles when the rest of the control is otherwise disabled.
+
+</PropertyDef>
+
 </PageSection>
 
 <PageSection>

--- a/src/stories/src/components/text-field/text-field.stories.tsx
+++ b/src/stories/src/components/text-field/text-field.stories.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect } from 'react';
 import { Meta, Story } from '@storybook/react';
-import { textFieldArgTypes, textFieldTextareaArgTypes, ITextFieldProps, ITextFieldTextareaProps } from './text-field-args';
-import { ForgeIcon, ForgeIconButton, ForgeTextField } from '@tylertech/forge-react';
 import { IconRegistry } from '@tylertech/forge';
+import { ForgeIcon, ForgeIconButton, ForgeTextField } from '@tylertech/forge-react';
 import { tylIconEvent, tylIconMoreVert, tylIconSend } from '@tylertech/tyler-icons/standard';
+import React, { useEffect } from 'react';
+
+import { ITextFieldProps, ITextFieldTextareaProps, textFieldArgTypes, textFieldTextareaArgTypes } from './text-field-args';
 
 const MDX = require('./text-field.mdx').default;
 
@@ -28,6 +29,7 @@ export const Default: Story<ITextFieldProps> = ({
   hasTrailing = false,
   hasHelperText = false,
   hasAddonEnd = false,
+  addonEndAlwaysEnabled = false,
 }) => {
   useEffect(() => {
     IconRegistry.define([tylIconEvent, tylIconMoreVert, tylIconSend]);
@@ -40,7 +42,9 @@ export const Default: Story<ITextFieldProps> = ({
       shape={shape}
       invalid={invalid}
       required={required}
-      style={{width:  '259px'}}>
+      style={{width:  '259px'}}
+      addonEndAlwaysEnabled={addonEndAlwaysEnabled}>
+
       {hasLeading && <ForgeIcon slot="leading" name="event" />}
 
       <input autoComplete="off" type="text" id="input-text" disabled={disabled} placeholder={hasPlaceholder ? 'Enter first name...' : undefined} />
@@ -79,6 +83,7 @@ Default.args = {
   hasTrailing: false,
   hasHelperText: false,
   hasAddonEnd: false,
+  addonEndAlwaysEnabled: false,
 } as ITextFieldProps;
 
 export const Textarea: Story<ITextFieldTextareaProps> = ({

--- a/src/test/spec/chip-field/chip-field.spec.ts
+++ b/src/test/spec/chip-field/chip-field.spec.ts
@@ -986,8 +986,48 @@ describe('ChipFieldComponent', function(this: ITestContext) {
       });
     });
 
-    describe('Disable chip field', function(this: ITestContext) {
-      it('should set the disabled class on root when the native input disabled property is set to true', async function(this: ITestContext) {
+    describe('API (attributes) - addon-end-always-enabled', function (this: ITestContext) {
+      it('should set addonEndAlwaysEnabled via attribute', async function (this: ITestContext) {
+        this.context = setupTestContext();
+
+        this.context.component.setAttribute(FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED, 'true');
+        await tick();
+
+        expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED)).toBe(true);
+      });
+
+      it('should toggle correct class for addonEndAlwaysEnabled via attribute', async function (this: ITestContext) {
+        this.context = setupTestContext();
+        this.context.component.setAttribute(FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED, 'true');
+        await tick();
+        this.context.component.setAttribute(FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED, 'false');
+        await tick();
+        expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED)).toBe(false);
+      });
+    });
+
+    describe('API (Properties) - addonEndAlwaysEnabled', function (this: ITestContext) {
+      it('should set addonEndAlwaysEnabled via property', async function (this: ITestContext) {
+        this.context = setupTestContext();
+
+        this.context.component.addonEndAlwaysEnabled = true;
+        await tick();
+
+        expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED)).toBe(true);
+      });
+
+      it('should toggle correct class for addonEndAlwaysEnabled via property', async function (this: ITestContext) {
+        this.context = setupTestContext();
+        this.context.component.addonEndAlwaysEnabled = true;
+        await tick();
+        this.context.component.addonEndAlwaysEnabled = false;
+        await tick();
+        expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED)).toBe(false);
+      });
+    });
+
+    describe('Disable chip field', function (this: ITestContext) {
+      it('should set the disabled class on root when the native input disabled property is set to true', async function (this: ITestContext) {
         this.context = setupTestContext();
         getNativeInput(this.context.component).disabled = true;
 

--- a/src/test/spec/select/select.spec.ts
+++ b/src/test/spec/select/select.spec.ts
@@ -1429,6 +1429,44 @@ describe('SelectComponent', function(this: ITestContext) {
     });
   });
 
+  describe('API - addon-end-always-enabled', function (this: ITestContext) {
+    it('should set addonEndAlwaysEnabled via property', async function (this: ITestContext) {
+      this.context = setupTestContext(true);
+
+      this.context.component.addonEndAlwaysEnabled = true;
+      await tick();
+
+      expect(this.context.rootElement.classList.contains(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED)).toBe(true);
+    });
+
+    it('should set addonEndAlwaysEnabled via attribute', async function (this: ITestContext) {
+      this.context = setupTestContext(true);
+
+      this.context.component.setAttribute(FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED, 'true');
+      await tick();
+
+      expect(this.context.rootElement.classList.contains(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED)).toBe(true);
+    });
+
+    it('should toggle correct class for addonEndAlwaysEnabled via property', async function (this: ITestContext) {
+      this.context = setupTestContext(true);
+      this.context.component.addonEndAlwaysEnabled = true;
+      await tick();
+      this.context.component.addonEndAlwaysEnabled = false;
+      await tick();
+      expect(this.context.rootElement.classList.contains(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED)).toBe(false);
+    });
+
+    it('should toggle correct class for addonEndAlwaysEnabled via attribute', async function (this: ITestContext) {
+      this.context = setupTestContext(true);
+      this.context.component.setAttribute(FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED, 'true');
+      await tick();
+      this.context.component.setAttribute(FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED, 'false');
+      await tick();
+      expect(this.context.rootElement.classList.contains(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED)).toBe(false);
+    });
+  })
+
   function _createFixture(): HTMLElement {
     const fixture = document.createElement('div');
     fixture.id = 'select-test-fixture';

--- a/src/test/spec/text-field/text-field.spec.ts
+++ b/src/test/spec/text-field/text-field.spec.ts
@@ -1,23 +1,16 @@
-import {
-  defineTextFieldComponent,
-  ITextFieldComponent,
-  TEXT_FIELD_CONSTANTS,
-  TextFieldComponentDelegate,
-  TextFieldComponentDelegateProps,
-  ITextFieldFoundation,
-  ITextFieldComponentDelegateOptions
-} from '@tylertech/forge/text-field';
-import { removeElement, getShadowElement } from '@tylertech/forge-core';
+import { getShadowElement, removeElement } from '@tylertech/forge-core';
 import { tick, timer } from '@tylertech/forge-testing';
-import { FLOATING_LABEL_CONSTANTS } from '@tylertech/forge/floating-label';
-import { expectFloatingLabelState, floatTick, testFloatingLabelState } from '../../utils/floating-label-utils';
 import { FIELD_CONSTANTS } from '@tylertech/forge/field/field-constants';
+import { FLOATING_LABEL_CONSTANTS } from '@tylertech/forge/floating-label';
+import { defineTextFieldComponent, ITextFieldComponent, ITextFieldComponentDelegateOptions, ITextFieldFoundation, TEXT_FIELD_CONSTANTS, TextFieldComponentDelegate, TextFieldComponentDelegateProps } from '@tylertech/forge/text-field';
+
+import { expectFloatingLabelState, floatTick, testFloatingLabelState } from '../../utils/floating-label-utils';
 
 interface ITestContext {
   context: ITextFieldTestContext;
 }
 
-interface ITextFieldTestContext { 
+interface ITextFieldTestContext {
   delegate: TextFieldComponentDelegate;
   component: ITextFieldComponent;
   root: HTMLElement;
@@ -29,17 +22,17 @@ interface ITextFieldTestContext {
   destroy(): void;
 }
 
-describe('TextFieldComponent', function(this: ITestContext) {  
-  beforeAll(function(this: ITestContext) {
+describe('TextFieldComponent', function (this: ITestContext) {
+  beforeAll(function (this: ITestContext) {
     defineTextFieldComponent();
   });
 
-  describe('Imperative creation', function(this: ITestContext) {
-    afterEach(function(this: ITestContext) {
+  describe('Imperative creation', function (this: ITestContext) {
+    afterEach(function (this: ITestContext) {
       this.context.destroy();
     });
 
-    it('should allow for interaction before initialization', function(this: ITestContext) {
+    it('should allow for interaction before initialization', function (this: ITestContext) {
       this.context = setupTestContext(false);
       const catchSpy = jasmine.createSpy('caught exception');
 
@@ -53,16 +46,16 @@ describe('TextFieldComponent', function(this: ITestContext) {
       } catch {
         catchSpy();
       }
-      
+
       expect(catchSpy).not.toHaveBeenCalled();
     });
 
-    it('should not initialize until input element is added', async function(this: ITestContext) {
+    it('should not initialize until input element is added', async function (this: ITestContext) {
       this.context = setupTestContext(false);
       // Remove the input and label elements from the text-field before adding to DOM
       this.context.component.removeChild(this.context.label);
       this.context.component.removeChild(this.context.input);
-      
+
       document.body.appendChild(this.context.component);
       await tick();
 
@@ -78,7 +71,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.foundation['_isInitialized']).toBe(true);
     });
 
-    it('should float label if value is set before adding to DOM', async function(this: ITestContext) {
+    it('should float label if value is set before adding to DOM', async function (this: ITestContext) {
       this.context = setupTestContext(false);
       this.context.input.value = 'text';
       document.body.appendChild(this.context.component);
@@ -86,7 +79,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expectFloatingLabelState(this.context, true);
     });
 
-    it('should float label if float label type is set to "always"', async function(this: ITestContext) {
+    it('should float label if float label type is set to "always"', async function (this: ITestContext) {
       this.context = setupTestContext(false);
       this.context.component.floatLabelType = 'always';
       document.body.appendChild(this.context.component);
@@ -95,7 +88,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expectFloatingLabelState(this.context, true);
     });
 
-    it('should float label if float label type is changed to "always" after initial render', async function(this: ITestContext) {
+    it('should float label if float label type is changed to "always" after initial render', async function (this: ITestContext) {
       this.context = setupTestContext(false);
       document.body.appendChild(this.context.component);
       await tick();
@@ -104,7 +97,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expectFloatingLabelState(this.context, true);
     });
 
-    it('should float label always if placeholder is set', async function(this: ITestContext) {
+    it('should float label always if placeholder is set', async function (this: ITestContext) {
       this.context = setupTestContext(false);
       this.context.input.placeholder = 'placeholder text';
       document.body.appendChild(this.context.component);
@@ -113,7 +106,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expectFloatingLabelState(this.context, true);
     });
 
-    it('should be disabled if set by default', async function(this: ITestContext) {
+    it('should be disabled if set by default', async function (this: ITestContext) {
       this.context = setupTestContext(false);
 
       this.context.input.disabled = true;
@@ -124,7 +117,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.DISABLED)).toBe(true);
     });
 
-    it('should be readonly if set by default', async function(this: ITestContext) {
+    it('should be readonly if set by default', async function (this: ITestContext) {
       this.context = setupTestContext(false);
 
       this.context.input.readOnly = true;
@@ -135,7 +128,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.READONLY)).toBe(true);
     });
 
-    it('should initialize with textarea', async function(this: ITestContext) {
+    it('should initialize with textarea', async function (this: ITestContext) {
       this.context = setupTestContext(false);
 
       removeElement(this.context.input);
@@ -147,7 +140,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(TEXT_FIELD_CONSTANTS.classes.TEXTAREA)).toBe(true);
     });
 
-    it('should detect addon-end content when connecting', async function(this: ITestContext) {
+    it('should detect addon-end content when connecting', async function (this: ITestContext) {
       this.context = setupTestContext(false);
 
       const element = document.createElement('div');
@@ -161,20 +154,20 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ADDON_END)).toBeTrue();
     });
   });
-  
-  describe('Basic functionality', function(this: ITestContext) {
-    afterEach(function(this: ITestContext) {
+
+  describe('Basic functionality', function (this: ITestContext) {
+    afterEach(function (this: ITestContext) {
       this.context.destroy();
     });
 
-    it('should not float label when no value is specified', async function(this: ITestContext) {
+    it('should not float label when no value is specified', async function (this: ITestContext) {
       this.context = setupTestContext();
       await tick();
 
       expectFloatingLabelState(this.context, false);
     });
 
-    it('should float label when value is set', async function(this: ITestContext) {
+    it('should float label when value is set', async function (this: ITestContext) {
       this.context = setupTestContext();
       await tick();
       this.context.input.value = 'test';
@@ -182,7 +175,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expectFloatingLabelState(this.context, true);
     });
 
-    it('should float label when invoked programmatically', async function(this: ITestContext) {
+    it('should float label when invoked programmatically', async function (this: ITestContext) {
       this.context = setupTestContext();
       await tick();
       this.context.component.floatLabel(true);
@@ -190,7 +183,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expectFloatingLabelState(this.context, true);
     });
 
-    it('should un-float label when invoked programmatically', async function(this: ITestContext) {
+    it('should un-float label when invoked programmatically', async function (this: ITestContext) {
       this.context = setupTestContext();
       await tick();
       this.context.component.floatLabel(true);
@@ -200,14 +193,14 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expectFloatingLabelState(this.context, false);
     });
 
-    it('should float label when value is set by default', async function(this: ITestContext) {
+    it('should float label when value is set by default', async function (this: ITestContext) {
       this.context = setupTestContext();
       this.context.input.value = 'test';
       await floatTick();
       expectFloatingLabelState(this.context, true);
     });
 
-    it('should float label when focused', async function(this: ITestContext) {
+    it('should float label when focused', async function (this: ITestContext) {
       this.context = setupTestContext();
       await tick();
       this.context.input.dispatchEvent(new Event('focus'));
@@ -215,7 +208,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expectFloatingLabelState(this.context, true);
     });
 
-    it('should set proper state when focused', async function(this: ITestContext) {
+    it('should set proper state when focused', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       await tick();
@@ -226,7 +219,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.input.classList.contains(FIELD_CONSTANTS.classes.INPUT_FOCUSED)).toBe(true);
     });
 
-    it('should not float label when blurred', async function(this: ITestContext) {
+    it('should not float label when blurred', async function (this: ITestContext) {
       this.context = setupTestContext();
       await tick();
       this.context.input.dispatchEvent(new Event('focus'));
@@ -237,7 +230,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expectFloatingLabelState(this.context, false);
     });
 
-    it('should set dense via property', function(this: ITestContext) {
+    it('should set dense via property', function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.component.density = 'dense';
@@ -245,7 +238,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.DENSE)).toBe(true);
     });
 
-    it('should set dense via attribute', function(this: ITestContext) {
+    it('should set dense via attribute', function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.component.setAttribute(FIELD_CONSTANTS.attributes.DENSITY, 'dense');
@@ -253,7 +246,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.DENSE)).toBe(true);
     });
 
-    it('should set roomy via property', function(this: ITestContext) {
+    it('should set roomy via property', function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.component.density = 'roomy';
@@ -261,7 +254,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ROOMY)).toBe(true);
     });
 
-    it('should set roomy via attribute', function(this: ITestContext) {
+    it('should set roomy via attribute', function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.component.setAttribute(FIELD_CONSTANTS.attributes.DENSITY, 'roomy');
@@ -269,7 +262,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ROOMY)).toBe(true);
     });
 
-    it('should be disabled when the input is', async function(this: ITestContext) {
+    it('should be disabled when the input is', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.input.disabled = true;
@@ -278,7 +271,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.DISABLED)).toBe(true);
     });
 
-    it('should not be disabled when the input is not', async function(this: ITestContext) {
+    it('should not be disabled when the input is not', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.input.disabled = false;
@@ -287,7 +280,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.DISABLED)).toBe(false);
     });
 
-    it('should be readonly when the input is', async function(this: ITestContext) {
+    it('should be readonly when the input is', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.input.readOnly = true;
@@ -296,7 +289,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.READONLY)).toBe(true);
     });
 
-    it('should not be readonly when the input is not', async function(this: ITestContext) {
+    it('should not be readonly when the input is not', async function (this: ITestContext) {
       this.context = setupTestContext();
       this.context.input.readOnly = false;
       await timer();
@@ -304,7 +297,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.READONLY)).toBe(false);
     });
 
-    it('should correctly remove disabled if removed from the DOM and re-added', async function(this: ITestContext) {
+    it('should correctly remove disabled if removed from the DOM and re-added', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.input.disabled = true;
@@ -316,7 +309,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.DISABLED)).toBe(false);
     });
 
-    it('should correctly remove readonly if removed from the DOM and re-added', async function(this: ITestContext) {
+    it('should correctly remove readonly if removed from the DOM and re-added', async function (this: ITestContext) {
       this.context = setupTestContext();
       this.context.input.readOnly = true;
       await timer();
@@ -327,7 +320,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.READONLY)).toBe(false);
     });
 
-    it('should set invalid', async function(this: ITestContext) {
+    it('should set invalid', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.component.invalid = true;
@@ -336,7 +329,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.INVALID)).toBe(true);
     });
 
-    it('should set invalid via attribute', async function(this: ITestContext) {
+    it('should set invalid via attribute', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.component.setAttribute(FIELD_CONSTANTS.attributes.INVALID, 'true');
@@ -346,7 +339,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.INVALID)).toBe(true);
     });
 
-    it('should set required', async function(this: ITestContext) {
+    it('should set required', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.component.required = true;
@@ -355,7 +348,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.REQUIRED)).toBe(true);
     });
 
-    it('should set required via attribute', async function(this: ITestContext) {
+    it('should set required via attribute', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.component.setAttribute(FIELD_CONSTANTS.attributes.REQUIRED, 'true');
@@ -365,7 +358,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.REQUIRED)).toBe(true);
     });
 
-    it('should toggle required attribute', async function(this: ITestContext) {
+    it('should toggle required attribute', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.component.required = true;
@@ -377,7 +370,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.component.hasAttribute(FIELD_CONSTANTS.attributes.REQUIRED)).toBe(false);
     });
 
-    it('should set shape to rounded', async function(this: ITestContext) {
+    it('should set shape to rounded', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.component.shape = 'rounded';
@@ -386,7 +379,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.SHAPE_ROUNDED)).toBe(true);
     });
 
-    it('should set rounded shape via attribute', async function(this: ITestContext) {
+    it('should set rounded shape via attribute', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.component.setAttribute(FIELD_CONSTANTS.attributes.SHAPE, 'rounded');
@@ -396,7 +389,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.SHAPE_ROUNDED)).toBe(true);
     });
 
-    it('should set density to dense', async function(this: ITestContext) {
+    it('should set density to dense', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.component.density = 'dense';
@@ -405,7 +398,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.DENSE)).toBe(true);
     });
 
-    it('should set density to dense via attribute', async function(this: ITestContext) {
+    it('should set density to dense via attribute', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.component.setAttribute(FIELD_CONSTANTS.attributes.DENSITY, 'dense');
@@ -415,7 +408,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.DENSE)).toBe(true);
     });
 
-    it('should set density to roomy', async function(this: ITestContext) {
+    it('should set density to roomy', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.component.density = 'roomy';
@@ -424,7 +417,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ROOMY)).toBe(true);
     });
 
-    it('should set density to roomy via attribute', async function(this: ITestContext) {
+    it('should set density to roomy via attribute', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.component.setAttribute(FIELD_CONSTANTS.attributes.DENSITY, 'roomy');
@@ -434,7 +427,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ROOMY)).toBe(true);
     });
 
-    it('should un-float label if value is removed when input is not focused', async function(this: ITestContext) {
+    it('should un-float label if value is removed when input is not focused', async function (this: ITestContext) {
       this.context = setupTestContext();
       this.context.input.value = 'test';
       await tick();
@@ -445,7 +438,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expectFloatingLabelState(this.context, false);
     });
 
-    it('should set floating label state when input attribute value changes', async function(this: ITestContext) {
+    it('should set floating label state when input attribute value changes', async function (this: ITestContext) {
       this.context = setupTestContext();
       this.context.input.setAttribute('value', 'test');
       await tick();
@@ -456,7 +449,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expectFloatingLabelState(this.context, false);
     });
 
-    it('should float label if label text is empty', async function(this: ITestContext) {
+    it('should float label if label text is empty', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       this.context.label.textContent = '';
@@ -466,14 +459,14 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.label.classList.contains(FLOATING_LABEL_CONSTANTS.classes.FLOAT_ABOVE)).toBe(true);
     });
 
-    it('should not show addon-end content by default', async function(this: ITestContext) {
+    it('should not show addon-end content by default', async function (this: ITestContext) {
       this.context = setupTestContext();
       await tick();
 
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ADDON_END)).toBeFalse();
     });
 
-    it('should detect addon-end content', async function(this: ITestContext) {
+    it('should detect addon-end content', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       const element = document.createElement('div');
@@ -486,7 +479,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ADDON_END)).toBeTrue();
     });
 
-    it('should hide addon-on end content if element is removed', async function(this: ITestContext) {
+    it('should hide addon-on end content if element is removed', async function (this: ITestContext) {
       this.context = setupTestContext();
 
       const element = document.createElement('div');
@@ -503,9 +496,9 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ADDON_END)).toBeFalse();
     });
 
-    it('should set focus state when toggling input readonly attribute while focused', async function(this: ITestContext) {
+    it('should set focus state when toggling input readonly attribute while focused', async function (this: ITestContext) {
       this.context = setupTestContext(true);
-      
+
       this.context.input.focus();
       await tick();
 
@@ -518,56 +511,94 @@ describe('TextFieldComponent', function(this: ITestContext) {
     });
   });
 
-  describe('with leading icon', function(this: ITestContext) {
-    beforeEach(function(this: ITestContext) {
+  describe('API - addon-end-always-enabled', function (this: ITestContext) {
+    it('should set addonEndAlwaysEnabled via property', async function (this: ITestContext) {
+      this.context = setupTestContext();
+
+      this.context.component.addonEndAlwaysEnabled = true;
+      await tick();
+
+      expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED)).toBe(true);
+    });
+
+    it('should set addonEndAlwaysEnabled via attribute', async function (this: ITestContext) {
+      this.context = setupTestContext();
+
+      this.context.component.setAttribute(FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED, 'true');
+      await tick();
+
+      expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED)).toBe(true);
+    });
+
+    it('should toggle correct class for addonEndAlwaysEnabled via property', async function (this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.component.addonEndAlwaysEnabled = true;
+      await tick();
+      this.context.component.addonEndAlwaysEnabled = false;
+      await tick();
+      expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED)).toBe(false);
+    });
+
+    it('should toggle correct class for addonEndAlwaysEnabled via attribute', async function (this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.component.setAttribute(FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED, 'true');
+      await tick();
+      this.context.component.setAttribute(FIELD_CONSTANTS.attributes.ADDON_END_ALWAYS_ENABLED, 'false');
+      await tick();
+      expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.ADDON_END_ALWAYS_ENABLED)).toBe(false);
+    });
+  })
+
+  describe('with leading icon', function (this: ITestContext) {
+    beforeEach(function (this: ITestContext) {
       const leadingElement = document.createElement('i');
       const trailingElement = document.createElement('i');
 
       this.context = setupTestContext(true, {}, { leadingElement, trailingElement });
     });
 
-    afterEach(function(this: ITestContext) {
+    afterEach(function (this: ITestContext) {
       this.context.destroy();
     });
 
-    it('should render leading icon class', async function(this: ITestContext) {
+    it('should render leading icon class', async function (this: ITestContext) {
       await tick();
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.LEADING)).toBe(true);
     });
 
-    it('should render trailing icon class', async function(this: ITestContext) {
+    it('should render trailing icon class', async function (this: ITestContext) {
       await tick();
       expect(this.context.root.classList.contains(FIELD_CONSTANTS.classes.LEADING)).toBe(true);
     });
   });
 
-  describe('with multiple inputs', function(this: ITestContext) {
-    beforeEach(function(this: ITestContext) {
+  describe('with multiple inputs', function (this: ITestContext) {
+    beforeEach(function (this: ITestContext) {
       const inputElement = document.createElement('input');
       this.context = setupTestContext(false);
       this.context.component.appendChild(inputElement);
       document.body.appendChild(this.context.component);
     });
 
-    afterEach(function(this: ITestContext) {
+    afterEach(function (this: ITestContext) {
       this.context.destroy();
     });
 
-    it('should handle multiple inputs', function(this: ITestContext) {
+    it('should handle multiple inputs', function (this: ITestContext) {
       expect(this.context.root.classList.contains(TEXT_FIELD_CONSTANTS.classes.MULTI_INPUT)).toBeTruthy();
     });
   });
 
-  describe('TextFieldComponentDelegate', function(this: ITestContext) {
-    describe('without being in DOM', function(this: ITestContext) {
-      it('should create input without label with default configuration', function(this: ITestContext) {
+  describe('TextFieldComponentDelegate', function (this: ITestContext) {
+    describe('without being in DOM', function (this: ITestContext) {
+      it('should create input without label with default configuration', function (this: ITestContext) {
         const delegate = new TextFieldComponentDelegate();
 
         expect(delegate.element.querySelector('input')).not.toBeNull();
         expect(delegate.element.querySelector('label')).toBeNull();
       });
 
-      it('should have correct default configuration', function(this: ITestContext) {
+      it('should have correct default configuration', function (this: ITestContext) {
         const delegate = new TextFieldComponentDelegate();
 
         expect(delegate.element.required).toBe(false);
@@ -575,33 +606,33 @@ describe('TextFieldComponent', function(this: ITestContext) {
         expect(delegate.element.floatLabelType).toBe('auto');
         expect(delegate.inputElement.placeholder).toBe('');
       });
-  
-      it('should create label', function(this: ITestContext) {
-        const delegate = new TextFieldComponentDelegate({ options: { label: 'Label' }});
+
+      it('should create label', function (this: ITestContext) {
+        const delegate = new TextFieldComponentDelegate({ options: { label: 'Label' } });
         const label = delegate.element.querySelector('label') as HTMLLabelElement;
 
         expect(label).not.toBeNull();
         expect(label.innerText).toBe('Label');
       });
-  
-      it('should create helper text', function(this: ITestContext) {
-        const delegate = new TextFieldComponentDelegate({ options: { helperText: 'Helper text' }});
+
+      it('should create helper text', function (this: ITestContext) {
+        const delegate = new TextFieldComponentDelegate({ options: { helperText: 'Helper text' } });
         const span = delegate.element.querySelector('[slot="helper-text"]') as HTMLSpanElement;
 
         expect(span).not.toBeNull();
         expect(span.innerText).toBe('Helper text');
       });
-  
-      it('should change helper text content', function(this: ITestContext) {
-        const delegate = new TextFieldComponentDelegate({ options: { helperText: 'Helper text' }});
+
+      it('should change helper text content', function (this: ITestContext) {
+        const delegate = new TextFieldComponentDelegate({ options: { helperText: 'Helper text' } });
 
         delegate.setHelperText('New helper text');
 
         const span = delegate.element.querySelector('[slot="helper-text"]') as HTMLSpanElement;
         expect(span.innerText).toBe('New helper text');
       });
-  
-      it('should not add helper text if set to null', function(this: ITestContext) {
+
+      it('should not add helper text if set to null', function (this: ITestContext) {
         const delegate = new TextFieldComponentDelegate();
 
         delegate.setHelperText(null);
@@ -609,26 +640,26 @@ describe('TextFieldComponent', function(this: ITestContext) {
         const span = delegate.element.querySelector('[slot="helper-text"]') as HTMLSpanElement;
         expect(span).toBeNull();
       });
-  
-      it('should change label', function(this: ITestContext) {
-        const delegate = new TextFieldComponentDelegate({ options: { label: 'Initial label' }});
+
+      it('should change label', function (this: ITestContext) {
+        const delegate = new TextFieldComponentDelegate({ options: { label: 'Initial label' } });
 
         delegate.setLabel('New label');
 
         const label = delegate.element.querySelector('label') as HTMLLabelElement;
         expect(label.innerText).toBe('New label');
       });
-  
-      it('should remove label', function(this: ITestContext) {
-        const delegate = new TextFieldComponentDelegate({ options: { label: 'Initial label' }});
+
+      it('should remove label', function (this: ITestContext) {
+        const delegate = new TextFieldComponentDelegate({ options: { label: 'Initial label' } });
 
         delegate.setLabel(null);
 
         const label = delegate.element.querySelector('label') as HTMLLabelElement;
         expect(label).toBeNull();
       });
-  
-      it('should create label after initialization', function(this: ITestContext) {
+
+      it('should create label after initialization', function (this: ITestContext) {
         const delegate = new TextFieldComponentDelegate();
 
         delegate.setLabel('Label text');
@@ -638,19 +669,19 @@ describe('TextFieldComponent', function(this: ITestContext) {
         expect(label.innerText).toBe('Label text');
       });
 
-      it('should expose reference for input element', function(this: ITestContext) {
+      it('should expose reference for input element', function (this: ITestContext) {
         const delegate = new TextFieldComponentDelegate();
 
         expect(delegate.inputElement).not.toBeNull();
       });
 
-      it('should expose reference for label element', function(this: ITestContext) {
+      it('should expose reference for label element', function (this: ITestContext) {
         const delegate = new TextFieldComponentDelegate();
 
         expect(delegate.labelElement).not.toBeNull();
       });
 
-      it('should set disabled', function(this: ITestContext) {
+      it('should set disabled', function (this: ITestContext) {
         const delegate = new TextFieldComponentDelegate();
 
         delegate.disabled = true;
@@ -658,7 +689,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
         expect(delegate.inputElement.disabled).toBe(true);
       });
 
-      it('should set disabled', function(this: ITestContext) {
+      it('should set disabled', function (this: ITestContext) {
         const delegate = new TextFieldComponentDelegate();
 
         delegate.disabled = true;
@@ -667,15 +698,15 @@ describe('TextFieldComponent', function(this: ITestContext) {
         expect(delegate.inputElement.disabled).toBe(false);
       });
 
-      it('should set initial value', function(this: ITestContext) {
-        const delegate = new TextFieldComponentDelegate({ options: { value: 'val' }});
+      it('should set initial value', function (this: ITestContext) {
+        const delegate = new TextFieldComponentDelegate({ options: { value: 'val' } });
 
         expect(delegate.inputElement.value).toBe('val');
         expect(delegate.value).toBe('val');
       });
 
-      it('should change value', function(this: ITestContext) {
-        const delegate = new TextFieldComponentDelegate({ options: { value: 'val' }});
+      it('should change value', function (this: ITestContext) {
+        const delegate = new TextFieldComponentDelegate({ options: { value: 'val' } });
 
         delegate.value = 'new val';
 
@@ -683,51 +714,51 @@ describe('TextFieldComponent', function(this: ITestContext) {
         expect(delegate.value).toBe('new val');
       });
 
-      it('should initialize required', function(this: ITestContext) {
-        const delegate = new TextFieldComponentDelegate({ props: { required: true }});
+      it('should initialize required', function (this: ITestContext) {
+        const delegate = new TextFieldComponentDelegate({ props: { required: true } });
 
         expect(delegate.element.required).toBe(true);
       });
 
-      it('should initialize invalid', function(this: ITestContext) {
-        const delegate = new TextFieldComponentDelegate({ props: { invalid: true }});
+      it('should initialize invalid', function (this: ITestContext) {
+        const delegate = new TextFieldComponentDelegate({ props: { invalid: true } });
 
         expect(delegate.invalid).toBe(true);
       });
 
-      it('should initialize float label type', function(this: ITestContext) {
-        const delegate = new TextFieldComponentDelegate({ props: { floatLabelType: 'always' }});
+      it('should initialize float label type', function (this: ITestContext) {
+        const delegate = new TextFieldComponentDelegate({ props: { floatLabelType: 'always' } });
 
         expect(delegate.element.floatLabelType).toBe('always');
       });
 
-      it('should initialize placeholder', function(this: ITestContext) {
-        const delegate = new TextFieldComponentDelegate({ options: { placeholder: 'placeholder text' }});
+      it('should initialize placeholder', function (this: ITestContext) {
+        const delegate = new TextFieldComponentDelegate({ options: { placeholder: 'placeholder text' } });
 
         expect(delegate.inputElement.placeholder).toBe('placeholder text');
       });
 
-      it('should pass validation after input value set', function(this: ITestContext) {
-        const delegate = new TextFieldComponentDelegate({ options: { value: 'val' }});
+      it('should pass validation after input value set', function (this: ITestContext) {
+        const delegate = new TextFieldComponentDelegate({ options: { value: 'val' } });
 
         expect(delegate.invalid).toBeFalse();
       });
 
-      it('should set density', function(this: ITestContext) {
-        const delegate = new TextFieldComponentDelegate({ props: { density: 'dense' }});
+      it('should set density', function (this: ITestContext) {
+        const delegate = new TextFieldComponentDelegate({ props: { density: 'dense' } });
 
         expect(delegate.element.density).toBe('dense');
       });
     });
 
-    describe('in DOM', function(this: ITestContext) {
-      afterEach(function(this: ITestContext) {
+    describe('in DOM', function (this: ITestContext) {
+      afterEach(function (this: ITestContext) {
         this.context.destroy();
       });
 
-      it('should remove helper text element', async function(this: ITestContext) {
+      it('should remove helper text element', async function (this: ITestContext) {
         this.context = setupTestContext(true, {}, { helperText: 'Helper text' });
-        
+
         await tick();
         this.context.delegate.setHelperText(null);
         await tick();
@@ -736,7 +767,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
         expect(span).toBeNull();
       });
 
-      it('should float label', async function(this: ITestContext) {
+      it('should float label', async function (this: ITestContext) {
         this.context = setupTestContext(true, {}, { label: 'Test' });
         await tick();
         this.context.delegate.floatLabel(true);
@@ -744,7 +775,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
         testFloatingLabelState(this.context.delegate.labelElement as HTMLLabelElement, true);
       });
 
-      it('should un-float label', async function(this: ITestContext) {
+      it('should un-float label', async function (this: ITestContext) {
         this.context = setupTestContext(true, {}, { label: 'Test' });
         await tick();
         this.context.delegate.floatLabel(true);
@@ -754,7 +785,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
         testFloatingLabelState(this.context.delegate.labelElement as HTMLLabelElement, false);
       });
 
-      it('should notify when input value changes', async function(this: ITestContext) {
+      it('should notify when input value changes', async function (this: ITestContext) {
         this.context = setupTestContext(false);
 
         const listener = jasmine.createSpy('onChange listener');
@@ -768,7 +799,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
         expect(listener).toHaveBeenCalledWith('a');
       });
 
-      it('should notify when input receives focus', async function(this: ITestContext) {
+      it('should notify when input receives focus', async function (this: ITestContext) {
         this.context = setupTestContext(false);
 
         const listener = jasmine.createSpy('onFocus listener');
@@ -781,7 +812,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
         expect(listener).toHaveBeenCalled();
       });
 
-      it('should notify when input loses focus', async function(this: ITestContext) {
+      it('should notify when input loses focus', async function (this: ITestContext) {
         this.context = setupTestContext(false);
 
         const listener = jasmine.createSpy('onBlur listener');
@@ -790,7 +821,7 @@ describe('TextFieldComponent', function(this: ITestContext) {
         document.body.appendChild(this.context.component);
         await tick();
         this.context.delegate.inputElement.dispatchEvent(new Event('blur'));
-        
+
         expect(listener).toHaveBeenCalled();
       });
     });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: [Y]
- Docs have been added / updated: [Y]
- Does this PR introduce a breaking change? [N]
- I have linked any related GitHub issues to be closed when this PR is merged? [N/A]

## Describe the new behavior?
adds new attribute/property to base field component that will allow the addon-end slot content to remain enabled when the field is otherwise disabled.
