### PR TITLE
fix(autocomplete): keep dropdown open when selecting items in stateless + multiple mode

### DIFF
--- a/src/lib/autocomplete/autocomplete-foundation.ts
+++ b/src/lib/autocomplete/autocomplete-foundation.ts
@@ -516,7 +516,9 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
       const result = this._adapter.emitHostEvent(AUTOCOMPLETE_CONSTANTS.events.SELECT, data, true, true);
       if (result) {
         this._filterText = '';
-        this._closeDropdown();
+        if (!this._multiple) {
+          this._closeDropdown();
+        }
       }
       return;
     }

--- a/src/test/spec/autocomplete/autocomplete.spec.ts
+++ b/src/test/spec/autocomplete/autocomplete.spec.ts
@@ -1313,6 +1313,23 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       expect(this.context.component.isConnected).toBe(true, 'Expected component to be connected to the DOM');
       expect(this.context.component instanceof AutocompleteComponent).toBe(true, 'Expected component to be instance of AutocompleteComponent');
     });
+
+    it('should keep dropdown open when selecting options in stateless + multiple mode', async function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      this.context.component.mode = 'stateless';
+      this.context.component.multiple = true;
+      this.context.component.filter = () => DEFAULT_FILTER_OPTIONS;
+      _triggerDropdownClick(this.context.input);
+      await tick();
+
+      expect(this.context.component.popupElement).not.toBeNull();
+
+      _clickListItem(0, this.context.component.popupElement);
+      expect(this.context.component.popupElement).not.toBeNull();
+
+      _clickListItem(1, this.context.component.popupElement);
+      expect(this.context.component.popupElement).not.toBeNull();
+    });
   });
 
   describe('with text-field and icon', function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The dropdown will now stay open when selecting items when `mode` equals `'stateless'` and `multiple` is enabled. This allows for more easily selecting multiple items without the dropdown closing after each selection to be consistent with the default stateful mode of this component.

## Additional information
Fixes #268 
