### PR TITLE
fix(autocomplete): always define the `arrow_drop_down` icon

### DIFF
--- a/src/dev/pages/autocomplete/autocomplete.ts
+++ b/src/dev/pages/autocomplete/autocomplete.ts
@@ -8,13 +8,12 @@ import '@tylertech/forge/label-value';
 
 // Icons
 import type { AutocompleteFilterCallback, IAutocompleteComponent, IListItemComponent, ISelectComponent } from '@tylertech/forge';
-import { IconRegistry, IOption, IOptionGroup } from '@tylertech/forge';
+import { IOption, IOptionGroup, IconRegistry } from '@tylertech/forge';
 import { IListDropdownOption, IListDropdownOptionGroup } from '@tylertech/forge/list-dropdown';
-import { tylIconArrowDropDown, tylIconClose } from '@tylertech/tyler-icons/standard';
+import { tylIconClose } from '@tylertech/tyler-icons/standard';
 import { randomTimeout } from '../../src/utils/utils';
 
 IconRegistry.define([
-  tylIconArrowDropDown,
   tylIconClose
 ]);
 

--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -1,5 +1,5 @@
 import { attachShadowTemplate, coerceBoolean, coerceNumber, CustomElement, ensureChild, FoundationProperty } from '@tylertech/forge-core';
-import { tylIconCheckBox, tylIconCheckBoxOutlineBlank } from '@tylertech/tyler-icons/standard';
+import { tylIconArrowDropDown, tylIconCheckBox, tylIconCheckBoxOutlineBlank } from '@tylertech/tyler-icons/standard';
 import { DividerComponent } from '../divider';
 import { IconComponent, IconRegistry } from '../icon';
 import { LinearProgressComponent } from '../linear-progress';
@@ -90,7 +90,7 @@ export class AutocompleteComponent extends ListDropdownAware implements IAutocom
 
   constructor() {
     super();
-    IconRegistry.define([tylIconCheckBox, tylIconCheckBoxOutlineBlank]);
+    IconRegistry.define([tylIconArrowDropDown, tylIconCheckBox, tylIconCheckBoxOutlineBlank]);
     attachShadowTemplate(this, template, styles);
     this._foundation = new AutocompleteFoundation(new AutocompleteAdapter(this));
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The autocomplete component will now auto-define the `arrow_drop_down` icon that is commonly used with this component for convenience.

## Additional information
Fixes #217 
