### PR TITLE
fix(switch): fixed a bug where the UI could incorrectly reflect the component state

### DIFF
--- a/src/lib/switch/switch.ts
+++ b/src/lib/switch/switch.ts
@@ -113,13 +113,24 @@ export class SwitchComponent extends BaseComponent implements ISwitchComponent {
       return;
     }
 
-    this._mdcSwitch.ripple.layout();
-    const isCancelled = !emitEvent(this, SWITCH_CONSTANTS.events.SELECT, !this._selected, true, true);
+    // Prevents MDCSwitch from receiving the click event in the targeting phase.
+    // We will handle updating the selected state of MDCSwitch based on the result of our own event.
+    evt.stopImmediatePropagation();
 
-    if (isCancelled) {
-      evt.stopImmediatePropagation(); // Prevents MDCSwitch from receiving the click event in the targeting phase
-    } else {
-      this._selected = !this._selected;
+    this._mdcSwitch.ripple.layout();
+
+    const newValue = !this._selected;
+    const isCancelled = !emitEvent(this, SWITCH_CONSTANTS.events.SELECT, newValue, true, true);
+    
+    if (!isCancelled) {
+      this._applySelected(newValue);
+    }
+  }
+
+  private _applySelected(value: boolean): void {
+    this._selected = value;
+    if (this._mdcSwitch) {
+      this._mdcSwitch.selected = this._selected;
     }
   }
 
@@ -169,10 +180,7 @@ export class SwitchComponent extends BaseComponent implements ISwitchComponent {
   }
   public set selected(value: boolean) {
     if (this._selected !== value) {
-      this._selected = value;
-      if (this._mdcSwitch) {
-        this._mdcSwitch.selected = this._selected;
-      }
+      this._applySelected(value);
       toggleAttribute(this, this._selected, SWITCH_CONSTANTS.attributes.SELECTED);
     }
   }

--- a/src/test/spec/switch/switch.spec.ts
+++ b/src/test/spec/switch/switch.spec.ts
@@ -243,6 +243,25 @@ describe('SwitchComponent', function (this: ITestContext) {
     expect(this.context.getMDCSwitch().selected).withContext('Expected MDCSwitch selected state to stay unchanged').toBeFalse();
   });
 
+  /**
+   * It is common for developers to hold their own state that is bound to a select, and they often times toggle the value
+   * and bind it to the select within event listeners. This test ensures that the internal state does not toggle incorrectly
+   * to avoid the UI incorrectly reflecting the opposite state value.
+   */
+  it('should always set selected state to value provided in select event if not cancelled', function(this: ITestContext) {
+    this.context = setupTestContext(true);
+    let switchState = false;
+    const selectSpy = jasmine.createSpy('select event spy', (evt: CustomEvent<boolean>) => {
+      switchState = !switchState; // Simulate a developer updating their own state (in reality it would be more correct to use `evt.detail` here though...)
+      this.context.component.selected = switchState; // Developer updating the state (they in theory should not be doing this, but the component is smart enough to handle it)
+    }).and.callThrough();
+    this.context.component.addEventListener(SWITCH_CONSTANTS.events.SELECT, selectSpy);
+    this.context.buttonElement.dispatchEvent(new MouseEvent('click'));
+
+    expect(this.context.component.selected).withContext('Expected selected state to be correct').toBeTrue();
+    expect(this.context.getMDCSwitch().selected).withContext('Expected MDCSwitch selected state to match').toBeTrue();
+  });
+
   function setupTestContext(append = true, config?: Partial<ISwitchComponent>): ISwitchTextContext {
     const component = document.createElement('forge-switch');
     component.textContent = 'Label text';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: [Y]
- Docs have been added / updated: [N]
- Does this PR introduce a breaking change? [N]
- I have linked any related GitHub issues to be closed when this PR is merged? [N]

## Describe the new behavior?
The switch component will now always force its UI updates after the `forge-switch-select` event if the event is not cancelled to the same value provided in the event `detail`. This will ensure that the state cannot get out of sync with the UI, and ensures that if developers attempt to incorrectly toggle the state value from within the event listener that it won't get out of sync with the internal component state.

If developers need to update the state of the components `selected` property manually, they should always be calling `preventDefault()` on the `forge-switch-select` event. This will ensure that the state and UI does not update internally within the component until the developers chooses when to do so.

Another slight change is that we always stop immediate event propagation in our internal capturing click handler now to avoid the `MDCSwitch` implementation from receiving the event. This allows our wrapper component full control over when to update the state of the `MDCSwitch` and synchronize the UI properly.

## Additional information
A side note to call out is that the `event.target.selected` property will not reflect the "new" state of the component (same as prior) but the new state is always available in the `event.detail` property (same as prior).
