### PR TITLE
fix(expansion-panel): allow keydown events to propagate except for toggle keys

### DIFF
--- a/src/lib/expansion-panel/expansion-panel-foundation.ts
+++ b/src/lib/expansion-panel/expansion-panel-foundation.ts
@@ -144,9 +144,8 @@ export class ExpansionPanelFoundation implements IExpansionPanelFoundation {
    * @param {KeyboardEvent} evt The keydown event
    */
   private _onKeydown(evt: KeyboardEvent): void {
-    evt.stopPropagation();
-
-    if (evt.key === 'Space' || evt.key === 'Enter' || evt.keyCode === 32 || evt.keyCode === 13) {
+    if (evt.key === ' ' || evt.key === 'Enter') {
+      evt.stopPropagation();
       evt.preventDefault();
       this._toggle();
       this._emitEvent();

--- a/src/test/spec/expansion-panel/expansion-panel.spec.ts
+++ b/src/test/spec/expansion-panel/expansion-panel.spec.ts
@@ -239,10 +239,31 @@ describe('ExpansionPanelComponent', function(this: ITestContext) {
 
     it('should open when pressing space key while header element is focused', async function(this: ITestContext) {
       this.context = setupTestContext(true);
-      dispatchKeyEvent(getPanelHeader(this.context.component), 'keydown', 'Space');
+      dispatchKeyEvent(getPanelHeader(this.context.component), 'keydown', ' ');
       await timer(EXPANSION_PANEL_CONSTANTS.numbers.COLLAPSE_ANIMATION_DURATION);
       expect(this.context.component.open).toBe(true);
       expect(getInternalPanelContent(this.context.component).clientHeight).toBeGreaterThan(0);
+    });
+
+    it('should propagate all keydown events except for toggle keys', async function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      const keydownSpy = jasmine.createSpy('document keydown spy');
+      document.addEventListener('keydown', keydownSpy);
+
+      await tick();
+
+      dispatchKeyEvent(getPanelHeader(this.context.component), 'keydown', ' ');
+      dispatchKeyEvent(getPanelHeader(this.context.component), 'keydown', 'Enter');
+      dispatchKeyEvent(getPanelHeader(this.context.component), 'keydown', 'Tab');
+      dispatchKeyEvent(getPanelHeader(this.context.component), 'keydown', 'a');
+      
+      document.removeEventListener('keydown', keydownSpy);
+
+      expect(keydownSpy).toHaveBeenCalledTimes(2);
+      expect(keydownSpy).not.toHaveBeenCalledWith(jasmine.objectContaining({ key: ' ' }));
+      expect(keydownSpy).not.toHaveBeenCalledWith(jasmine.objectContaining({ key: 'Enter' }));
+      expect(keydownSpy).toHaveBeenCalledWith(jasmine.objectContaining({ key: 'Tab' }));
+      expect(keydownSpy).toHaveBeenCalledWith(jasmine.objectContaining({ key: 'a' }));
     });
 
     it('should emit toggle event when expanded', function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N/A

## Describe the new behavior?
All keydown events will now propagate except for the `Space` and `Enter` keys which we use for toggling the open state. We need these events to stop propagation for cases where there are nested expansion panels. All other key events should be able to propagate fine now.

## Additional information
This bug was discovered in an app where trapping focus was necessary, but the `Tab` keydown event was not propagating to their document-level listener. A workaround was provided to use a capturing listener.
