### PR TITLE
Fix/popup position

### DIFF
--- a/src/lib/popup/popup-adapter.ts
+++ b/src/lib/popup/popup-adapter.ts
@@ -63,6 +63,13 @@ export class PopupAdapter extends BaseAdapter<IPopupComponent> implements IPopup
   public addPopup(targetElement: HTMLElement, manageFocus: boolean): void {
     this._component.setAttribute('tabindex', '-1');
     this._component.setAttribute(POPUP_CONSTANTS.attributes.HOST, '');
+
+    // Set initial position to top-left of the host element while we wait for positioning.
+    // This ensures that the element is not visible, nor does it affect layouts before it
+    // is properly moved into its expected location.
+    this._component.style.top = '0';
+    this._component.style.left = '0';
+
     const hostDocument = targetElement.ownerDocument || document;
     this._hostElement = (closestElement(POPUP_CONSTANTS.selectors.HOST, targetElement) as HTMLElement) || hostDocument.body;
     this._hostElement.appendChild(this._component);

--- a/src/stories/src/components/checkbox/code/checkbox-default.ts
+++ b/src/stories/src/components/checkbox/code/checkbox-default.ts
@@ -1,7 +1,7 @@
 export const CheckboxDefaultCodeHtml = () => {
   return `
 <forge-checkbox>
-  <input type="checkbox" id="checkbox-field />
+  <input type="checkbox" id="checkbox-field" />
   <label for="checkbox-field">Label</label>
 </forge-checkbox>
   `;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
A bug was found where popups could be incorrectly positioned if adding the `<forge-popup>` element to the DOM causes a scrollbar to render. This is due to the fact that the scrollbar would shift the layout to account for its height/width **before** position calculation.

To fix this, we ensure that the `top: 0` and `left: 0` styles are applied to the host element (which uses absolute positioning already) so that it does not inadvertently affect the layout.
