### PR TITLE
feat(badge): added leading and trailing slots with support for icons

### DIFF
--- a/src/lib/badge/_mixins.scss
+++ b/src/lib/badge/_mixins.scss
@@ -27,6 +27,8 @@
 }
 
 @mixin host() {
+  --forge-icon-font-size: 14px;
+
   display: flex;
   box-sizing: border-box;
 }
@@ -46,7 +48,9 @@
   @include theme.css-custom-property(max-width, --forge-badge-max-width, variables.$max-width);
   @include theme.css-custom-property(border, --forge-badge-border, none);
 
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   transition: transform 200ms ease-in-out;
   transform: scale(0);
   overflow: hidden;

--- a/src/lib/badge/badge.html
+++ b/src/lib/badge/badge.html
@@ -1,5 +1,7 @@
 <template>
   <div class="forge-badge forge-badge--open" part="root">
+    <slot name="leading"></slot>
     <slot></slot>
+    <slot name="trailing"></slot>
   </div>
 </template>

--- a/src/stories/src/components/badge/badge-arg-types.ts
+++ b/src/stories/src/components/badge/badge-arg-types.ts
@@ -5,6 +5,8 @@ export interface IBadgeProps {
   positioned: boolean;
   strong: boolean;
   text: string;
+  hasLeadingIcon: boolean;
+  hasTrailingIcon: boolean;
 }
 
 export const argTypes = {
@@ -57,6 +59,20 @@ export const argTypes = {
   text: { 
     control: 'text',
     description: 'Use a numeric badge for numeric counts. Use a text status badge to communicate status or description.',
+    table: {
+      category: 'Slots'
+    },
+  },
+  hasLeadingIcon: { 
+    control: 'boolean',
+    description: 'Use an icon to visually reinforce a badge\'s meaning.',
+    table: {
+      category: 'Slots'
+    },
+  },
+  hasTrailingIcon: { 
+    control: 'boolean',
+    description: 'Use an icon to visually reinforce a badge\'s meaning.',
     table: {
       category: 'Slots'
     },

--- a/src/stories/src/components/badge/badge.mdx
+++ b/src/stories/src/components/badge/badge.mdx
@@ -93,6 +93,8 @@ You can use the built-in themes via attribute. If you need a custom color, see t
 | Name                           | Description
 | :------------------------------| :----------------
 | `default`                      | The default (unnamed) slot will render any content that is placed within the badge component element directly.
+| `leading`                      | The leading slot for content to render before the default slot. This is typically an icon element.
+| `trailing`                     | The trailing slot for content to render after the default slot. This is typically an icon element.
 
 </PageSection>
 

--- a/src/stories/src/components/badge/badge.stories.tsx
+++ b/src/stories/src/components/badge/badge.stories.tsx
@@ -5,7 +5,7 @@ import { argTypes, IBadgeProps } from './badge-arg-types';
 import { Story } from '@storybook/react';
 import { ForgeBadge, ForgeIcon, ForgeIconButton } from '@tylertech/forge-react';
 import { IconRegistry } from '@tylertech/forge';
-import { tylIconNotifications } from '@tylertech/tyler-icons/standard';
+import { tylIconFace, tylIconNotifications, tylIconStar } from '@tylertech/tyler-icons/standard';
 
 const MDX = require('./badge.mdx').default;
 
@@ -25,17 +25,31 @@ export const Default: Story<IBadgeProps> = ({
   strong = false,
   dot = false,
   positioned = false,
-  theme = 'default'
-}) => (
-  <ForgeBadge dot={dot} open={open} positioned={positioned} strong={strong} theme={theme}>{text}</ForgeBadge>
-);
+  theme = 'default',
+  hasLeadingIcon = false,
+  hasTrailingIcon = false
+}) => {
+  useEffect(() => {
+    IconRegistry.define([tylIconFace, tylIconStar]);
+  }, []);
+
+  return (
+    <ForgeBadge dot={dot} open={open} positioned={positioned} strong={strong} theme={theme}>
+      {hasLeadingIcon && <ForgeIcon slot="leading" name="face" />}
+      <span>{text}</span>
+      {hasTrailingIcon && <ForgeIcon slot="trailing" name="star" />}
+    </ForgeBadge>
+  )
+};
 Default.args = {
   dot: false,
   open: true,
   theme: 'default',
   positioned: false,
   strong: false,
-  text: 'Default'
+  text: 'Default',
+  hasLeadingIcon: false,
+  hasTrailingIcon: false
 } as IBadgeProps;
 
 export const WithIconButton: Story<IBadgeProps> = ({
@@ -44,10 +58,12 @@ export const WithIconButton: Story<IBadgeProps> = ({
   strong = false,
   dot = false,
   positioned = false,
-  theme = 'default'
+  theme = 'default',
+  hasLeadingIcon = false,
+  hasTrailingIcon = false
 }) => {
   useEffect(() => {
-    IconRegistry.define(tylIconNotifications);
+    IconRegistry.define([tylIconFace, tylIconNotifications, tylIconStar]);
   }, []);
 
   const demoIconButtonStyles = {
@@ -59,7 +75,11 @@ export const WithIconButton: Story<IBadgeProps> = ({
       <button type="button">
         <ForgeIcon name="notifications" />
       </button>
-      <ForgeBadge  dot={dot} open={open} positioned={positioned} strong={strong} theme={theme}>{text}</ForgeBadge>
+      <ForgeBadge  dot={dot} open={open} positioned={positioned} strong={strong} theme={theme}>
+        {hasLeadingIcon && <ForgeIcon slot="leading" name="face" />}
+        <span>{text}</span>
+        {hasTrailingIcon && <ForgeIcon slot="trailing" name="star" />}
+      </ForgeBadge>
     </ForgeIconButton>
   )
 };
@@ -69,25 +89,7 @@ WithIconButton.args = {
   theme: 'default',
   positioned: true,
   strong: false,
-  text: '3'
+  text: '3',
+  hasLeadingIcon: false,
+  hasTrailingIcon: false
 } as IBadgeProps;
-
-export const withIcon: Story<IBadgeProps> = ({
-  text = 'Default',
-  open = true,
-  strong = false,
-  dot = false,
-  positioned = false,
-  theme = 'default'
-}) => {
-  useEffect(() => {
-    IconRegistry.define(tylIconNotifications)
-  }, []);
-
-  return (
-    <ForgeBadge dot={dot} open={open} positioned={positioned} strong={strong} theme={theme}>
-      <ForgeIcon slot="leading" name="notifications" />
-      {text}
-    </ForgeBadge>
-  )
-}

--- a/src/stories/src/components/badge/badge.stories.tsx
+++ b/src/stories/src/components/badge/badge.stories.tsx
@@ -71,3 +71,23 @@ WithIconButton.args = {
   strong: false,
   text: '3'
 } as IBadgeProps;
+
+export const withIcon: Story<IBadgeProps> = ({
+  text = 'Default',
+  open = true,
+  strong = false,
+  dot = false,
+  positioned = false,
+  theme = 'default'
+}) => {
+  useEffect(() => {
+    IconRegistry.define(tylIconNotifications)
+  }, []);
+
+  return (
+    <ForgeBadge dot={dot} open={open} positioned={positioned} strong={strong} theme={theme}>
+      <ForgeIcon slot="leading" name="notifications" />
+      {text}
+    </ForgeBadge>
+  )
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Closes #183 

Added leading and trailing slots to the root element of the badge. The root element has also been made into a flex container with `align-items` set to `center` and `--forge-icon-font-size` has been set to `14px` on the host element, allowing content including icons to lay out predictably by default.
