### PR TITLE
fix(split-view): avoid updating size and accessibility of closed panels

### DIFF
--- a/src/lib/split-view/split-view-panel/split-view-panel-foundation.ts
+++ b/src/lib/split-view/split-view-panel/split-view-panel-foundation.ts
@@ -739,7 +739,7 @@ export class SplitViewPanelFoundation implements ISplitViewPanelFoundation {
     }
 
     // Size
-    if (config.size) {
+    if (config.size && this.open) {
       const parentSize = this._adapter.getParentSize(this._orientation);
       this._pixelMin = getPixelDimension(this._min, parentSize);
       this._pixelMax = isDefined(this._max) ? getPixelDimension(this._max as number | string, parentSize) : undefined;
@@ -755,7 +755,7 @@ export class SplitViewPanelFoundation implements ISplitViewPanelFoundation {
     const availableSpace = this._adapter.getAvailableSpace(this._orientation, this._resizable);
 
     // Accessibility
-    if (config.accessibility) {
+    if (config.accessibility && this.open) {
       const valueNow = getValuenow(size, { ...this._state, availableSpace });
       this._adapter.setValuenow(valueNow);
     }

--- a/src/lib/split-view/split-view/split-view-adapter.ts
+++ b/src/lib/split-view/split-view/split-view-adapter.ts
@@ -7,6 +7,8 @@ import { SplitViewOrientation, SPLIT_VIEW_CONSTANTS } from './split-view-constan
 
 export interface ISplitViewAdapter extends IBaseAdapter {
   registerSlotListener(listener: (evt: Event) => void): void;
+  registerDidOpenListener(listener: () => void): void;
+  registerDidCloseListener(listener: () => void): void;
   observeResize(callback: (entry: ResizeObserverEntry) => void): void;
   unobserveResize(): void;
   getSlottedPanels(): ISplitViewPanelComponent[];
@@ -23,6 +25,14 @@ export class SplitViewAdapter extends BaseAdapter<ISplitViewComponent> implement
 
   public registerSlotListener(listener: (evt: Event) => void): void {
     this._root.addEventListener('slotchange', listener);
+  }
+
+  public registerDidOpenListener(listener: () => void): void {
+    this._root.addEventListener(SPLIT_VIEW_PANEL_CONSTANTS.events.DID_OPEN, listener);
+  }
+
+  public registerDidCloseListener(listener: () => void): void {
+    this._root.addEventListener(SPLIT_VIEW_PANEL_CONSTANTS.events.DID_CLOSE, listener);
   }
 
   public observeResize(callback: (entry: ResizeObserverEntry) => void): void {
@@ -61,7 +71,7 @@ export class SplitViewAdapter extends BaseAdapter<ISplitViewComponent> implement
     let diff = combinedPanelSize - size;
 
     // Size down the panels as needed in reverse order, adjusting diff accordingly
-    panels.reverse().forEach(panel => {
+    panels.slice().reverse().forEach(panel => {
       if (diff <= 0) {
         return;
       }

--- a/src/lib/split-view/split-view/split-view-foundation.ts
+++ b/src/lib/split-view/split-view/split-view-foundation.ts
@@ -20,16 +20,22 @@ export class SplitViewFoundation implements ISplitViewFoundation {
   private _autoClose = false;
   private _autoCloseThreshold = 0;
   private _slotListener: (evt: Event) => void;
+  private _didOpenListener: () => void;
+  private _didCloseListener: () => void;
   private _resizeObserverCallback: ForgeResizeObserverCallback;
   private _isInitialized = false;
 
   constructor(private _adapter: ISplitViewAdapter) {
     this._slotListener = evt => this._onSlotChange(evt);
+    this._didOpenListener = () => this._onDidOpen();
+    this._didCloseListener = () => this._onDidClose();
     this._resizeObserverCallback = throttle((entry: ResizeObserverEntry) => this._onResize(entry), SPLIT_VIEW_CONSTANTS.numbers.RESIZE_THROTTLE_THRESHOLD);
   }
 
   public initialize(): void {
     this._adapter.registerSlotListener(this._slotListener);
+    this._adapter.registerDidOpenListener(this._didOpenListener);
+    this._adapter.registerDidCloseListener(this._didCloseListener);
     this._adapter.observeResize(this._resizeObserverCallback);
     
     this._applyOrientation();
@@ -43,6 +49,16 @@ export class SplitViewFoundation implements ISplitViewFoundation {
   private _onSlotChange(evt: Event): void {
     this._layoutSlottedPanels();
     this.update({ accessibility: true, cursor: true, orientation: this._orientation });
+  }
+
+  private _onDidOpen(): void {
+    this._adapter.refitSlottedPanels(this._orientation);
+    this.update({ accessibility: true, cursor: true, size: true});
+  }
+
+  private _onDidClose(): void {
+    this._adapter.refitSlottedPanels(this._orientation);
+    this.update({ accessibility: true, cursor: true, size: true});
   }
 
   private _onResize(entry: ResizeObserverEntry): void {

--- a/src/test/spec/split-view/split-view/split-view.spec.ts
+++ b/src/test/spec/split-view/split-view/split-view.spec.ts
@@ -1,6 +1,6 @@
 import { removeElement } from '@tylertech/forge-core';
 import { tick } from '@tylertech/forge-testing';
-import { defineSplitViewComponent, ISplitViewComponent, ISplitViewPanelComponent, SplitViewAnimatingLayer, SPLIT_VIEW_CONSTANTS } from '@tylertech/forge/split-view';
+import { defineSplitViewComponent, ISplitViewComponent, ISplitViewPanelComponent, SplitViewAnimatingLayer, SPLIT_VIEW_CONSTANTS, SPLIT_VIEW_PANEL_CONSTANTS } from '@tylertech/forge/split-view';
 
 interface ITestContext {
   context: ITestSplitViewContext;
@@ -165,6 +165,19 @@ describe('SplitViewComponent', function(this: ITestContext) {
       this.context.component.parentElement!.style.width = '400px';
       await tick();
       expect(spy).toHaveBeenCalled();
+    });
+
+    it('should not update size of closed panels on resize', async function(this: ITestContext) {
+      this.context = setupTestContext(true, 2);
+      await tick();
+      this.context.component.style.width = '400px';
+      this.context.panels![1].size = '50%'
+      this.context.panels![1].open = false;
+      await tick();
+      this.context.component.style.width = '200px';
+      await tick();
+      const size = this.context.panels![1].style.getPropertyValue(SPLIT_VIEW_PANEL_CONSTANTS.customCssProperties.SIZE);
+      expect(size).not.toBe('0px');
     });
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Closes #201 

When a split view resizes closed panels will no longer have their size set to zero when reopening. To cover edge cases panels are refit and their sizing recalculated after every open and close event.
