### PR TITLE
[list-item][select] allow list-item/option text to wrap

### DIFF
--- a/src/dev/pages/list/list.ejs
+++ b/src/dev/pages/list/list.ejs
@@ -11,6 +11,51 @@
     </div>
   </div>
 
+  <!-- Single-line long text -->
+  <div>
+    <h3 class="forge-typography--subtitle1">Single-Line (long text)</h3>
+    <div class="list-demo">
+      <forge-list>
+        <forge-list-item>Lorem ipsum dolor sit amet consectetur adipisicing elit. Dignissimos, libero nemo. Similique suscipit ipsam ab veritatis excepturi repellendus ipsa labore! Accusantium, sint ex. Illum architecto rerum, voluptates consectetur cum quaerat.</forge-list-item>
+        <forge-list-item>Lorem ipsum dolor sit amet consectetur adipisicing elit. Dignissimos, libero nemo. Similique suscipit ipsam ab veritatis excepturi repellendus ipsa labore! Accusantium, sint ex. Illum architecto rerum, voluptates consectetur cum quaerat.</forge-list-item>
+        <forge-list-item>Lorem ipsum dolor sit amet consectetur adipisicing elit. Dignissimos, libero nemo. Similique suscipit ipsam ab veritatis excepturi repellendus ipsa labore! Accusantium, sint ex. Illum architecto rerum, voluptates consectetur cum quaerat.</forge-list-item>
+      </forge-list>
+    </div>
+  </div>
+
+  <!-- Single-line long text w/wrap -->
+  <div>
+    <h3 class="forge-typography--subtitle1">Single-Line (long text w/wrap)</h3>
+    <div class="list-demo">
+      <forge-list>
+        <forge-list-item wrap>Lorem ipsum dolor sit amet consectetur adipisicing elit. Dignissimos, libero nemo. Similique suscipit ipsam ab veritatis excepturi repellendus ipsa labore! Accusantium, sint ex. Illum architecto rerum, voluptates consectetur cum quaerat.</forge-list-item>
+        <forge-list-item wrap>Lorem ipsum dolor sit amet consectetur adipisicing elit. Dignissimos, libero nemo. Similique suscipit ipsam ab veritatis excepturi repellendus ipsa labore! Accusantium, sint ex. Illum architecto rerum, voluptates consectetur cum quaerat.</forge-list-item>
+        <forge-list-item wrap>Lorem ipsum dolor sit amet consectetur adipisicing elit. Dignissimos, libero nemo. Similique suscipit ipsam ab veritatis excepturi repellendus ipsa labore! Accusantium, sint ex. Illum architecto rerum, voluptates consectetur cum quaerat.</forge-list-item>
+      </forge-list>
+    </div>
+  </div>
+
+  <!-- Two-line long text w/wrap -->
+  <div>
+    <h3 class="forge-typography--subtitle1">Two-Line (long text w/wrap)</h3>
+    <div class="list-demo">
+      <forge-list>
+        <forge-list-item two-line wrap>
+          <span slot="title">List Item</span>
+          <span slot="subtitle">Lorem ipsum dolor sit amet consectetur adipisicing elit. Dignissimos, libero nemo. Similique suscipit ipsam ab veritatis excepturi repellendus ipsa labore! Accusantium, sint ex. Illum architecto rerum, voluptates consectetur cum quaerat.</span>
+        </forge-list-item>
+        <forge-list-item two-line wrap>
+          <span slot="title">List Item</span>
+          <span slot="subtitle">Lorem ipsum dolor sit amet consectetur adipisicing elit. Dignissimos, libero nemo. Similique suscipit ipsam ab veritatis excepturi repellendus ipsa labore! Accusantium, sint ex. Illum architecto rerum, voluptates consectetur cum quaerat.</span>
+        </forge-list-item>
+        <forge-list-item two-line wrap>
+          <span slot="title">List Item</span>
+          <span slot="subtitle">Lorem ipsum dolor sit amet consectetur adipisicing elit. Dignissimos, libero nemo. Similique suscipit ipsam ab veritatis excepturi repellendus ipsa labore! Accusantium, sint ex. Illum architecto rerum, voluptates consectetur cum quaerat.</span>
+        </forge-list-item>
+      </forge-list>
+    </div>
+  </div>
+
   <!-- Single-line (dense) -->
   <div>
     <h3 class="forge-typography--subtitle1">Single-Line (dense)</h3>

--- a/src/lib/list-dropdown/list-dropdown-aware-foundation.ts
+++ b/src/lib/list-dropdown/list-dropdown-aware-foundation.ts
@@ -10,6 +10,8 @@ export interface IListDropdownAwareFoundation extends ICustomElementFoundation {
   optionLimit: number;
   observeScroll: boolean;
   observeScrollThreshold: number;
+  constrainPopupWidth: boolean;
+  wrapOptionText: boolean;
 }
 
 export abstract class ListDropdownAwareFoundation implements IListDropdownAwareFoundation {
@@ -20,6 +22,8 @@ export abstract class ListDropdownAwareFoundation implements IListDropdownAwareF
   protected _optionLimit = 0;
   protected _observeScroll = false;
   protected _observeScrollThreshold = 0;
+  protected _constrainPopupWidth = true;
+  protected _wrapOptionText = false;
 
   public get syncPopupWidth(): boolean {
     return this._syncPopupWidth;
@@ -73,6 +77,20 @@ export abstract class ListDropdownAwareFoundation implements IListDropdownAwareF
   }
   public set popupFooterBuilder(value: ListDropdownFooterBuilder) {
     this._popupFooterBuilder = value;
+  }
+
+  public get constrainPopupWidth(): boolean {
+    return this._constrainPopupWidth;
+  }
+  public set constrainPopupWidth(value: boolean) {
+    this._constrainPopupWidth = value;
+  }
+
+  public get wrapOptionText(): boolean {
+    return this._wrapOptionText;
+  }
+  public set wrapOptionText(value: boolean) {
+    this._wrapOptionText = value;
   }
 
   protected _applySelection(): void {}

--- a/src/lib/list-dropdown/list-dropdown-aware.ts
+++ b/src/lib/list-dropdown/list-dropdown-aware.ts
@@ -10,6 +10,8 @@ export interface IListDropdownAware extends IBaseComponent {
   optionLimit: number;
   observeScroll: boolean;
   observeScrollThreshold: number;
+  constrainPopupWidth: boolean;
+  wrapOptionText: boolean;
 }
 
 export class ListDropdownAware extends BaseComponent {
@@ -34,6 +36,12 @@ export class ListDropdownAware extends BaseComponent {
       case LIST_DROPDOWN_CONSTANTS.attributes.SYNC_POPUP_WIDTH:
         this.syncPopupWidth = coerceBoolean(newValue);
         break;
+      case LIST_DROPDOWN_CONSTANTS.attributes.CONSTRAIN_POPUP_WIDTH:
+        this.constrainPopupWidth = coerceBoolean(newValue);
+        break;
+      case LIST_DROPDOWN_CONSTANTS.attributes.WRAP_OPTION_TEXT:
+        this.wrapOptionText = coerceBoolean(newValue);
+        break;
     }
   }
   
@@ -41,11 +49,11 @@ export class ListDropdownAware extends BaseComponent {
   @FoundationProperty()
   public declare popupClasses: string | string[];
 
-  /** Gets/sets the list of classes to apply to the popup element. */
+  /** Gets/sets the callback function for generating header content within the popup. */
   @FoundationProperty()
   public declare popupHeaderBuilder: ListDropdownHeaderBuilder;
 
-  /** Gets/sets the list of classes to apply to the popup element. */
+  /** Gets/sets the callback function for generating header content within the popup. */
   @FoundationProperty()
   public declare popupFooterBuilder: ListDropdownFooterBuilder;
 
@@ -64,4 +72,15 @@ export class ListDropdownAware extends BaseComponent {
   /** The number of pixels from the bottom to trigger the scroll bottom event. Only applicable if `observeScroll` is true. */
   @FoundationProperty()
   public declare observeScrollThreshold: number;
+
+  /** Gets/sets whether the popup width will be constrained to a max width of the viewport width (default: `100vw`). */
+  @FoundationProperty()
+  public declare constrainPopupWidth: boolean;
+
+  /**
+   * Gets/sets whether the options will wrap their text or not.
+   * This only applies if `constrainPopupWidth` is `true`, if there is an explicit width set via CSS.
+   * */
+  @FoundationProperty()
+  public declare wrapOptionText: boolean;
 }

--- a/src/lib/list-dropdown/list-dropdown-constants.ts
+++ b/src/lib/list-dropdown/list-dropdown-constants.ts
@@ -6,6 +6,8 @@ const attributes = {
   OBSERVE_SCROLL: 'observe-scroll',
   OBSERVE_SCROLL_THRESHOLD: 'observe-scroll-threshold',
   SYNC_POPUP_WIDTH: 'sync-popup-width',
+  CONSTRAIN_POPUP_WIDTH: 'constrain-popup-width',
+  WRAP_OPTION_TEXT: 'wrap-option-text',
 
   // Internal
   CHECKBOX_ELEMENT: 'data-list-dropdown-checkbox',
@@ -68,6 +70,8 @@ export interface IListDropdownConfig<T = any> {
   activeChangeCallback?: (id: string) => void;
   closeCallback?: () => void;
   syncWidth?: boolean;
+  constrainViewportWidth?: boolean;
+  wrapOptionText?: boolean;
   selectedValues?: T[];
   multiple?: boolean;
   activeStartIndex?: number;

--- a/src/lib/list-dropdown/list-dropdown-utils.ts
+++ b/src/lib/list-dropdown/list-dropdown-utils.ts
@@ -56,11 +56,15 @@ export function createDropdown(config: IListDropdownOpenConfig, targetElement: H
 }
 
 export function createPopupDropdown(config: IListDropdownOpenConfig, targetElement: HTMLElement): IPopupComponent {
-  const popupElement = document.createElement(POPUP_CONSTANTS.elementName) as IPopupComponent;
+  const popupElement = document.createElement('forge-popup');
   popupElement.targetElement = targetElement;
   popupElement.placement = config.popupPlacement || 'bottom-start';
   popupElement.manageFocus = false;
   popupElement.static = !!config.popupStatic;
+
+  if (config.constrainViewportWidth) {
+    popupElement.setAttribute(POPUP_CONSTANTS.attributes.CONSTRAIN_VIEWPORT_WIDTH, '');
+  }
 
   if (config.popupOffset) {
     popupElement.offset = config.popupOffset;
@@ -151,11 +155,15 @@ export function createListItems(config: IListDropdownOpenConfig, listElement: IL
       
       // Create and configure the list element
       const isSelected = config.selectedValues ? config.selectedValues.some(v => isDeepEqual(v, option.value)) : false;
-      let listItemElement = document.createElement(LIST_ITEM_CONSTANTS.elementName) as IListItemComponent;
+      let listItemElement = document.createElement('forge-list-item');
       listItemElement.value = option.value;
       listItemElement.id = `list-dropdown-option-${config.id}-${optionIndex}`;
       listItemElement.style.cursor = 'pointer';
 
+      if (config.wrapOptionText) {
+        listItemElement.wrap = true;
+      }
+      
       // Add any CSS classes to the option list-item
       if (option.optionClass && (typeof option.optionClass === 'string' || Array.isArray(option.optionClass) && option.optionClass.length)) {
         addClass(option.optionClass, listItemElement);

--- a/src/lib/list/list-item/_mixins.scss
+++ b/src/lib/list/list-item/_mixins.scss
@@ -1,4 +1,3 @@
-@use '@material/list/evolution-variables' as mdc-evolution-variables;
 @use '@material/rtl/rtl' as mdc-rtl;
 @use '@material/theme/theme' as mdc-theme;
 @use '@material/typography' as mdc-typography;
@@ -37,12 +36,6 @@
       }
     }
   
-    &--wrap {
-      .forge-list-item__text {
-        @include text-wrap;
-      }
-    }
-  
     &__text {
       @include text;
     }
@@ -55,7 +48,7 @@
     ::slotted([slot=tertiary-title]) {
       @include subtitle;
     }
-  
+
     &--two-line {
       @include two-line;
     }
@@ -81,6 +74,18 @@
       }
     }
   
+    &--wrap {
+      @include theme.css-custom-property(min-height, --forge-list-item-min-height, variables.$single-line-height);
+      @include theme.css-custom-property(height, --forge-list-item-height, auto);
+
+      ::slotted([slot=title]),
+      ::slotted([slot=subtitle]),
+      ::slotted([slot=tertiary-title]),
+      .forge-list-item__text {
+        @include text-wrap;
+      }
+    }
+
     &--indented {
       @include indented;
     }
@@ -137,11 +142,13 @@
     }
 
     &--two-line {
-      height: variables.$two-line-height - 8px;
+      @include theme.css-custom-property(min-height, --forge-list-item-min-height, variables.$two-line-height - 8px);
+      @include theme.css-custom-property(height, --forge-list-item-height, variables.$two-line-height - 8px);
     }
 
     &--three-line {
-      height: variables.$three-line-height - 8px;
+      @include theme.css-custom-property(min-height, --forge-list-item-min-height, variables.$three-line-height - 8px);
+      @include theme.css-custom-property(height, --forge-list-item-height, variables.$three-line-height - 8px);
     }
 
     &:nth-child(1) {
@@ -162,6 +169,12 @@
       }
     }
 
+    &--wrap {
+      @include theme.css-custom-property(height, --forge-list-item-height, auto);
+      @include theme.css-custom-property(padding, --forge-list-item-padding, 4px variables.$drawer-inline-padding);
+      @include theme.css-custom-property(min-height, --forge-list-item-min-height, variables.$drawer-single-line-height);
+    }
+
     &--disabled {
       @include theme.css-custom-property(cursor, --forge-list-item-cursor, not-allowed);
     }
@@ -175,10 +188,10 @@
 }
 
 @mixin base() {
-  @include theme.css-custom-property(min-height, --forge-list-item-min-height, auto);
-  @include theme.css-custom-property(max-height, --forge-list-item-max-height, auto);
+  @include theme.css-custom-property(min-height, --forge-list-item-min-height, variables.$single-line-height);
+  @include theme.css-custom-property(max-height, --forge-list-item-max-height, none);
   @include theme.css-custom-property(height, --forge-list-item-height, variables.$single-line-height);
-  @include theme.css-custom-property(padding, --forge-list-item-padding, 0 mdc-evolution-variables.$side-padding);
+  @include theme.css-custom-property(padding, --forge-list-item-padding, #{variables.$block-padding variables.$inline-padding});
   @include theme.css-custom-property(margin-left, --forge-list-item-indent, 0);
   @include theme.css-custom-property(align-items, --forge-list-item-align-items, center);
 
@@ -251,13 +264,13 @@
 
 @mixin drawer {
   @include theme.css-custom-property(margin, --forge-list-item-margin, variables.$margin-drawer);
-  @include theme.css-custom-property(padding, --forge-list-item-padding, 0 8px);
+  @include theme.css-custom-property(padding, --forge-list-item-padding, 0 variables.$drawer-inline-padding);
   @include theme.css-custom-property(border-radius, --forge-list-item-border-radius, 4px);
   @include theme.css-custom-property(cursor, --forge-list-item-cursor, pointer);
+  @include theme.css-custom-property(height, --forge-list-item-height, variables.$drawer-single-line-height);
 
   font-size: 0.875rem;
   font-weight: 500;
-  height: 40px;
 }
 
 @mixin leading() {

--- a/src/lib/list/list-item/_variables.scss
+++ b/src/lib/list/list-item/_variables.scss
@@ -1,14 +1,23 @@
+@use 'sass:math';
+
+$block-padding: 8px;
+$inline-padding: 16px;
+$drawer-inline-padding: #{math.div($inline-padding, 2)};
+
 /// The default height for a single line list item.
-$single-line-height: 48px !default;
+$single-line-height: #{48px - $block-padding * 2} !default;
+
+/// The default min-height for a single line list item in a drawer context.
+$drawer-single-line-height: 40px !default;
 
 /// The default height for a two-line list item.
-$two-line-height: 72px !default;
+$two-line-height: #{72px - $block-padding * 2} !default;
 
 /// The default height for a three-line list item.
-$three-line-height: 88px !default;
+$three-line-height: #{88px - $block-padding * 2} !default;
 
 /// The default height for the dense single-line list item
-$dense-height: 32px !default;
+$dense-height: #{32px - $block-padding * 2} !default;
 
 /// The default margin for list items when placed in a drawer
 $margin-drawer: 8px !default;

--- a/src/lib/popup/popup-constants.ts
+++ b/src/lib/popup/popup-constants.ts
@@ -12,7 +12,8 @@ const attributes = {
   STATIC: 'static',
   HIDE_WHEN_CLIPPED: 'hide-when-clipped',
   HOST: 'forge-popup-host',
-  INITIAL_FOCUS: 'forge-popup-focus'
+  INITIAL_FOCUS: 'forge-popup-focus',
+  CONSTRAIN_VIEWPORT_WIDTH: 'constrain-viewport-width'
 };
 
 const classes = {

--- a/src/lib/popup/popup.scss
+++ b/src/lib/popup/popup.scss
@@ -9,3 +9,7 @@
 :host([hidden]) {
   display: none;
 }
+
+:host([constrain-viewport-width]) {
+  max-width: 100vw;
+}

--- a/src/lib/select/core/base-select-constants.ts
+++ b/src/lib/select/core/base-select-constants.ts
@@ -15,7 +15,9 @@ const observedAttributes = {
   OBSERVE_SCROLL_THRESHOLD: 'observe-scroll-threshold',
   POPUP_CLASSES: 'popup-classes',
   OPTION_LIMIT: 'option-limit',
-  SYNC_POPUP_WIDTH: 'sync-popup-width'
+  SYNC_POPUP_WIDTH: 'sync-popup-width',
+  CONSTRAIN_POPUP_WIDTH: 'constrain-popup-width',
+  WRAP_OPTION_TEXT: 'wrap-option-text'
 };
 
 const attributes = {

--- a/src/lib/select/core/base-select-foundation.ts
+++ b/src/lib/select/core/base-select-foundation.ts
@@ -15,9 +15,6 @@ export interface IBaseSelectFoundation extends IListDropdownAwareFoundation {
   popupElement: HTMLElement | undefined;
   optionBuilder: SelectOptionBuilder;
   selectedTextBuilder: SelectSelectedTextBuilder;
-  observeScroll: boolean;
-  observeScrollThreshold: number;
-  syncPopupWidth: boolean;
   beforeValueChange: SelectBeforeValueChangeCallback<any>;
   appendOptions(options: ISelectOption[] | ISelectOptionGroup[]): void;
   selectAll(): void;
@@ -176,6 +173,8 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
       id: this._identifier,
       optionBuilder: this._optionBuilder,
       syncWidth: this._syncPopupWidth,
+      constrainViewportWidth: this._constrainPopupWidth,
+      wrapOptionText: this._wrapOptionText,
       observeScroll: this._observeScroll,
       observeScrollThreshold: this._observeScrollThreshold,
       scrollEndListener: this._dropdownScrollEndListener,
@@ -656,28 +655,6 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
   public set selectedTextBuilder(fn: SelectSelectedTextBuilder) {
     this._selectedTextBuilder = fn;
   }
-
-  public get observeScroll(): boolean {
-    return this._observeScroll;
-  }
-  public set observeScroll(value: boolean) {
-    this._observeScroll = value;
-  }
-
-  public get observeScrollThreshold(): number {
-    return this._observeScrollThreshold;
-  }
-  public set observeScrollThreshold(value: number) {
-    this._observeScrollThreshold = value;
-  }
-
-  public get syncPopupWidth(): boolean {
-    return this._syncPopupWidth;
-  }
-  public set syncPopupWidth(value: boolean) {
-    this._syncPopupWidth = value;
-  }
-
 
   public get optionLimit(): number {
     return this._optionLimit;

--- a/src/lib/select/select/select.ts
+++ b/src/lib/select/select/select.ts
@@ -78,7 +78,9 @@ export class SelectComponent extends BaseSelectComponent<SelectFoundation> imple
       SELECT_CONSTANTS.attributes.OBSERVE_SCROLL_THRESHOLD,
       BASE_SELECT_CONSTANTS.attributes.POPUP_CLASSES,
       BASE_SELECT_CONSTANTS.attributes.OPTION_LIMIT,
-      BASE_SELECT_CONSTANTS.attributes.SYNC_POPUP_WIDTH
+      BASE_SELECT_CONSTANTS.attributes.SYNC_POPUP_WIDTH,
+      BASE_SELECT_CONSTANTS.attributes.CONSTRAIN_POPUP_WIDTH,
+      BASE_SELECT_CONSTANTS.attributes.WRAP_OPTION_TEXT
     ];
   }
 

--- a/src/stories/src/components/popup/popup.mdx
+++ b/src/stories/src/components/popup/popup.mdx
@@ -142,6 +142,12 @@ Gets/sets whether the popup will automatically hide itself when the target eleme
 
 </PropertyDef>
 
+<PropertyDef name="constrain-viewport-width" prop={false} type="boolean" defaultValue="''">
+
+Controls whether the host element will have a `max-width` applied or not.
+
+</PropertyDef>
+
 </PageSection>
 
 ---

--- a/src/stories/src/components/select/select-args.ts
+++ b/src/stories/src/components/select/select-args.ts
@@ -11,6 +11,8 @@ export interface ISelectProps {
   floatLabelType: SelectFloatLabelType;
   shape: SelectShapeType;
   placeholder: string;
+  constrainPopupWidth: boolean;
+  wrapOptionText: boolean;
   hasLeadingIcon: boolean;
   hasHelperText: boolean;
   hasAddonEnd: boolean;
@@ -104,6 +106,20 @@ export const argTypes = {
   },
   placeholder: {
     control: 'text',
+    description: '',
+    table: {
+      category: 'Properties',
+    },
+  },
+  constrainPopupWidth: {
+    control: 'boolean',
+    description: '',
+    table: {
+      category: 'Properties',
+    },
+  },
+  wrapOptionText: {
+    control: 'boolean',
     description: '',
     table: {
       category: 'Properties',

--- a/src/stories/src/components/select/select.mdx
+++ b/src/stories/src/components/select/select.mdx
@@ -182,6 +182,44 @@ Gets/sets the placeholder text for when no values are selected. This only applie
 
 </PropertyDef>
 
+<PropertyDef name="popupClasses" type="string | string[]" defaultValue="[]">
+
+Gets/sets the list of classes to apply to the popup element.
+
+</PropertyDef>
+
+<PropertyDef name="popupHeaderBuilder" type="ListDropdownHeaderBuilder" defaultValue="undefined">
+
+Gets/sets the callback function for generating header content within the popup.
+
+</PropertyDef>
+
+<PropertyDef name="popupFooterBuilder" type="ListDropdownFooterBuilder" defaultValue="undefined">
+
+Gets/sets the callback function for generating footer content within the popup.
+
+</PropertyDef>
+
+<PropertyDef name="syncPopupWidth" type="boolean" defaultValue="false">
+
+Gets/sets whether the popup width is synchronized with the popup target width.
+
+</PropertyDef>
+
+<PropertyDef name="constrainPopupWidth" type="boolean" defaultValue="true">
+
+Gets/sets whether the popup width will be constrained to a max width of the viewport width (default: `100vw`).
+
+</PropertyDef>
+
+<PropertyDef name="wrapOptionText" type="boolean" defaultValue="false">
+
+Gets/sets whether the options will wrap their text or not.
+
+This only applies if `constrainPopupWidth` is `true`, if there is an explicit width set via CSS.
+
+</PropertyDef>
+
 </PageSection>
 
 ---
@@ -408,6 +446,18 @@ type SelectFloatLabelType = 'default' | 'always';
 
 ```ts
 type SelectBeforeValueChangeCallback<T> = (value: T | T[]) => boolean | Promise<boolean>;
+```
+
+### ListDropdownHeaderBuilder
+
+```ts
+type ListDropdownHeaderBuilder = () => HTMLElement;
+```
+
+### ListDropdownFooterBuilder
+
+```ts
+type ListDropdownFooterBuilder = () => HTMLElement;
 ```
 
 </PageSection>

--- a/src/stories/src/components/select/select.stories.tsx
+++ b/src/stories/src/components/select/select.stories.tsx
@@ -28,6 +28,8 @@ export const Default: Story<ISelectProps> = ({
   floatLabelType = 'default',
   shape = 'default',
   placeholder = '',
+  constrainPopupWidth = true,
+  wrapOptionText = false,
   hasLeadingIcon = false,
   hasHelperText = false,
   hasAddonEnd = false
@@ -48,6 +50,8 @@ export const Default: Story<ISelectProps> = ({
       floatLabelType={floatLabelType}
       shape={shape}
       placeholder={placeholder}
+      constrainPopupWidth={constrainPopupWidth}
+      wrapOptionText={wrapOptionText}
       style={{ width: '259px' }}>
       {hasLeadingIcon && <ForgeIcon slot="leading" name="fastfood" />}
       <ForgeOption value="grains">Bread, Cereal, Rice, and Pasta</ForgeOption>
@@ -74,6 +78,8 @@ Default.args = {
   open: false,
   label: 'Food group',
   placeholder: '',
+  constrainPopupWidth: true,
+  wrapOptionText: false,
   hasLeadingIcon: false,
   hasHelperText: false,
   hasAddonEnd: false,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?

- [list-item] fixed the list-item component to ensure that setting the `wrap` property/attribute will allow text to wrap on slotted elements.
- [select] added new properties/attributes to the select component to allow for controlling whether the popup will allow for options to wrap or not. We may want to make this the default, but in an effort to avoid breaking changes we have made this opt-in.
- [popup] added the ability to specify if the popup should constrain itself to the width of the viewport as a `max-width`.
- [select] set the dropdown popup element to constrain to the viewport width by default. This seems like a good default to have, otherwise popups with long option text could expand off screen. Devs will need to opt-in to the new option wrap functionality if they want their options to wrap.

## Additional information
Fixes #207 and closes #218 
