### PR TITLE
fix(select): fixed a bug where the UI was not reflecting the selected value if the option values are changed after the component value is set

### DIFF
--- a/src/lib/select/core/base-select-adapter.ts
+++ b/src/lib/select/core/base-select-adapter.ts
@@ -146,9 +146,21 @@ export abstract class BaseSelectAdapter extends BaseAdapter<IBaseSelectComponent
   }
 
   public setOptionsListener(listener: (options: ISelectOption[] | ISelectOptionGroup[]) => void): SelectOptionListenerDestructor {
+    // Watch for option value property changes
+    const optionValueChangeListener: EventListener = evt => {
+      evt.stopPropagation();
+      listener(this.getOptions());
+    };
+    this._component.addEventListener(OPTION_CONSTANTS.events.VALUE_CHANGE, optionValueChangeListener);
+
+    // Watch for DOM changes
     const observer = new MutationObserver(() => listener(this.getOptions()));
     observer.observe(this._component, { childList: true, subtree: true });
-    return () => observer.disconnect();
+
+    return () => {
+      this._component.removeEventListener(OPTION_CONSTANTS.events.VALUE_CHANGE, optionValueChangeListener);
+      observer.disconnect();
+    };
   }
 
   public setOptions(options: ISelectOption[] | ISelectOptionGroup[], clear = true): void {

--- a/src/lib/select/core/base-select-foundation.ts
+++ b/src/lib/select/core/base-select-foundation.ts
@@ -70,6 +70,9 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
   protected _onFocus(evt: Event): void {}
 
   public initialize(): void {
+    if (this._optionListenerDestructor) {
+      this._optionListenerDestructor();
+    }
     this._optionListenerDestructor = this._adapter.setOptionsListener(this._optionsChangedListener);
     this._initializeValue();
   }
@@ -219,6 +222,7 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
       const label = option ? option.label : '';
 
       // Store the current selections in case we need to rollback (if the event was cancelled)
+      const prevValues = [...this._value];
       const prevSelectedValues = [...this._selectedValues];
       const prevSelectedLabels = [...this._selectedLabels];
       const prevSelectedIndexes = [...this._selectedIndexes];
@@ -246,16 +250,16 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
         }
       }
 
+      this._value = [...this._selectedValues];
+
       const rollbackValue = (): void => {
         this._selectedValues = [...prevSelectedValues];
         this._selectedLabels = [...prevSelectedLabels];
         this._selectedIndexes = [...prevSelectedIndexes];
+        this._value = [...prevValues];
       };
 
       const applyValue = (): void => {
-        // Always keep the internal value in sync in case the component needs to reinitialize with the existing value later on
-        this._value = [...this._selectedValues];
-
         // If we're in multiselect mode, we need to toggle the selected option
         if (this._multiple) {
           const isSelected = this._selectedIndexes.includes(optionIndex);
@@ -543,7 +547,7 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
 
   /** Gets/sets the value of the component. */
   public get value(): any {
-    return this._multiple ? [...this._selectedValues] : this._selectedValues[0];
+    return this._multiple ? [...this._value] : this._value[0];
   }
   public set value(value: any) {
     let _value: string | string[];

--- a/src/lib/select/option/option-constants.ts
+++ b/src/lib/select/option/option-constants.ts
@@ -16,7 +16,12 @@ const attributes = {
   VALUE: 'value'
 };
 
+const events = {
+  VALUE_CHANGE: `${elementName}-value-change`
+};
+
 export const OPTION_CONSTANTS = {
   elementName,
-  attributes
+  attributes,
+  events
 };

--- a/src/lib/select/option/option-foundation.ts
+++ b/src/lib/select/option/option-foundation.ts
@@ -24,12 +24,13 @@ export class OptionFoundation implements IOptionFoundation {
   constructor(private _adapter: IOptionAdapter) {}
 
   /** Gets/sets the value of this option. */
-  public get value(): string {
+  public get value(): any {
     return this._value;
   }
-  public set value(value: string) {
+  public set value(value: any) {
     if (this._value !== value) {
       this._value = value;
+      this._adapter.emitHostEvent(OPTION_CONSTANTS.events.VALUE_CHANGE, this._value);
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The select component was not updating its selection state if child `<forge-option>` elements change their `value` property. This was causing issues where a value being set on the `<forge-select>` would not reflect in the UI if the `<forge-option>` values are set **after** the `<forge-select>` value...

The new behavior is that the `<forge-option>` elements will now dispatch a `forge-option-value-change` event when the `value` setter is executed. This is intended to be an internal use only event that will not be documented. This event allows for the parent `<forge-select>` element to capture that event and ensure that it updates its selection state internally and reflects it properly in the UI.

## Additional information
This issue was discovered in an Angular app where incremental rendering and the order of bindings was causing the `<forge-select>` element to update its value before the `<forge-option>` element `value` bindings were set.
