### PR TITLE
fix(expansion-panel): avoid nested buttons in header

### DIFF
--- a/src/dev/pages/expansion-panel/expansion-panel.ejs
+++ b/src/dev/pages/expansion-panel/expansion-panel.ejs
@@ -1,19 +1,36 @@
-<h3 class="forge-typography--subtitle1">Basic (unstyled)</h3>
-<forge-expansion-panel id="expansion-panel-basic">
-  <div slot="header">Click me</div>
-  <div>Expandable content</div>
+<h3 class="forge-typography--subtitle1">Manual</h3>
+<forge-button class="manual-toggle-button">
+  <button id="manual-toggle-button" type="button" aria-expanded="false" aria-controls="manual-panel-content">Toggle panel</button>
+</forge-button>
+<forge-expansion-panel id="expansion-panel-manual" type="manual">
+  <div slot="header">Expansion panel header</div>
+  <div id="manual-panel-content" role="group">Expandable content</div>
 </forge-expansion-panel>
 
-<h3 class="forge-typography--subtitle1">Card</h3>
+<h3 class="forge-typography--subtitle1">Button</h3>
 <forge-card class="expandable-card" outlined>
-  <forge-expansion-panel id="expansion-panel-card">
-    <div slot="header" role="button" class="flex expansion-panel-header">
-      <div class="forge-typography--body1">Click me too</div>
+  <forge-expansion-panel id="expansion-panel-button">
+    <div slot="header" class="flex expansion-panel-header">
+      <div class="forge-typography--body1">Click me</div>
       <forge-open-icon></forge-open-icon>
     </div>
     <div class="forge-typography--body1">
-      Expandable card content
+      Expandable content
     </div>
+  </forge-expansion-panel>
+</forge-card>
+
+<h3 class="forge-typography--subtitle1">Button with nested buttons</h3>
+<forge-card class="expandable-card" outlined>
+  <forge-expansion-panel id="expansion-panel-button-nested">
+    <div slot="header" class="flex expansion-panel-header">
+      <span>Click me too</span>
+      <forge-button forge-ignore>
+        <button type="button">Nested button</button>
+      </forge-button>
+      <forge-open-icon></forge-open-icon>
+    </div>
+    <div>Expandable content</div>
   </forge-expansion-panel>
 </forge-card>
 

--- a/src/dev/pages/expansion-panel/expansion-panel.scss
+++ b/src/dev/pages/expansion-panel/expansion-panel.scss
@@ -1,7 +1,12 @@
-.expandable-card {
-  --forge-card-padding: 16px;
+.manual-toggle-button {
+  margin-block-end: 16px;
+}
+
+forge-card:has(#expansion-panel-button, #expansion-panel-button-nested) {
+  --forge-card-padding: 0;
 }
 
 .expansion-panel-header {
+  width: 100%;
   justify-content: space-between;
 }

--- a/src/dev/pages/expansion-panel/expansion-panel.ts
+++ b/src/dev/pages/expansion-panel/expansion-panel.ts
@@ -5,11 +5,17 @@ import '@tylertech/forge/open-icon';
 import './expansion-panel.scss';
 import type { IExpansionPanelComponent, ISwitchComponent } from '@tylertech/forge';
 
-const basicExpansionPanel = document.querySelector('#expansion-panel-basic') as IExpansionPanelComponent;
-const cardExpansionPanel = document.querySelector('#expansion-panel-card') as IExpansionPanelComponent;
+const manualExpansionPanel = document.querySelector('#expansion-panel-manual') as IExpansionPanelComponent;
+const buttonExpansionPanel = document.querySelector('#expansion-panel-button') as IExpansionPanelComponent;
+const manualToggleButton = document.querySelector('#manual-toggle-button') as HTMLButtonElement;
 const useAnimationToggle = document.getElementById('opt-use-animations') as ISwitchComponent;
 
+manualToggleButton.addEventListener('click', () => {
+  manualExpansionPanel.toggle();
+  manualToggleButton.ariaExpanded = manualExpansionPanel.open.toString();
+});
+
 useAnimationToggle.addEventListener('forge-switch-select', ({ detail: selected }) => {
-  basicExpansionPanel.useAnimations = selected;
-  cardExpansionPanel.useAnimations = selected;
+  manualExpansionPanel.useAnimations = selected;
+  buttonExpansionPanel.useAnimations = selected;
 });

--- a/src/lib/expansion-panel/_mixins.scss
+++ b/src/lib/expansion-panel/_mixins.scss
@@ -2,6 +2,7 @@
 @use '@material/ripple/ripple' as mdc-ripple;
 @use '@material/ripple/ripple-theme' as mdc-ripple-theme;
 @use '../theme';
+@use '../utils/mixins' as utils;
 
 @mixin core-styles() {
   .forge-expansion-panel {
@@ -10,8 +11,8 @@
     &__header {
       @include header;
 
-      &:hover {
-        @include header-hover;
+      &--button {
+        @include header-button;
       }
       
       forge-open-icon {
@@ -22,6 +23,10 @@
     &__content {
       @include content;
     }
+
+    &__button {
+      @include button;
+    }
   }
 }
 
@@ -30,16 +35,27 @@
   @include theme.css-custom-property(height, --forge-expansion-panel-height, auto);
 }
 
-@mixin header() {
-  outline: none;
-}
+@mixin header() {}
 
-@mixin header-hover() {
+@mixin header-button() {
+  @include mdc-ripple.surface();
+  @include mdc-ripple.radius-bounded();
+  @include mdc-ripple-theme.states(text-hint-on-background, true);
+
+  display: flex;
+  align-items: center;
+  padding: 16px;
+  overflow: hidden;
+  font-size: 1rem;
   cursor: pointer;
 }
 
 @mixin header-icon() {
   margin-left: auto;
+}
+
+@mixin button {
+  @include utils.visually-hidden();
 }
 
 @mixin content() {
@@ -51,7 +67,7 @@
 @mixin slotted-button() {
   @include mdc-ripple.surface();
   @include mdc-ripple.radius-bounded();
-  @include mdc-ripple-theme.states(text-hint-on-background, false);
+  @include mdc-ripple-theme.states(text-hint-on-background, true);
   @include mdc-theme.property(color, text-primary-on-background);
 
   display: flex;
@@ -79,4 +95,8 @@
   border-top-width: 1px;
   border-top-style: solid;
   padding: 16px;
+}
+
+@mixin toggle {
+  @include utils.visually-hidden();
 }

--- a/src/lib/expansion-panel/expansion-panel-constants.ts
+++ b/src/lib/expansion-panel/expansion-panel-constants.ts
@@ -6,7 +6,13 @@ const elementName: keyof HTMLElementTagNameMap = `${COMPONENT_NAME_PREFIX}expans
 const classes = {
   CONTAINER: 'forge-expansion-panel',
   HEADER: 'forge-expansion-panel__header',
-  CONTENT: 'forge-expansion-panel__content'
+  HEADER_BUTTON: 'forge-expansion-panel__header--button',
+  CONTENT: 'forge-expansion-panel__content',
+  BUTTON: 'forge-expansion-panel__button'
+};
+
+const ids = {
+  CONTENT: 'content'
 };
 
 const selectors = {
@@ -14,7 +20,9 @@ const selectors = {
   HEADER: `.${classes.HEADER}`,
   CONTENT: `.${classes.CONTENT}`,
   HEADER_SLOT: `.${classes.HEADER} > slot[name=header]`,
-  OPEN_ICON: `[slot=header] ${OPEN_ICON_CONSTANTS.elementName}`
+  OPEN_ICON: `[slot=header] ${OPEN_ICON_CONSTANTS.elementName}`,
+  BUTTON: `.${classes.BUTTON}`,
+  IGNORE: `[forge-ignore]`
 };
 
 const events = {
@@ -24,7 +32,9 @@ const events = {
 const attributes = {
   OPEN: 'open',
   ORIENTATION: 'orientation',
-  USE_ANIMATIONS: 'use-animations'
+  USE_ANIMATIONS: 'use-animations',
+  TYPE: 'type',
+  ACCESSIBLE_LABEL: 'accessible-label'
 };
 
 const numbers = {
@@ -42,9 +52,12 @@ const strings = {
 export const EXPANSION_PANEL_CONSTANTS = {
   elementName,
   classes,
+  ids,
   selectors,
   events,
   attributes,
   numbers,
   strings
 };
+
+export type ExpansionPanelType = 'button' | 'manual';

--- a/src/lib/expansion-panel/expansion-panel-utils.ts
+++ b/src/lib/expansion-panel/expansion-panel-utils.ts
@@ -1,0 +1,17 @@
+import { getEventPath } from '@tylertech/forge-core';
+import { EXPANSION_PANEL_CONSTANTS } from './expansion-panel-constants';
+
+export function eventPathIncludesIgnoredElement(evt: Event): boolean {
+  const path = getEventPath(evt);
+  return path.some(p => p.matches?.(EXPANSION_PANEL_CONSTANTS.selectors.IGNORE));
+}
+
+export function createButtonElement(expanded: boolean): HTMLButtonElement {
+  const el = document.createElement('button');
+  el.classList.add(EXPANSION_PANEL_CONSTANTS.classes.BUTTON);
+  el.setAttribute('type', 'button');
+  el.setAttribute('part', 'button');
+  el.setAttribute('aria-controls', EXPANSION_PANEL_CONSTANTS.ids.CONTENT);
+  el.setAttribute('aria-expanded', expanded.toString());
+  return el;
+}

--- a/src/lib/expansion-panel/expansion-panel.html
+++ b/src/lib/expansion-panel/expansion-panel.html
@@ -1,6 +1,6 @@
 <template>
   <div class="forge-expansion-panel" part="root">
-    <div class="forge-expansion-panel__header" role="button" aria-controls="content" aria-expanded="false" part="header">
+    <div class="forge-expansion-panel__header" part="header">
       <slot name="header"></slot>
     </div>
     <div id="content" role="group" class="forge-expansion-panel__content" style="height: 0; opacity: 0; visibility: hidden;" part="content">

--- a/src/lib/expansion-panel/expansion-panel.ts
+++ b/src/lib/expansion-panel/expansion-panel.ts
@@ -1,7 +1,7 @@
 import { attachShadowTemplate, coerceBoolean, CustomElement, FoundationProperty } from '@tylertech/forge-core';
 import { BaseComponent, IBaseComponent } from '../core/base/base-component';
 import { ExpansionPanelAdapter } from './expansion-panel-adapter';
-import { EXPANSION_PANEL_CONSTANTS } from './expansion-panel-constants';
+import { ExpansionPanelType, EXPANSION_PANEL_CONSTANTS } from './expansion-panel-constants';
 import { ExpansionPanelFoundation } from './expansion-panel-foundation';
 
 import template from './expansion-panel.html';
@@ -9,10 +9,12 @@ import styles from './expansion-panel.scss';
 
 export interface IExpansionPanelComponent extends IBaseComponent {
   open: boolean;
-  useAnimations: boolean;
   openCallback: () => void | Promise<void>;
   closeCallback: () => void | Promise<void>;
+  useAnimations: boolean;
   orientation: string;
+  type: ExpansionPanelType;
+  accessibleLabel: string;
   toggle(): void;
   setOpenImmediate(open: boolean): void;
 }
@@ -40,7 +42,9 @@ export class ExpansionPanelComponent extends BaseComponent implements IExpansion
     return [
       EXPANSION_PANEL_CONSTANTS.attributes.OPEN,
       EXPANSION_PANEL_CONSTANTS.attributes.ORIENTATION,
-      EXPANSION_PANEL_CONSTANTS.attributes.USE_ANIMATIONS
+      EXPANSION_PANEL_CONSTANTS.attributes.USE_ANIMATIONS,
+      EXPANSION_PANEL_CONSTANTS.attributes.TYPE,
+      EXPANSION_PANEL_CONSTANTS.attributes.ACCESSIBLE_LABEL
     ];
   }
 
@@ -70,6 +74,12 @@ export class ExpansionPanelComponent extends BaseComponent implements IExpansion
         break;
       case EXPANSION_PANEL_CONSTANTS.attributes.USE_ANIMATIONS:
         this.useAnimations = coerceBoolean(newValue);
+        break;
+      case EXPANSION_PANEL_CONSTANTS.attributes.TYPE:
+        this.type = newValue as ExpansionPanelType;
+        break;
+      case EXPANSION_PANEL_CONSTANTS.attributes.ACCESSIBLE_LABEL:
+        this.accessibleLabel = newValue;
         break;
     }
   }
@@ -108,6 +118,14 @@ export class ExpansionPanelComponent extends BaseComponent implements IExpansion
   /** Gets/sets if animations are used in the expand/collapse transition. */
   @FoundationProperty()
   public declare useAnimations: boolean;
+
+  /** Sets whether an internal button and associated interactions are attached. */
+  @FoundationProperty()
+  public declare type: ExpansionPanelType;
+
+  /** Gets/sets the internal toggle button's label. */
+  @FoundationProperty()
+  public declare accessibleLabel: string;
 
   /** Toggles the collapsed state. */
   public toggle(): void {

--- a/src/lib/expansion-panel/forge-expansion-panel.scss
+++ b/src/lib/expansion-panel/forge-expansion-panel.scss
@@ -1,10 +1,6 @@
 @use './mixins';
 
 .forge-expansion-panel {
-  &__button {
-    @include mixins.slotted-button;
-  }
-
   &__content {
     @include mixins.slotted-content;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? Y
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Fixes #247 

The button role and related ARIA attributes have been removed from the expansion panel header itself and a visually hidden button is appended to the end of the header. The click listener remains on the header so a click anywhere still toggles the panel, but accessibility and keyboard interactions are handled by the button.

For added flexibility a `type` property has also been added. When set to `'button'` the new button is added along with the click listener and accessibility attributes. When set to `'manual'` the expansion panel is not directly interactive and doesn't handle accessibility at all, to enable programmatic toggling through external UI elements.

## Additional information
This also fixes an issue in Safari where mousing over a panel header doesn't set the correct cursor until it's clicked.
