### PR TITLE
docs(button-toggle): corrects spelling error

### DIFF
--- a/src/stories/src/components/button-toggle/button-toggle.mdx
+++ b/src/stories/src/components/button-toggle/button-toggle.mdx
@@ -140,7 +140,7 @@ Gets/sets the dense state.
 
 | Name                               | Description
 | :----------------------------------| :----------------
-| `forge-button-toggle-group-change`   | Emits when the selected state of the gruop is changed.
+| `forge-button-toggle-group-change`   | Emits when the selected state of the group is changed.
 
 </PageSection>
 


### PR DESCRIPTION
Updates simple spelling error in the docs. 
