### PR TITLE
feat(app-bar-notification-button): allow icon to be set to a user specificied icon

### DIFF
--- a/src/lib/app-bar/notification-button/app-bar-notification-button-adapter.ts
+++ b/src/lib/app-bar/notification-button/app-bar-notification-button-adapter.ts
@@ -2,9 +2,11 @@ import { getLightElement, toggleAttribute } from '@tylertech/forge-core';
 import { BADGE_CONSTANTS, IBadgeComponent } from '../../badge';
 import { BaseAdapter, IBaseAdapter } from '../../core/base/base-adapter';
 import { IAppBarNotificationButtonComponent } from './app-bar-notification-button';
+import { ICON_CONSTANTS, IIconComponent } from '../../icon';
 
 export interface IAppBarNotificationButtonAdapter extends IBaseAdapter {
   initialize(): void;
+  setIcon(icon: string): void;
   setCount(value: number): void;
   setBadgeType(dot: boolean): void;
   setBadgeTheme(theme: string): void;
@@ -13,13 +15,19 @@ export interface IAppBarNotificationButtonAdapter extends IBaseAdapter {
 
 export class AppBarNotificationButtonAdapter extends BaseAdapter<IAppBarNotificationButtonComponent> implements IAppBarNotificationButtonAdapter {
   private _badgeElement: IBadgeComponent;
+  private _iconElement: IIconComponent;
 
   constructor(component: IAppBarNotificationButtonComponent) {
     super(component);
   }
 
+  public setIcon(icon: string): void {
+    this._iconElement.setAttribute('name', icon);
+  }
+
   public initialize(): void {
     this._badgeElement = getLightElement(this._component, BADGE_CONSTANTS.elementName) as IBadgeComponent;
+    this._iconElement = getLightElement(this._component, ICON_CONSTANTS.elementName) as IIconComponent;
   }
 
   public setCount(value: number): void {

--- a/src/lib/app-bar/notification-button/app-bar-notification-button-adapter.ts
+++ b/src/lib/app-bar/notification-button/app-bar-notification-button-adapter.ts
@@ -22,7 +22,7 @@ export class AppBarNotificationButtonAdapter extends BaseAdapter<IAppBarNotifica
   }
 
   public setIcon(icon: string): void {
-    this._iconElement.setAttribute('name', icon);
+    this._iconElement.name = icon;
   }
 
   public initialize(): void {

--- a/src/lib/app-bar/notification-button/app-bar-notification-button-constants.ts
+++ b/src/lib/app-bar/notification-button/app-bar-notification-button-constants.ts
@@ -6,7 +6,8 @@ const attributes = {
   COUNT: 'count',
   DOT: 'dot',
   THEME: 'theme',
-  SHOW_BADGE: 'show-badge'
+  SHOW_BADGE: 'show-badge',
+  ICON: 'icon'
 };
 
 export const APP_BAR_NOTIFICATION_BUTTON_CONSTANTS = {

--- a/src/lib/app-bar/notification-button/app-bar-notification-button-foundation.ts
+++ b/src/lib/app-bar/notification-button/app-bar-notification-button-foundation.ts
@@ -7,6 +7,7 @@ export interface IAppBarNotificationButtonFoundation extends ICustomElementFound
   dot: boolean;
   theme: string;
   showBadge: boolean;
+  icon: string;
 }
 
 export class AppBarNotificationButtonFoundation implements IAppBarNotificationButtonFoundation {
@@ -15,6 +16,7 @@ export class AppBarNotificationButtonFoundation implements IAppBarNotificationBu
   private _theme: string;
   private _showBadge = false;
   private _isInitialized = false;
+  private _icon = 'notifications';
 
   constructor(private _adapter: IAppBarNotificationButtonAdapter) {}
 
@@ -24,11 +26,25 @@ export class AppBarNotificationButtonFoundation implements IAppBarNotificationBu
     this._adapter.setBadgeType(this._dot);
     this._adapter.setBadgeTheme(this._theme);
     this._adapter.setBadgeVisible(this._showBadge);
+    this._adapter.setIcon(this._icon);
     this._isInitialized = true;
   }
 
   public disconnect(): void {
     this._isInitialized = false;
+  }
+
+  public get icon(): string {
+    return this._icon;
+  }
+  public set icon(value: string) {
+    if (this._icon !== value) {
+      this._icon = value;
+      if (this._isInitialized) {
+        this._adapter.setIcon(this._icon);
+        this._adapter.setHostAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.ICON, this._icon);
+      }
+    }
   }
 
   public get count(): number {

--- a/src/lib/app-bar/notification-button/app-bar-notification-button.html
+++ b/src/lib/app-bar/notification-button/app-bar-notification-button.html
@@ -1,7 +1,7 @@
 <template>
   <forge-icon-button class="forge-icon-button--with-badge">
     <button type="button" aria-label="Show notifications">
-      <forge-icon name="notifications"></forge-icon>
+      <forge-icon></forge-icon>
     </button>
     <forge-tooltip delay="500" position="bottom">Notifications</forge-tooltip>
     <forge-badge positioned app-bar-context></forge-badge>

--- a/src/lib/app-bar/notification-button/app-bar-notification-button.ts
+++ b/src/lib/app-bar/notification-button/app-bar-notification-button.ts
@@ -22,6 +22,7 @@ export interface IAppBarNotificationButtonComponent extends IBaseComponent {
   dot: boolean;
   showBadge: boolean;
   theme: string;
+  icon: string;
 }
 /**
  * The web component class behind the `<forge-app-bar-notification-button>` custom element.
@@ -43,7 +44,8 @@ export class AppBarNotificationButtonComponent extends BaseComponent implements 
       APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.COUNT,
       APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.DOT,
       APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.THEME,
-      APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.SHOW_BADGE
+      APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.SHOW_BADGE,
+      APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.ICON
     ];
   }
 
@@ -74,6 +76,9 @@ export class AppBarNotificationButtonComponent extends BaseComponent implements 
       case APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.THEME:
         this.theme = newValue;
         break;
+      case APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.ICON:
+        this.icon = newValue;
+        break;
       case APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.SHOW_BADGE:
         this.showBadge = coerceBoolean(newValue);
         break;
@@ -88,6 +93,9 @@ export class AppBarNotificationButtonComponent extends BaseComponent implements 
 
   @FoundationProperty()
   public declare theme: string;
+
+  @FoundationProperty()
+  public declare icon: string;
 
   @FoundationProperty()
   public declare showBadge: boolean;

--- a/src/stories/src/components/app-bar-notifications/app-bar-notifications-args.ts
+++ b/src/stories/src/components/app-bar-notifications/app-bar-notifications-args.ts
@@ -3,6 +3,7 @@ export interface IAppBarNotificationsProps {
   dot: boolean;
   showBadge: boolean;
   theme: string;
+  icon: string;
 }
 
 export const argTypes = {
@@ -22,6 +23,21 @@ export const argTypes = {
   },
   showBadge: {
     control: 'boolean',
+    description: '',
+    table: {
+      category: 'Properties',
+    },
+  },
+  icon: {
+    control: {
+      type: 'select',
+      labels: {
+        'notifications': 'Notifications (Default)',
+        'email': 'Emails',
+        'connection': 'Connections'
+      },
+    },
+    options: ['notifications', 'email', 'connection'],
     description: '',
     table: {
       category: 'Properties',

--- a/src/stories/src/components/app-bar-notifications/app-bar-notifications.mdx
+++ b/src/stories/src/components/app-bar-notifications/app-bar-notifications.mdx
@@ -61,6 +61,12 @@ The notification button provides a consistent icon, as well as options to contro
 
 </PropertyDef>
 
+<PropertyDef name="icon" type="string" defaultValue="'notifications'">
+
+Gets/sets the icon of the notification button
+
+</PropertyDef>
+
 </PageSection>
 
 ---

--- a/src/stories/src/components/app-bar-notifications/app-bar-notifications.stories.tsx
+++ b/src/stories/src/components/app-bar-notifications/app-bar-notifications.stories.tsx
@@ -4,6 +4,8 @@ import { Story } from '@storybook/react';
 import { IconRegistry } from '@tylertech/forge';
 import { ForgeAppBar, ForgeAppBarNotificationButton, ForgeIcon } from '@tylertech/forge-react';
 import { tylIconForgeLogo } from '@tylertech/tyler-icons/custom';
+import { tylIconEmail } from '@tylertech/tyler-icons/standard'
+import { tylIconConnection } from '@tylertech/tyler-icons/extended'
 import React, { useEffect } from 'react';
 
 const MDX = require('./app-bar-notifications.mdx').default;
@@ -22,10 +24,11 @@ export const Default: Story<IAppBarNotificationsProps> = ({
   count = 1,
   dot = true,
   showBadge = true,
-  theme = 'default'
+  theme = 'default',
+  icon = 'notifications'
 }) => {
   useEffect(() => {
-    IconRegistry.define(tylIconForgeLogo);
+    IconRegistry.define([tylIconForgeLogo, tylIconEmail, tylIconConnection]);
   }, []);
 
   if (theme === 'default') {
@@ -40,7 +43,9 @@ export const Default: Story<IAppBarNotificationsProps> = ({
         count={count}
         dot={dot}
         showBadge={showBadge}
-        theme={theme}></ForgeAppBarNotificationButton>
+        theme={theme}
+        icon={icon}
+    ></ForgeAppBarNotificationButton>
     </ForgeAppBar>
   );
 };
@@ -48,5 +53,6 @@ Default.args = {
   count: 1,
   dot: true,
   showBadge: true,
-  theme: 'default'
+  theme: 'default',
+  icon: 'notifications'
 } as IAppBarNotificationsProps;

--- a/src/test/spec/app-bar/notification-button/app-bar-notification-button.spec.ts
+++ b/src/test/spec/app-bar/notification-button/app-bar-notification-button.spec.ts
@@ -108,6 +108,16 @@ describe('AppBarNotificationButtonComponent', function(this: ITestContext) {
     });
   });
 
+  describe('icon', function (this: ITestContext) {
+    it('should change icon when set via property', function (this: ITestContext) {
+      this.context = setupTestContext();
+      const icon = 'connection';
+      this.context.component.icon = icon;
+      expect(this.context.component.icon).toBe(icon, `Component property icon value should be set to: ${icon}`);
+      expect(this.context.component.getAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.ICON)).toBe(icon, `Component attribute icon value should be set to: ${icon}`);
+    });
+  });
+
   describe('showBadge', function(this: ITestContext) {
     it('should default showBadge property and attribute to false', function(this: ITestContext) {
       this.context = setupTestContext();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: [Y]
- Docs have been added / updated: [Y]
- Does this PR introduce a breaking change? [N]
- I have linked any related GitHub issues to be closed when this PR is merged? [Y]

## Describe the new behavior?
Changes the app-bar-notification-button to allow a consuming developer to specify an alternative icon to the default.

## Additional information
Add any other context about the change here.
