### PR TITLE
fix(select): copy all configuration-based option properties to underlying option elements

### DIFF
--- a/src/lib/core/utils/utils.ts
+++ b/src/lib/core/utils/utils.ts
@@ -123,3 +123,14 @@ export function safeMin(...args: (number | undefined)[]): number {
 export function safeMax(...args: (number | undefined)[]): number {
   return Math.max(...args.map(arg => arg ?? Number.NEGATIVE_INFINITY));
 }
+
+/**
+ * Copies properties from one object to another, much like Object.assign(), but only where properties exist in both source objects.
+ * @param from The object to apply properties from.
+ * @param to The object to apply property values to.
+ */
+export function assignMatchingProperties(from: object, to: object): void {
+  Object.keys(from)
+    .filter(prop => prop in to)
+    .forEach(prop => to[prop] = from[prop]);
+}

--- a/src/lib/select/core/base-select-adapter.ts
+++ b/src/lib/select/core/base-select-adapter.ts
@@ -8,6 +8,7 @@ import { IOptionGroupComponent, OPTION_GROUP_CONSTANTS } from '../option-group';
 import { ISelectOption, ISelectOptionGroup, SelectOptionListenerDestructor } from './base-select-constants';
 import { isOptionGroupObject } from './select-utils';
 import { IPopupComponent, POPUP_CONSTANTS } from '../../popup';
+import { assignMatchingProperties } from '../../core/utils/utils';
 
 export interface IBaseSelectAdapter extends IBaseAdapter {
   initializeAccessibility(): void;
@@ -200,18 +201,16 @@ export abstract class BaseSelectAdapter extends BaseAdapter<IBaseSelectComponent
 
 
   private _createOptionGroupElement(group: ISelectOptionGroup): HTMLElement {
-    const optionGroupElement = document.createElement(OPTION_GROUP_CONSTANTS.elementName) as IOptionGroupComponent;
-    optionGroupElement.label = group.text || '';
+    const optionGroupElement = document.createElement('forge-option-group');
+    assignMatchingProperties(group, optionGroupElement);
+    optionGroupElement.label = group.text ?? '';
     return optionGroupElement;
   }
 
   private _createOptionElement(option: ISelectOption): HTMLElement {
-    const optionElement = document.createElement(OPTION_CONSTANTS.elementName) as IOptionComponent;
-    optionElement.value = option.value;
+    const optionElement = document.createElement('forge-option');
+    assignMatchingProperties(option, optionElement);
     optionElement.textContent = option.label;
-    if (option.disabled) {
-      optionElement.disabled = option.disabled;
-    }
     return optionElement;
   }
 }

--- a/src/test/spec/select/select.spec.ts
+++ b/src/test/spec/select/select.spec.ts
@@ -10,7 +10,8 @@ import {
   SelectOptionBuilder,
   defineOptionComponent,
   defineOptionGroupComponent,
-  BASE_SELECT_CONSTANTS
+  BASE_SELECT_CONSTANTS,
+  OPTION_GROUP_CONSTANTS
 } from '@tylertech/forge/select';
 import { POPUP_CONSTANTS, IPopupComponent } from '@tylertech/forge/popup';
 import { LIST_ITEM_CONSTANTS, IListItemComponent } from '@tylertech/forge/list/list-item';
@@ -1304,6 +1305,44 @@ describe('SelectComponent', function(this: ITestContext) {
       this.context.component.options = options;
       await tick();
       expect(this.context.component.querySelectorAll(OPTION_CONSTANTS.elementName).length).toBe(3);
+    });
+
+    it('should apply option and option-group configuration to elements when setting options via property', async function(this: ITestContext) {        
+      this.context = setupTestContext(true);
+      this.context.component.value = 'one';
+      await tick();
+      
+      await tick();
+      this.context.component.options = [
+        {
+          text: '',
+          options: [
+            { label: 'option-1', value: 1, disabled: true, leadingBuilder: () => document.createElement('div'), metadata: 'test-meta' } as any,
+          ]
+        },
+        {
+          text: 'group',
+          options: [
+            { label: 'option-2', value: 2 },
+            { label: 'option-3', value: 3, optionClass: 'test-cls' }
+          ]
+        }
+      ];
+      await tick();
+
+      const optionGroupElements = this.context.component.querySelectorAll(OPTION_GROUP_CONSTANTS.elementName);
+      const optionElements = this.context.component.querySelectorAll(OPTION_CONSTANTS.elementName);
+
+      expect(optionGroupElements[0].label).toBe('');
+      expect(optionGroupElements[1].label).toBe('group');
+
+      expect(optionElements[0].label).toBe('option-1');
+      expect(optionElements[0].disabled).toBeTrue();
+      expect(optionElements[0].leadingBuilder).toBeTruthy();
+      expect('metadata' in optionElements[0]).toBeFalse();
+
+      expect(optionElements[2].label).toBe('option-3');
+      expect(optionElements[2].optionClass).toEqual(['test-cls']);
     });
 
     it('should set value and selected text correctly when options are set via property', async function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Added a new utility function to copy properties from one object to another only where the properties exist in both objects. This is much like `Object.assign()` but ensures we only copy properties that we care about.

The select will now properly apply properties from configuration-based options to the underlying `<forge-option>` and `<forge-option-group>` elements.

## Additional information
Fixes #177 
