### PR TITLE
chore: separate temp storybook deployment from build-pr workflow

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -32,13 +32,9 @@ jobs:
             test:
               - 'src/lib/**'
               - 'src/test/**'
-            storybook:
-              - 'src/lib/**'
-              - 'src/stories/**'
     outputs:
       build-files-changed: ${{ steps.file-filter.outputs.build == 'true' }}
       test-files-changed: ${{ steps.file-filter.outputs.test == 'true' }}
-      deploy-storybook: ${{ steps.file-filter.outputs.storybook == 'true' }}
 
   build:
     name: Build and Test
@@ -49,20 +45,4 @@ jobs:
       BUILD_ENABLED: ${{ needs.wf-config.outputs.build-files-changed == 'true' }}
       TESTS_ENABLED: ${{ needs.wf-config.outputs.test-files-changed == 'true' }}
     secrets:
-      NPM_TOKEN: ${{ secrets.FORGE_NPM_TOKEN }}
-
-  deploy-storybook:
-    name: Deploy Storybook
-    needs: wf-config
-    uses: tyler-technologies-oss/forge-automation-shared/.github/workflows/wf-publish-gh-pages.yml@v2.8.1
-    if: ${{ github.event.pull_request.head.repo.fork == false && needs.wf-config.outputs.deploy-storybook == 'true' }}
-    with:
-      PRODUCTION_RELEASE: false
-      BUILD_DIRECTORY: dist/storybook
-      BUILD_TARGET_DIRECTORY: docs/pr/${{ github.event.pull_request.head.label }}
-      BUILD_NPM_SCRIPT: "ci:build-storybook"
-      PR_COMMENT_HEADER: "View Storybook Deployment"
-      PR_PATH: pr/${{ github.event.pull_request.head.label }}
-    secrets:
-      GITHUB_DEPLOY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NPM_TOKEN: ${{ secrets.FORGE_NPM_TOKEN }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -146,7 +146,6 @@ jobs:
       AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
       AWS_CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
 
-
   ## We run this job only when files that effect Storybook are found in the changed files
   deploy-storybook:
     name: Deploy Storybook

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -1,0 +1,37 @@
+name: Deploy Pull Request
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  wf-config:
+    name: Workflow Configuration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check File Changes
+        uses: dorny/paths-filter@v2
+        id: file-filter
+        with:
+          filters: |
+            storybook:
+              - 'src/lib/**'
+              - 'src/stories/**'
+    outputs:
+      deploy-storybook: ${{ steps.file-filter.outputs.storybook == 'true' }}
+
+  deploy-storybook:
+    name: Storybook
+    needs: wf-config
+    uses: tyler-technologies-oss/forge-automation-shared/.github/workflows/wf-publish-gh-pages.yml@v2.8.1
+    if: ${{ github.event.pull_request.head.repo.fork == false && needs.wf-config.outputs.deploy-storybook == 'true' && contains(github.event.pull_request.labels.*.name, 'storybook-preview') }}
+    with:
+      PRODUCTION_RELEASE: false
+      BUILD_DIRECTORY: dist/storybook
+      BUILD_TARGET_DIRECTORY: docs/pr/${{ github.event.pull_request.head.label }}
+      BUILD_NPM_SCRIPT: "ci:build-storybook"
+      PR_COMMENT_HEADER: "View Storybook Deployment"
+      PR_PATH: pr/${{ github.event.pull_request.head.label }}
+    secrets:
+      GITHUB_DEPLOY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NPM_TOKEN: ${{ secrets.FORGE_NPM_TOKEN }}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The PR build workflows have been altered to separate the temporary Storybook deployment from the `build-pr.yml` workflow. This is to allow us to opt-in to deploying a Storybook build for a PR via a label instead of having it happen automatically for every PR.

The reason for this is to allow for us to choose when we want to deploy Storybook for PRs in case it isn't necessary, or if we choose to use Codeflow or pull to local instead for testing.

## Additional information
The Storybook deployment will only be triggered when adding the `storybook-preview` label to the PR. This can happen before or after a PR is created (only if files changed affect Storybook).
