### PR TITLE
fix(button-toggle-group): fixed `forge-button-toggle-group-change` typings

### DIFF
--- a/src/lib/button-toggle/button-toggle-group/button-toggle-group-constants.ts
+++ b/src/lib/button-toggle/button-toggle-group/button-toggle-group-constants.ts
@@ -33,7 +33,7 @@ export const BUTTON_TOGGLE_GROUP_CONSTANTS = {
   events
 };
 
-export type IButtonToggleGroupChangeEventData<T> = T;
+export type IButtonToggleGroupChangeEventData<T = any> = T;
 
 export interface IButtonToggleOption {
   label?: string;

--- a/src/lib/button-toggle/button-toggle-group/button-toggle-group.ts
+++ b/src/lib/button-toggle/button-toggle-group/button-toggle-group.ts
@@ -2,7 +2,7 @@ import { attachShadowTemplate, coerceBoolean, CustomElement, FoundationProperty 
 import { BaseComponent, IBaseComponent } from '../../core/base/base-component';
 import { ButtonToggleComponent } from '../button-toggle/button-toggle';
 import { ButtonToggleGroupAdapter } from './button-toggle-group-adapter';
-import { BUTTON_TOGGLE_GROUP_CONSTANTS, IButtonToggleOption } from './button-toggle-group-constants';
+import { BUTTON_TOGGLE_GROUP_CONSTANTS, IButtonToggleGroupChangeEventData, IButtonToggleOption } from './button-toggle-group-constants';
 import { ButtonToggleGroupFoundation } from './button-toggle-group-foundation';
 
 import template from './button-toggle-group.html';
@@ -22,6 +22,10 @@ export interface IButtonToggleGroupComponent extends IBaseComponent {
 declare global {
   interface HTMLElementTagNameMap {
     'forge-button-toggle-group': IButtonToggleGroupComponent;
+  }
+
+  interface HTMLElementEventMap {
+    'forge-button-toggle-group-change': CustomEvent<IButtonToggleGroupChangeEventData>;
   }
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Added `forge-button-toggle-group-change` to the global `HTMLElementEventMap` type, and ensured that the default generic provides an `any` type.

## Additional information
This was found when attempting to implement within an Angular app and noticed the typings were missing.
