### PR TITLE
fix(list-item): fixed a bug where the UI could incorrectly reflect the component state

### DIFF
--- a/src/lib/list/list-item/list-item-adapter.ts
+++ b/src/lib/list/list-item/list-item-adapter.ts
@@ -215,13 +215,10 @@ export class ListItemAdapter extends BaseAdapter<IListItemComponent> implements 
     }
 
     const listValues = list.selectedValue instanceof Array ? list.selectedValue : [list.selectedValue];
-    if (listValues.some(v => isDeepEqual(v, value))) {
-      this.setSelected(true);
-      this.tryToggleCheckboxRadio(true);
-      return true;
-    } else {
-      this.tryToggleCheckboxRadio(false);
-      return false;
-    }
+    const isSelected = listValues.some(v => isDeepEqual(v, value));
+
+    this.setSelected(isSelected);
+    this.tryToggleCheckboxRadio(isSelected);
+    return isSelected;
   }
 }

--- a/src/lib/list/list-item/list-item-adapter.ts
+++ b/src/lib/list/list-item/list-item-adapter.ts
@@ -26,7 +26,7 @@ export interface IListItemAdapter extends IBaseAdapter {
   setDense(dense: boolean): void;
   setIndented(indented: boolean): void;
   setWrap(value: boolean): void;
-  trySelect(value: unknown): boolean;
+  trySelect(value: unknown): boolean | null;
 }
 
 export class ListItemAdapter extends BaseAdapter<IListItemComponent> implements IListItemAdapter {
@@ -208,10 +208,10 @@ export class ListItemAdapter extends BaseAdapter<IListItemComponent> implements 
    * @param value The value to compare to the parent list element's selected value
    * @returns Returns whether the list item is selected or not
    */
-  public trySelect(value: unknown): boolean {
+  public trySelect(value: unknown): boolean | null {
     const list = requireParent<IListComponent>(this._component, LIST_CONSTANTS.elementName);
     if (!list || list.selectedValue === undefined) {
-      return false;
+      return null;
     }
 
     const listValues = list.selectedValue instanceof Array ? list.selectedValue : [list.selectedValue];

--- a/src/lib/list/list-item/list-item-adapter.ts
+++ b/src/lib/list/list-item/list-item-adapter.ts
@@ -26,7 +26,7 @@ export interface IListItemAdapter extends IBaseAdapter {
   setDense(dense: boolean): void;
   setIndented(indented: boolean): void;
   setWrap(value: boolean): void;
-  trySelect(value: unknown): void;
+  trySelect(value: unknown): boolean;
 }
 
 export class ListItemAdapter extends BaseAdapter<IListItemComponent> implements IListItemAdapter {
@@ -203,15 +203,25 @@ export class ListItemAdapter extends BaseAdapter<IListItemComponent> implements 
     toggleClass(this._listItemElement, value, LIST_ITEM_CONSTANTS.classes.WRAP);
   }
 
-  public trySelect(value: unknown): void {
+  /**
+   * Attempts to set the selected state of the list item element and it's visual indicators
+   * @param value The value to compare to the parent list element's selected value
+   * @returns Returns whether the list item is selected or not
+   */
+  public trySelect(value: unknown): boolean {
     const list = requireParent<IListComponent>(this._component, LIST_CONSTANTS.elementName);
     if (!list || list.selectedValue === undefined) {
-      return;
+      return false;
     }
 
     const listValues = list.selectedValue instanceof Array ? list.selectedValue : [list.selectedValue];
     if (listValues.some(v => isDeepEqual(v, value))) {
       this.setSelected(true);
+      this.tryToggleCheckboxRadio(true);
+      return true;
+    } else {
+      this.tryToggleCheckboxRadio(false);
+      return false;
     }
   }
 }

--- a/src/lib/list/list-item/list-item-foundation.ts
+++ b/src/lib/list/list-item/list-item-foundation.ts
@@ -69,7 +69,10 @@ export class ListItemFoundation implements IListItemFoundation {
       this._adapter.setTwoLine(this._twoLine);
     }
 
-    this._selected = this._adapter.trySelect(this._value);
+    const isSelected = this._adapter.trySelect(this._value);
+    if(isSelected != null) {
+      this._selected = isSelected;
+    }
   }
 
   public disconnect(): void {
@@ -252,7 +255,10 @@ export class ListItemFoundation implements IListItemFoundation {
   }
   public set value(value: any) {
     this._value = value;
-    this._selected = this._adapter.trySelect(this._value);
+    const isSelected = this._adapter.trySelect(this._value);
+    if(isSelected != null) {
+      this._selected = isSelected;
+    }
   }
 
   /** Gets/sets the href link that this list item will send the browser to when clicked. */

--- a/src/lib/list/list-item/list-item-foundation.ts
+++ b/src/lib/list/list-item/list-item-foundation.ts
@@ -69,7 +69,7 @@ export class ListItemFoundation implements IListItemFoundation {
       this._adapter.setTwoLine(this._twoLine);
     }
 
-    this._adapter.trySelect(this._value);
+    this._selected = this._adapter.trySelect(this._value);
   }
 
   public disconnect(): void {
@@ -252,7 +252,7 @@ export class ListItemFoundation implements IListItemFoundation {
   }
   public set value(value: any) {
     this._value = value;
-    this._adapter.trySelect(this._value);
+    this._selected = this._adapter.trySelect(this._value);
   }
 
   /** Gets/sets the href link that this list item will send the browser to when clicked. */

--- a/src/lib/list/list-item/list-item.ts
+++ b/src/lib/list/list-item/list-item.ts
@@ -73,7 +73,7 @@ export class ListItemComponent extends BaseComponent implements IListItemCompone
     this._foundation = new ListItemFoundation(new ListItemAdapter(this));
   }
 
-  public initializedCallback(): void {
+  public connectedCallback(): void {
     // To simulate the :host-context() selector for Firefox until they implement it, we need to determine if the
     // list item is within a drawer for auto-styling the list item when included within a drawer. Check to see if
     // any of the parents of this element are a drawer.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: [Y]
- Docs have been added / updated: [N]
- Does this PR introduce a breaking change? [N]
- I have linked any related GitHub issues to be closed when this PR is merged? [N]

## Describe the new behavior?
The `forge-list-item` component will now properly toggle it's child checkbox component on initialization if the parent `forge-list` has an initial `selectedValue` provided. It does this by attempting to call the tryToggleCheckboxRadio when trySelect is called.

## Additional information
The `forge-list-item` component was not updating it's child checkbox state when Angular application was databinding the `selectedValue` and a `forge-list` component and it's `forge-list-item` components were dynamically rendered in a ngFor.