### PR TITLE
fix(select): accessibility improvements

### DIFF
--- a/src/dev/pages/select/select.ejs
+++ b/src/dev/pages/select/select.ejs
@@ -22,7 +22,7 @@
   <h4>Select dropdown</h4>
   <forge-button type="raised">
     <button type="button" style="width: 256px;" id="select-dropdown-target" aria-label="Choose an option">
-      <span id="select-dropdown-text">Choose...</span>
+      <span id="select-dropdown-text" aria-live="assertive" aria-atomic="true">Choose...</span>
       <forge-icon name="arrow_drop_down"></forge-icon>
     </button>
   </forge-button>

--- a/src/lib/select/core/base-select-foundation.ts
+++ b/src/lib/select/core/base-select-foundation.ts
@@ -429,7 +429,7 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
     } else if (isArrowUp || isArrowDown) {
       evt.preventDefault();
 
-      if (this._multiple && !this._open) {
+      if (!this._open) {
         this._openDropdown();
         this._adapter.activateFirstOption();
         return;
@@ -455,12 +455,7 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
         optionIndex = this._getNextHighlightableOptionIndex(optionIndex, this._nonDividerOptions);
       }
 
-      // If the dropdown is open then we just move the active index, otherwise we change the selection (to mimic the native <select>)
-      if (this._open) {
-        this._adapter.highlightActiveOption(optionIndex);
-      } else {
-        this._onSelect(this._nonDividerOptions[optionIndex], optionIndex);
-      }
+      this._adapter.highlightActiveOption(optionIndex);
     } else if (isHomeKey) {
       if (this._open) {
         evt.preventDefault();

--- a/src/lib/select/select/select.html
+++ b/src/lib/select/select/select.html
@@ -5,7 +5,7 @@
         <slot name="leading"></slot>
       </div>
       <div class="forge-field__label-input-container" part="label-input-container">
-        <div id="selected-text" class="forge-select__selected-text" part="text"></div>
+        <div id="selected-text" class="forge-select__selected-text" part="text" aria-live="assertive" aria-atomic="true"></div>
         <label id="select-label" aria-hidden="true" part="label"></label>
       </div>
       <forge-icon class="forge-select__dropdown-icon" name="arrow_drop_down" part="icon"></forge-icon>

--- a/src/test/spec/select/select.spec.ts
+++ b/src/test/spec/select/select.spec.ts
@@ -867,24 +867,28 @@ describe('SelectComponent', function(this: ITestContext) {
       expect(this.context.foundation['_filterTimeout']).toBeUndefined();
     });
 
-    it('should select next item if arrow down key is pressed while popup is closed', async function(this: ITestContext) {
+    it('should open popup if arrow down key is pressed while popup is closed', async function(this: ITestContext) {
       this.context = setupTestContext(true);
       await tick();
       
       dispatchKeyEvent(this.context.component, 'keydown', 'ArrowDown');
       await timer();
       
-      expect(this.context.component.value).toBe(DEFAULT_OPTIONS[0].value);
+      _expectPopupVisibility(this.context.component.popupElement, true);
+      expect(this.context.component.open).toBeTrue();
+      expect(this.context.component.value).toBeUndefined();
     });
 
-    it('should select previous item if arrow up key is pressed while popup is closed', async function(this: ITestContext) {
+    it('should open popup if arrow up key is pressed while popup is closed', async function(this: ITestContext) {
       this.context = setupTestContext(true);
       await tick();
       
       dispatchKeyEvent(this.context.component, 'keydown', 'ArrowUp');
       await timer();
       
-      expect(this.context.component.value).toBe(DEFAULT_OPTIONS[2].value);
+      _expectPopupVisibility(this.context.component.popupElement, true);
+      expect(this.context.component.open).toBeTrue();
+      expect(this.context.component.value).toBeUndefined();
     });
 
     it('should not select item if arrow key is pressed while popup is closed in multiple mode', async function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?

The `<forge-select>` was incorrectly cycling through options when pressing up and down arrow keys while the field is focused but the dropdown not open. The component should open the dropdown when these keys are pressed instead.

The component allows for typing characters while the `<forge-select>` is focused (to emulate the native `<select>` element), but it was not announcing the value text change to screen readers.

- The `<forge-select>` element will now open the dropdown when pressing the arrow up or arrow down keys.
- The `<forge-select>` element will now use an ARIA live region to announce changes to the value text internally.

Fixes #244 