### PR TITLE
update select and autocomplete dropdown position when options are selected

### DIFF
--- a/src/lib/autocomplete/autocomplete-adapter.ts
+++ b/src/lib/autocomplete/autocomplete-adapter.ts
@@ -43,6 +43,7 @@ export interface IAutocompleteAdapter extends IBaseAdapter {
   getActiveOptionIndex(): number | null;
   clearActiveOption(): void;
   setSelectedOptions(options: IOption[]): void;
+  queueDropdownPositionUpdate(): void;
 }
 
 /**
@@ -257,6 +258,17 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
       const values = options.map(o => o.value);
       this._listDropdown.setSelectedValues(values);
     }
+  }
+
+  public queueDropdownPositionUpdate(): void {
+    if (!this.getPopupElement()) {
+      return;
+    }
+    // We need to wait for the next animation frame to ensure that the layout has been updated
+    window.requestAnimationFrame(() => {
+      const dropdownEl = this.getPopupElement() as IPopupComponent | undefined;
+      dropdownEl?.position();
+    });
   }
 
   private _getTargetElement(selector?: string): HTMLElement {

--- a/src/lib/autocomplete/autocomplete-foundation.ts
+++ b/src/lib/autocomplete/autocomplete-foundation.ts
@@ -573,7 +573,7 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
         this._adapter.toggleOptionMultiple(index, isSelected);
       }
 
-      this._emitChangeEvent();
+      this._tryUpdateDropdownPosition();
     };
 
     // We close the dropdown immediately if in single selection mode
@@ -586,6 +586,8 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
       const shouldContinue = await this._valueChanging;
       if (shouldContinue) {
         select();
+      } else {
+        this._tryUpdateDropdownPosition();
       }
       this._valueChanging = undefined;
     } else {
@@ -605,6 +607,12 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
 
   private _emitChangeEvent(): void {
     this._adapter.emitHostEvent(AUTOCOMPLETE_CONSTANTS.events.CHANGE, this._getValue(), true);
+  }
+
+  private _tryUpdateDropdownPosition(): void {
+    if (this._isDropdownOpen) {
+      this._adapter.queueDropdownPositionUpdate();
+    }
   }
 
   /**

--- a/src/lib/autocomplete/autocomplete-foundation.ts
+++ b/src/lib/autocomplete/autocomplete-foundation.ts
@@ -573,8 +573,8 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
         this._adapter.toggleOptionMultiple(index, isSelected);
       }
 
-      this._tryUpdateDropdownPosition();
       this._emitChangeEvent();
+      this._tryUpdateDropdownPosition();
     };
 
     // We close the dropdown immediately if in single selection mode

--- a/src/lib/autocomplete/autocomplete-foundation.ts
+++ b/src/lib/autocomplete/autocomplete-foundation.ts
@@ -574,6 +574,7 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
       }
 
       this._tryUpdateDropdownPosition();
+      this._emitChangeEvent();
     };
 
     // We close the dropdown immediately if in single selection mode

--- a/src/lib/select/core/base-select-adapter.ts
+++ b/src/lib/select/core/base-select-adapter.ts
@@ -33,6 +33,7 @@ export interface IBaseSelectAdapter extends IBaseAdapter {
   appendDropdownOptions(options: ISelectOption[] | ISelectOptionGroup[]): void;
   setMultiple(multiple: boolean): void;
   isFocusWithinPopup(target: HTMLElement): boolean;
+  queueDropdownPositionUpdate(): void;
   popupElement: HTMLElement | undefined;
 }
 
@@ -188,6 +189,17 @@ export abstract class BaseSelectAdapter extends BaseAdapter<IBaseSelectComponent
     return this._listDropdown.dropdownElement.contains(target);
   }
 
+  public queueDropdownPositionUpdate(): void {
+    if (!this.popupElement) {
+      return;
+    }
+    // We need to wait for the next animation frame to ensure that the layout has been updated
+    window.requestAnimationFrame(() => {
+      const dropdownEl = this.popupElement as IPopupComponent | undefined;
+      dropdownEl?.position();
+    });
+  }
+
   private _clearOptions(): void {
     // First we remove all option group elements
     const existingOptionGroupElements = Array.from(this._component.querySelectorAll(OPTION_GROUP_CONSTANTS.elementName));
@@ -197,7 +209,6 @@ export abstract class BaseSelectAdapter extends BaseAdapter<IBaseSelectComponent
     const existingOptionElements = Array.from(this._component.querySelectorAll(OPTION_CONSTANTS.elementName));
     existingOptionElements.forEach((o: HTMLElement) => removeElement(o));
   }
-
 
   private _createOptionGroupElement(group: ISelectOptionGroup): HTMLElement {
     const optionGroupElement = document.createElement(OPTION_GROUP_CONSTANTS.elementName) as IOptionGroupComponent;

--- a/src/lib/select/core/base-select-foundation.ts
+++ b/src/lib/select/core/base-select-foundation.ts
@@ -279,6 +279,7 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
         this._valueChanging = undefined;
         if (!shouldContinue) {
           rollbackValue();
+          this._tryUpdateDropdownPosition();
           return resolve(false);
         }
       }
@@ -291,6 +292,7 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
         rollbackValue();
       }
 
+      this._tryUpdateDropdownPosition();
       resolve(!cancelled);
     });
   }
@@ -299,6 +301,12 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
     const activeOptionIndex = this._adapter.getActiveOptionIndex();
     if (activeOptionIndex >= 0 && this._nonDividerOptions[activeOptionIndex]) {
       this._onSelect(this._nonDividerOptions[activeOptionIndex], activeOptionIndex);
+    }
+  }
+
+  protected _tryUpdateDropdownPosition(): void {
+    if (this._open) {
+      this._adapter.queueDropdownPositionUpdate();
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The select and autocomplete will now update the position of the dropdown after an option is selected. This accounts for scenarios where the field position could get updated between frames when selecting an option, which was causing the dropdown to appear visually disconnected from its corresponding field.

## Additional information
Fixes #196 
