### PR TITLE
fix(date-range-picker): allow for setting `value` to `null` to clear the component value

### DIFF
--- a/src/lib/date-picker/base/base-date-picker.ts
+++ b/src/lib/date-picker/base/base-date-picker.ts
@@ -6,7 +6,7 @@ import { BaseDatePickerFoundation } from './base-date-picker-foundation';
 import { IBaseDatePickerAdapter } from './base-date-picker-adapter';
 
 export interface IBaseDatePickerComponent<TValue> extends IBaseComponent {
-  value: TValue | undefined;
+  value: TValue | null | undefined;
   min: Date | string | null | undefined;
   max: Date | string | null | undefined;
   disabledDates: Date | Date[] | null | undefined;
@@ -98,7 +98,7 @@ export abstract class BaseDatePickerComponent<TPublicValue, TPrivateValue, TFoun
 
   /** Gets/sets the value of the component. */
   @FoundationProperty()
-  public declare value: TPublicValue | undefined;
+  public declare value: TPublicValue | null | undefined;
 
   /** Gets/sets the minimum date the calendar will allow. */
   @FoundationProperty()

--- a/src/lib/date-range-picker/date-range-picker-foundation.ts
+++ b/src/lib/date-range-picker/date-range-picker-foundation.ts
@@ -339,12 +339,12 @@ export class DateRangePickerFoundation extends BaseDatePickerFoundation<IDateRan
     }
   }
 
-  public get value(): IDatePickerRange {
+  public get value(): IDatePickerRange | null | undefined {
     return { from: this.from, to: this.to };
   }
-  public set value(value: IDatePickerRange) {
+  public set value(value: IDatePickerRange | null | undefined) {
     if (!value) {
-      return;
+      value = { from: null, to: null };
     }
 
     if (value.from === undefined) {

--- a/src/stories/src/components/date-range-picker/date-range-picker.mdx
+++ b/src/stories/src/components/date-range-picker/date-range-picker.mdx
@@ -277,27 +277,6 @@ type DatepickerPrepareMaskCallback = (value: string, masked: Masked<string>, fla
 type DatePickerValueMode = 'object' | 'string' | 'iso-string';
 ```
 
-### IDatePickerRangeCalendarDropdownConfig
-
-```ts expanded
-interface IDatePickerRangeCalendarDropdownConfig {
-  value: DateRange | null;
-  min: Date | null;
-  max: Date | null;
-  disabledDates: Date | Date[] | null;
-  popupClasses: string | string[];
-  closeCallback: () => void;
-  selectCallback: (value: ICalendarDateRangeSelectEvent) => void;
-  activeChangeCallback: (id: string) => void;
-  showToday: boolean;
-  showClear: boolean;
-  todayCallback: () => void;
-  clearCallback: () => void;
-  disableDayCallback: (date: Date) => boolean;
-  disabledDaysOfWeek: DayOfWeek[] | null;
-}
-```
-
 ### IDatePickerRange
 
 ```ts expanded

--- a/src/test/spec/date-range-picker/date-range-picker.spec.ts
+++ b/src/test/spec/date-range-picker/date-range-picker.spec.ts
@@ -603,6 +603,22 @@ describe('DateRangePickerComponent', function(this: ITestContext) {
       expect(getToElement(this.context.component).value).toBe('');
     });
 
+    it('should clear value when set to null', function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      this.context.component.valueMode = 'string';
+      
+      const from = '01/01/2000';
+      const to = '01/10/2000';
+      this.context.component.value = { from: new Date(from), to: new Date(to) };
+
+      expect(this.context.component.from).toBe(from);
+      expect(this.context.component.to).toBe(to);
+      
+      this.context.component.value = null;
+
+      expect(this.context.component.value).toEqual({ from: null, to: null } as any);
+    });
+
     it('should clear value when min date is set if current value is not valid on from input', function(this: ITestContext) {
       this.context = setupTestContext(true);
       const minDate = new Date('01/01/2020');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?

The date-range-picker will now accept `null`, `undefined`, or any other falsy value to "clear" the current value in the component.

Also, removed an internally used TypeScript interface from the public component API docs in Storybook.

Fixes #258 
