### PR TITLE
[menu] fixed leading icon if options are reset while dropdown is open

### DIFF
--- a/src/lib/menu/menu-foundation.ts
+++ b/src/lib/menu/menu-foundation.ts
@@ -269,10 +269,7 @@ export class MenuFoundation extends CascadingListDropdownAwareFoundation<IMenuOp
       options.forEach(o => o.selected = false);
     }
 
-    const flatOptions = this._flatOptions;
-
-    // Map the old "icon" property to the new "leadingIcon" property (if exists)
-    flatOptions.filter(o => o.icon).forEach(o => o.leadingIcon = o.icon);
+    this._mapIconToLeadingIcon();
 
     const selectedValues = this._persistSelection ? this._getSelectedValues() : [];
 
@@ -468,6 +465,11 @@ export class MenuFoundation extends CascadingListDropdownAwareFoundation<IMenuOp
     return menu;
   }
 
+  private _mapIconToLeadingIcon(): void {
+    // For backwards compatibility with old API, map the old "icon" property to the new "leadingIcon" property (if exists)
+    this._flatOptions.filter(o => o.icon).forEach(o => o.leadingIcon = o.icon);
+  }
+
   public get open(): boolean {
     return this._open;
   }
@@ -494,6 +496,7 @@ export class MenuFoundation extends CascadingListDropdownAwareFoundation<IMenuOp
       this._options = options.map(o => ({ ...o }));
       
       if (this._open) {
+        this._mapIconToLeadingIcon();
         this._adapter.setOptions(this._options as IMenuOption[]);
         if (this._persistSelection) {
           const selectedValues = this._getSelectedValues();

--- a/src/test/spec/menu/menu.spec.ts
+++ b/src/test/spec/menu/menu.spec.ts
@@ -349,6 +349,31 @@ describe('MenuComponent', function(this: ITestContext) {
         expect(listItems[index].textContent).toBe(`Custom option: ${option.label}`);
       });
     });
+
+    it('should reset options with leading icon if set while dropdown is open', async function(this: ITestContext) {
+      this.context = setupTestContext();
+      const options = generateMenuOptions(1);
+
+      await tick();
+
+      this.context.component.options = options;
+      this.context.component.open = true;
+
+      await tick();
+
+      const newOptions = generateMenuOptions(1);
+      newOptions[0].icon = 'code';
+      this.context.component.options = newOptions;
+
+      await tick();
+
+      const list = getPopupList(getPopupElement());
+      const listItems = Array.from(list.querySelectorAll(LIST_ITEM_CONSTANTS.elementName)) as IListItemComponent[];
+      const leadingIconEl = listItems[0].querySelector('i[slot=leading]');
+
+      expect(leadingIconEl).toBeTruthy();
+      expect(leadingIconEl?.textContent).toBe('code');
+    });
   });
 
   describe(`events`, function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
This only occurs if the options were using the deprecated `icon` property to specify the leading icon. We map that `icon` property to the newer `leadingIcon` property for backwards compatibility in the options that are provided, but this was not happening if the options were set while the dropdown is open. This change ensures that this property is correctly mapped in this scenario.
