### PR TITLE
fix(split-view): add overlay to body while dragging to prevent context loss

### DIFF
--- a/src/lib/split-view/split-view-panel/split-view-panel-adapter.ts
+++ b/src/lib/split-view/split-view-panel/split-view-panel-adapter.ts
@@ -5,12 +5,13 @@ import { ISplitViewPanelComponent } from './split-view-panel';
 import { ISplitViewPanelCursorConfig, ISplitViewPanelOpenEvent, SplitViewPanelResizable, SPLIT_VIEW_PANEL_CONSTANTS } from './split-view-panel-constants';
 import { ISplitViewUpdateConfig, SplitViewOrientation, SPLIT_VIEW_CONSTANTS } from '../split-view/split-view-constants';
 import { ISplitViewComponent } from '../split-view/split-view';
-import { getCursor, getHandleIcon, getOverlay, getSplitViewPanelSibling } from './split-view-panel-utils';
+import { getCursor, getHandleIcon, createOverlay, getSplitViewPanelSibling } from './split-view-panel-utils';
 import { IIconComponent } from '../../icon';
 import { IRippleComponent } from '../../ripple';
 
 export interface ISplitViewPanelAdapter extends IBaseAdapter {
   initialize(): void;
+  tryRemoveOverlay(): void;
   setPointerdownListener(listener: (evt: PointerEvent) => void): void;
   setPointerupListener(listener: (evt: PointerEvent) => void): void;
   removePointerupListener(listener: (evt: PointerEvent) => void): void;
@@ -65,6 +66,11 @@ export class SplitViewPanelAdapter extends BaseAdapter<ISplitViewPanelComponent>
     if (parent?.tagName.toLowerCase() === SPLIT_VIEW_CONSTANTS.elementName) {
       this._parent = parent as ISplitViewComponent;
     }
+  }
+
+  public tryRemoveOverlay(): void {
+    this._overlay?.remove();
+    this._overlay = undefined;
   }
 
   public setPointerdownListener(listener: (evt: PointerEvent) => void): void {
@@ -215,11 +221,12 @@ export class SplitViewPanelAdapter extends BaseAdapter<ISplitViewPanelComponent>
     this._handle.setAttribute('aria-grabbed', value.toString());
 
     if (value) {
-      this._overlay = getOverlay();
+      if (!this._overlay) {
+        this._overlay = createOverlay();
+      }
       document.body.append(this._overlay);
     } else {
       this._overlay?.remove();
-      this._overlay = undefined;
     }
   }
 

--- a/src/lib/split-view/split-view-panel/split-view-panel-adapter.ts
+++ b/src/lib/split-view/split-view-panel/split-view-panel-adapter.ts
@@ -5,7 +5,7 @@ import { ISplitViewPanelComponent } from './split-view-panel';
 import { ISplitViewPanelCursorConfig, ISplitViewPanelOpenEvent, SplitViewPanelResizable, SPLIT_VIEW_PANEL_CONSTANTS } from './split-view-panel-constants';
 import { ISplitViewUpdateConfig, SplitViewOrientation, SPLIT_VIEW_CONSTANTS } from '../split-view/split-view-constants';
 import { ISplitViewComponent } from '../split-view/split-view';
-import { getCursor, getHandleIcon, getSplitViewPanelSibling } from './split-view-panel-utils';
+import { getCursor, getHandleIcon, getOverlay, getSplitViewPanelSibling } from './split-view-panel-utils';
 import { IIconComponent } from '../../icon';
 import { IRippleComponent } from '../../ripple';
 
@@ -48,6 +48,7 @@ export class SplitViewPanelAdapter extends BaseAdapter<ISplitViewPanelComponent>
   private _ripple: IRippleComponent;
   private _content: HTMLElement;
   private _parent?: ISplitViewComponent;
+  private _overlay?: HTMLElement;
 
   constructor(component: ISplitViewPanelComponent) {
     super(component);
@@ -212,10 +213,13 @@ export class SplitViewPanelAdapter extends BaseAdapter<ISplitViewPanelComponent>
   public setGrabbed(value: boolean): void {
     this._root.classList.toggle(SPLIT_VIEW_PANEL_CONSTANTS.classes.GRABBED, value);
     this._handle.setAttribute('aria-grabbed', value.toString());
-    this._parent?.update({ clearCursor: true });
 
-    if (!value) {
-      document.body.style.removeProperty('cursor');
+    if (value) {
+      this._overlay = getOverlay();
+      document.body.append(this._overlay);
+    } else {
+      this._overlay?.remove();
+      this._overlay = undefined;
     }
   }
 
@@ -233,12 +237,12 @@ export class SplitViewPanelAdapter extends BaseAdapter<ISplitViewPanelComponent>
   }
 
   /**
-   * Applies a cursor style to the document body.
+   * Applies a cursor style to the overlay element covering the document body.
    * @param orientation The component's orientation.
    * @param config The component's resizable value and whether it's at the min or max value.
    */
   public setBodyCursor(orientation: SplitViewOrientation, config?: ISplitViewPanelCursorConfig): void {
-    document.body.style.setProperty('cursor', getCursor(orientation, config));
+    this._overlay?.style.setProperty('cursor', getCursor(orientation, config));
   }
 
   /**

--- a/src/lib/split-view/split-view-panel/split-view-panel-constants.ts
+++ b/src/lib/split-view/split-view-panel/split-view-panel-constants.ts
@@ -26,7 +26,8 @@ const classes = {
   CLOSED: 'forge-split-view-panel--closed',
   CLOSING: 'forge-split-view-panel--closing',
   OPENING: 'forge-split-view-panel--opening',
-  DISABLED: 'forge-split-view-panel--disabled'
+  DISABLED: 'forge-split-view-panel--disabled',
+  OVERLAY: 'forge-split-view-panel-overlay'
 };
 
 const ids = {

--- a/src/lib/split-view/split-view-panel/split-view-panel-foundation.ts
+++ b/src/lib/split-view/split-view-panel/split-view-panel-foundation.ts
@@ -120,6 +120,7 @@ export class SplitViewPanelFoundation implements ISplitViewPanelFoundation {
   }
 
   public disconnect(): void {
+    this._adapter.tryRemoveOverlay();
     this._adapter.removePointerupListener(this._pointerupListener);
     this._adapter.removePointermoveListener(this._pointermoveListener);
   }

--- a/src/lib/split-view/split-view-panel/split-view-panel-foundation.ts
+++ b/src/lib/split-view/split-view-panel/split-view-panel-foundation.ts
@@ -764,10 +764,5 @@ export class SplitViewPanelFoundation implements ISplitViewPanelFoundation {
     if (config.cursor) {
       handleBoundariesAfterResize(this._adapter, size, { ...this._state, availableSpace });
     }
-
-    // Unset cursor
-    if (config.clearCursor) {
-      this._adapter.setHandleCursor();
-    }
   }
 }

--- a/src/lib/split-view/split-view-panel/split-view-panel-utils.ts
+++ b/src/lib/split-view/split-view-panel/split-view-panel-utils.ts
@@ -1,5 +1,5 @@
 import { percentToPixels, safeMin, scaleValue } from '../../core/utils/utils';
-import { ISplitViewPanelCursorConfig, ISplitViewPanelState, SplitViewInputDeviceType } from './split-view-panel-constants';
+import { ISplitViewPanelCursorConfig, ISplitViewPanelState, SplitViewInputDeviceType, SPLIT_VIEW_PANEL_CONSTANTS } from './split-view-panel-constants';
 import { ISplitViewPanelAdapter } from './split-view-panel-adapter';
 import { SplitViewOrientation } from '../split-view/split-view-constants';
 import { ISplitViewPanelComponent, SplitViewPanelComponent } from './split-view-panel';
@@ -345,4 +345,21 @@ export function getPixelDimension(value: number | string, parentSize: number): n
     return percentToPixels(parsedSize.amount, parentSize);
   }
   return parsedSize.amount;
+}
+
+/**
+ * Gets a transparent element to overlay on top of the document body, ensuring the split view
+ * behaves as expected when dragging over other contexts.
+ * @returns An overlay element.
+ */
+export function getOverlay(): HTMLElement {
+  const el = document.createElement('div');
+  el.classList.add(SPLIT_VIEW_PANEL_CONSTANTS.classes.OVERLAY);
+  el.style.position = 'fixed';
+  el.style.top = '0';
+  el.style.left = '0';
+  el.style.width = '100vw';
+  el.style.height = '100vh';
+  el.style.zIndex = '999';
+  return el;
 }

--- a/src/lib/split-view/split-view-panel/split-view-panel-utils.ts
+++ b/src/lib/split-view/split-view-panel/split-view-panel-utils.ts
@@ -348,11 +348,11 @@ export function getPixelDimension(value: number | string, parentSize: number): n
 }
 
 /**
- * Gets a transparent element to overlay on top of the document body, ensuring the split view
+ * Creates a transparent element to overlay on top of the document body, ensuring the split view
  * behaves as expected when dragging over other contexts.
  * @returns An overlay element.
  */
-export function getOverlay(): HTMLElement {
+export function createOverlay(): HTMLElement {
   const el = document.createElement('div');
   el.classList.add(SPLIT_VIEW_PANEL_CONSTANTS.classes.OVERLAY);
   el.style.position = 'fixed';

--- a/src/lib/split-view/split-view-panel/split-view-panel-utils.ts
+++ b/src/lib/split-view/split-view-panel/split-view-panel-utils.ts
@@ -360,6 +360,6 @@ export function getOverlay(): HTMLElement {
   el.style.left = '0';
   el.style.width = '100vw';
   el.style.height = '100vh';
-  el.style.zIndex = '999';
+  el.style.zIndex = '9999';
   return el;
 }

--- a/src/lib/split-view/split-view/split-view-constants.ts
+++ b/src/lib/split-view/split-view/split-view-constants.ts
@@ -47,7 +47,6 @@ export type SplitViewOrientation = 'horizontal' | 'vertical';
 
 export interface ISplitViewUpdateConfig {
   accessibility?: boolean;
-  clearCursor?: boolean;
   cursor?: boolean;
   orientation?: SplitViewOrientation;
   properties?: Partial<ISplitViewBase>;

--- a/src/test/spec/split-view/split-view-panel/split-view-panel.spec.ts
+++ b/src/test/spec/split-view/split-view-panel/split-view-panel.spec.ts
@@ -13,6 +13,7 @@ interface ITestSplitViewPanelContext {
   parent: ISplitViewComponent;
   adapter: ISplitViewPanelAdapter;
   getPart(part: string): HTMLElement | null;
+  getOverlay(): HTMLElement | null;
   keyEvent(type: string, key: string, shiftKey?: boolean): void;
   pointerEvent(type: string, clientX: number, clientY: number, onDocument?: boolean, buttons?: number): void;
   append(): void;
@@ -466,21 +467,21 @@ describe('SplitViewPanelComponent', function(this: ITestContext) {
       expect(handleGrabbed).toBe('true');
     });
 
-    it('should set horizontal body cursor on pointer down', function(this: ITestContext) {
+    it('should set horizontal overlay cursor on pointer down', function(this: ITestContext) {
       this.context = setupTestContext(true, 1);
       this.context.component.resizable = 'end';
       this.context.pointerEvent('pointerdown', 0, 0);
-      const documentCursor = document.body.style.getPropertyValue('cursor');
-      expect(documentCursor).toBe(getCursor('horizontal'));
+      const overlayCursor = this.context.getOverlay()?.style.getPropertyValue('cursor');
+      expect(overlayCursor).toBe(getCursor('horizontal'));
     });
 
-    it('should set vertical body cursor on pointer down', function(this: ITestContext) {
+    it('should set vertical overlay cursor on pointer down', function(this: ITestContext) {
       this.context = setupTestContext(true, 1);
       this.context.parent.orientation = 'vertical';
       this.context.component.resizable = 'start';
       this.context.pointerEvent('pointerdown', 0, 0);
-      const documentCursor = document.body.style.getPropertyValue('cursor');
-      expect(documentCursor).toBe(getCursor('vertical'));
+      const overlayCursor = this.context.getOverlay()?.style.getPropertyValue('cursor');
+      expect(overlayCursor).toBe(getCursor('vertical'));
     });
 
     it('should set grabbed value on pointer up', function(this: ITestContext) {
@@ -490,25 +491,6 @@ describe('SplitViewPanelComponent', function(this: ITestContext) {
       this.context.pointerEvent('pointerup', 0, 0, true);
       const handleGrabbed = this.context.getPart('handle')!.getAttribute('aria-grabbed');
       expect(handleGrabbed).toBe('false');
-    });
-
-    it('should unset horizontal body cursor on pointer up', function(this: ITestContext) {
-      this.context = setupTestContext(true, 1);
-      this.context.component.resizable = 'end';
-      this.context.pointerEvent('pointerdown', 0, 0);
-      this.context.pointerEvent('pointerup', 0, 0, true);
-      const documentCursor = document.body.style.getPropertyValue('cursor');
-      expect(documentCursor).toBe('');
-    });
-
-    it('should unset vertical body cursor on pointer up', function(this: ITestContext) {
-      this.context = setupTestContext(true, 1);
-      this.context.parent.orientation = 'vertical';
-      this.context.component.resizable = 'end';
-      this.context.pointerEvent('pointerdown', 0, 0);
-      this.context.pointerEvent('pointerup', 0, 0, true);
-      const documentCursor = document.body.style.getPropertyValue('cursor');
-      expect(documentCursor).toBe('');
     });
 
     it('should do nothing on pointer down if disabled', function(this: ITestContext) {
@@ -548,6 +530,21 @@ describe('SplitViewPanelComponent', function(this: ITestContext) {
       this.context.pointerEvent('pointermove', 10, 0, true);
       const handleGrabbed = this.context.getPart('handle')!.getAttribute('aria-grabbed');
       expect(handleGrabbed).toBe('false');
+    });
+
+    it('should append overlay on pointer down', function(this: ITestContext) {
+      this.context = setupTestContext(true, 1);
+      this.context.component.resizable = 'end';
+      this.context.pointerEvent('pointerdown', 0, 0);
+      expect(this.context.getOverlay()).toBeDefined();
+    });
+
+   it('should remove overlay on pointer up', function(this: ITestContext) {
+      this.context = setupTestContext(true, 1);
+      this.context.component.resizable = 'end';
+      this.context.pointerEvent('pointerdown', 0, 0);
+      this.context.pointerEvent('pointerup', 0, 0, true);
+      expect(this.context.getOverlay()).toBeNull();
     });
 
     describe('resizable end', function(this: ITestContext) {
@@ -1250,6 +1247,7 @@ describe('SplitViewPanelComponent', function(this: ITestContext) {
       parent: fixture,
       adapter: component['_foundation']['_adapter'],
       getPart: (part: string): HTMLElement | null => component.shadowRoot!.querySelector(`[part=${part}]`),
+      getOverlay: () => document.body.querySelector(`.${SPLIT_VIEW_PANEL_CONSTANTS.classes.OVERLAY}`),
       keyEvent: (type: string, key: string, shiftKey = false) => {
         const handle = component.shadowRoot!.querySelector('[part=handle]') as Element;
         const event = new KeyboardEvent(type, {key, shiftKey})

--- a/src/test/spec/split-view/split-view-panel/split-view-panel.spec.ts
+++ b/src/test/spec/split-view/split-view-panel/split-view-panel.spec.ts
@@ -870,7 +870,7 @@ describe('SplitViewPanelComponent', function(this: ITestContext) {
       expect(sibling.getContentSize()).toBe(startSize);
     });
 
-    it('should close when size is equal to or under auto size threshold and auto close is anabled', function(this: ITestContext) {
+    it('should close when size is equal to or under auto size threshold and auto close is enabled', function(this: ITestContext) {
       this.context = setupTestContext(true, 1);
       this.context.component.resizable = 'end';
       this.context.component.autoClose = true;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N/A

## Describe the new behavior?
Added a transparent viewport-sized div above other body content while dragging a split view panel's handle to prevent other contexts like iframes from interfering with listeners added to the document body while the pointer is over them. After dragging has stopped the div is removed. This also has the benefit of more easily maintaining a cursor style while dragging and preventing potentially destructive style mutations to the body by setting cursor styles to the div instead.

Fixes #221 
