### PR TITLE
fix(field): fixed a bug where height of helper-text element was incorrect

### DIFF
--- a/src/lib/field/_base.scss
+++ b/src/lib/field/_base.scss
@@ -474,9 +474,11 @@
 // Helper Text
 @mixin helper-text-core {
   @include mdc-typography.typography(caption, $exclude-props: (font-size));
-  @include mdc-typography.baseline-top(map.get(variables.$helper-text, text-baseline, default));
   display: block;
-  height: auto;
+  min-height: 1.5rem;
+  line-height: normal;
+  padding-top: 4px;
+  box-sizing: border-box;
 }
 
 @mixin helper-text-font-size($layout-state) {

--- a/src/lib/field/_variables.scss
+++ b/src/lib/field/_variables.scss
@@ -112,9 +112,6 @@ $helper-text: (
     roomy: 0.875rem,
     default: 0.75rem,
     dense: 0.75rem
-  ),
-  text-baseline: (
-    default: 18px
   )
 ) !default;
 

--- a/src/lib/field/_variables.scss
+++ b/src/lib/field/_variables.scss
@@ -114,7 +114,7 @@ $helper-text: (
     dense: 0.75rem
   ),
   text-baseline: (
-    default: 16px
+    default: 18px
   )
 ) !default;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Removed the ::before pseudo element which will simplify the structure to allow for multi-line text. Removed text-baseline and margin-top items from the $helper-text map as they are no longer needed.

## Additional information
Fixes #219 