### PR TITLE
perf(list-item): delay ripple creation

### DIFF
--- a/src/lib/list/list-item/list-item-adapter.ts
+++ b/src/lib/list/list-item/list-item-adapter.ts
@@ -1,5 +1,6 @@
 import { addClass, getShadowElement, removeClass, requireParent, isDeepEqual, toggleClass } from '@tylertech/forge-core';
 import { BaseAdapter, IBaseAdapter } from '../../core/base/base-adapter';
+import { userInteractionListener } from '../../core/utils';
 import { IListComponent } from '../list/list';
 import { LIST_CONSTANTS } from '../list/list-constants';
 import { IListItemComponent } from './list-item';
@@ -27,6 +28,7 @@ export interface IListItemAdapter extends IBaseAdapter {
   setIndented(indented: boolean): void;
   setWrap(value: boolean): void;
   trySelect(value: unknown): boolean | null;
+  userInteractionListener(): ReturnType<typeof userInteractionListener>;
 }
 
 export class ListItemAdapter extends BaseAdapter<IListItemComponent> implements IListItemAdapter {
@@ -220,5 +222,9 @@ export class ListItemAdapter extends BaseAdapter<IListItemComponent> implements 
     this.setSelected(isSelected);
     this.tryToggleCheckboxRadio(isSelected);
     return isSelected;
+  }
+
+  public userInteractionListener(): ReturnType<typeof userInteractionListener> {
+    return userInteractionListener(this._listItemElement);
   }
 }

--- a/src/lib/list/list-item/list-item-foundation.ts
+++ b/src/lib/list/list-item/list-item-foundation.ts
@@ -342,9 +342,16 @@ export class ListItemFoundation implements IListItemFoundation {
     }
   }
 
-  private _setRipple(): void {
+  private async _setRipple(): Promise<void> {
     if (this._ripple && !this._static && !this._rippleInstance) {
-      this._rippleInstance = this._adapter.createRipple();
+      const type = await this._adapter.userInteractionListener();
+      if (this._ripple && !this._static && !this._rippleInstance) { // need to re-check after await
+        this._rippleInstance = this._adapter.createRipple();
+        if (type === 'focusin') {
+          // eslint-disable-next-line @typescript-eslint/dot-notation
+          (this._rippleInstance as ForgeRipple)['foundation'].handleFocus();
+        }
+      }
     } else if ((!this._ripple || this._static) && this._rippleInstance) {
       this._rippleInstance.destroy();
       this._rippleInstance = undefined as any;

--- a/src/test/spec/list/list-item/list-item.spec.ts
+++ b/src/test/spec/list/list-item/list-item.spec.ts
@@ -1,5 +1,5 @@
 import { getShadowElement, removeElement, getActiveElement } from '@tylertech/forge-core';
-import { tick } from '@tylertech/forge-testing';
+import { tick, timer } from '@tylertech/forge-testing';
 import { CHECKBOX_CONSTANTS, ICheckboxComponent } from '@tylertech/forge/checkbox';
 import { DRAWER_CONSTANTS, IDrawerComponent } from '@tylertech/forge/drawer';
 import { defineListComponent, IListComponent, LIST_CONSTANTS } from '@tylertech/forge/list';
@@ -16,6 +16,8 @@ interface ITestListItemDefaultContext {
   getRootElement(): HTMLElement;
   append(): void;
   destroy(): void;
+  /** Simulates a user interaction with the button to instantiate the ripple */
+  simulateInteraction(): Promise<void>; 
 }
 
 interface ITestListItemDrawerContext {
@@ -88,11 +90,13 @@ describe('ListItemComponent', function(this: ITestContext) {
       expect((this.context as ITestListItemDefaultContext).getRootElement().classList.contains(LIST_ITEM_CONSTANTS.classes.ACTIVE)).toBe(false);
     });
 
-    it('should use ripple by default', async function(this: ITestContext) {
+    it('should use ripple by default, but delay initialization until user interaction', async function(this: ITestContext) {
       this.context = setupTestContext(true);
-      await tick();
-      expect(this.context.component.ripple).toBe(true);
-      expect((this.context as ITestListItemDefaultContext).getRootElement().classList.contains('mdc-ripple-upgraded')).toBe(true);
+      const context = this.context as ITestListItemDefaultContext ;
+      expect(context.component.ripple).withContext('ripple property').toBe(true);
+      expect(context.getRootElement().classList.contains('mdc-ripple-upgraded')).withContext('ripple before interaction').toBe(false);
+      await context.simulateInteraction();
+      expect(context.getRootElement().classList.contains('mdc-ripple-upgraded')).withContext('ripple after interaction').toBe(true);
     });
 
     it('should not be selected by default', function(this: ITestContext) {
@@ -569,7 +573,15 @@ describe('ListItemComponent', function(this: ITestContext) {
       component,
       getRootElement: () => getShadowElement(component, LIST_ITEM_CONSTANTS.selectors.LIST_ITEM),
       append: () => document.body.appendChild(fixture),
-      destroy: () => removeElement(fixture)
+      destroy: () => removeElement(fixture),
+      simulateInteraction: async () => {
+        const listItem = getShadowElement(component, LIST_ITEM_CONSTANTS.selectors.LIST_ITEM);
+        if (listItem) {
+          listItem.dispatchEvent(new Event('pointerenter'));
+          await timer();
+          await tick();
+        }
+      }
     };
   }
 


### PR DESCRIPTION
Fixes #230 

## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
A clear and concise description of the changes, including an breaking changes (if applicable)

## Additional information
Required a slight modification to the pattern used in #115 for icon-button because list-item has a `ripple` property that allows the ripple to be turned on and off.  I suspect it's an extreme edge case for this property to be set after initialization, but I think the logic should ensure a consistent state regardless.
