### PR TITLE
docs(split-view): add JSDoc for manifest

### DIFF
--- a/src/lib/split-view/split-view-panel/split-view-panel.ts
+++ b/src/lib/split-view/split-view-panel/split-view-panel.ts
@@ -44,6 +44,11 @@ declare global {
   }
 }
 
+/**
+ * The custom element class behind the `<forge-split-view-panel>` element.
+ * 
+ * @tag forge-split-view-panel
+ */
 @CustomElement({
   name: SPLIT_VIEW_PANEL_CONSTANTS.elementName,
   dependencies: [

--- a/src/lib/split-view/split-view/split-view.ts
+++ b/src/lib/split-view/split-view/split-view.ts
@@ -24,6 +24,11 @@ declare global {
   }
 }
 
+/**
+ * The custom element class behind the `<forge-split-view>` element.
+ * 
+ * @tag forge-split-view
+ */
 @CustomElement({
   name: SPLIT_VIEW_CONSTANTS.elementName,
   dependencies: [SplitViewPanelComponent]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: n/a
- Docs have been added / updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?
Adding JSDoc comments so the custom elements manifest is sufficient for proxy component generation in `forge-angular` repo.

Would be nice to have some linting to enforce this, which might be possible using [eslint-plugin-jsdoc](https://www.npmjs.com/package/eslint-plugin-jsdoc).  I can open up an issue to track that.