### PR TITLE
fix(autocomplete): fixed typings and leading icon render order

### DIFF
--- a/src/lib/autocomplete/autocomplete-adapter.ts
+++ b/src/lib/autocomplete/autocomplete-adapter.ts
@@ -1,12 +1,11 @@
 import { getShadowElement, deepQuerySelectorAll, getActiveElement, toggleAttribute } from '@tylertech/forge-core';
 import { BaseAdapter, IBaseAdapter } from '../core/base/base-adapter';
 import { IAutocompleteComponent } from './autocomplete';
-import { AUTOCOMPLETE_CONSTANTS, IAutocompleteOptionGroup } from './autocomplete-constants';
+import { AUTOCOMPLETE_CONSTANTS, IAutocompleteOption, IAutocompleteOptionGroup } from './autocomplete-constants';
 import { TEXT_FIELD_CONSTANTS } from '../text-field';
 import { IListDropdown, IListDropdownConfig, ListDropdown } from '../list-dropdown';
 import { CHIP_FIELD_CONSTANTS } from '../chip-field';
 import { IPopupComponent, POPUP_CONSTANTS } from '../popup';
-import { IAutocompleteOption } from '..';
 
 export interface IAutocompleteAdapter extends IBaseAdapter {
   setInputElement(): HTMLInputElement;

--- a/src/lib/autocomplete/autocomplete-adapter.ts
+++ b/src/lib/autocomplete/autocomplete-adapter.ts
@@ -1,12 +1,12 @@
 import { getShadowElement, deepQuerySelectorAll, getActiveElement, toggleAttribute } from '@tylertech/forge-core';
 import { BaseAdapter, IBaseAdapter } from '../core/base/base-adapter';
-import { IOption } from '../select';
 import { IAutocompleteComponent } from './autocomplete';
 import { AUTOCOMPLETE_CONSTANTS, IAutocompleteOptionGroup } from './autocomplete-constants';
 import { TEXT_FIELD_CONSTANTS } from '../text-field';
 import { IListDropdown, IListDropdownConfig, ListDropdown } from '../list-dropdown';
 import { CHIP_FIELD_CONSTANTS } from '../chip-field';
 import { IPopupComponent, POPUP_CONSTANTS } from '../popup';
+import { IAutocompleteOption } from '..';
 
 export interface IAutocompleteAdapter extends IBaseAdapter {
   setInputElement(): HTMLInputElement;
@@ -18,8 +18,8 @@ export interface IAutocompleteAdapter extends IBaseAdapter {
   show(config: IListDropdownConfig, popupTarget: string): void;
   hide(listener: () => void): void;
   focus(): void;
-  setOptions(options: IOption[] | IAutocompleteOptionGroup[]): void;
-  appendOptions(options: IOption[] | IAutocompleteOptionGroup[]): void;
+  setOptions(options: IAutocompleteOption[] | IAutocompleteOptionGroup[]): void;
+  appendOptions(options: IAutocompleteOption[] | IAutocompleteOptionGroup[]): void;
   setSelectedText(value: string): void;
   getInputValue(): string;
   selectInputValue(): void;
@@ -42,7 +42,7 @@ export interface IAutocompleteAdapter extends IBaseAdapter {
   setBusyVisibility(busy: boolean): void;
   getActiveOptionIndex(): number | null;
   clearActiveOption(): void;
-  setSelectedOptions(options: IOption[]): void;
+  setSelectedOptions(options: IAutocompleteOption[]): void;
   queueDropdownPositionUpdate(): void;
 }
 
@@ -143,11 +143,11 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
     window.requestAnimationFrame(() => this._inputElement.focus());
   }
 
-  public setOptions(options: IOption[] | IAutocompleteOptionGroup[]): void {
+  public setOptions(options: IAutocompleteOption[] | IAutocompleteOptionGroup[]): void {
     this._listDropdown?.setOptions(options);
   }
 
-  public appendOptions(options: IOption[] | IAutocompleteOptionGroup[]): void {
+  public appendOptions(options: IAutocompleteOption[] | IAutocompleteOptionGroup[]): void {
     this._listDropdown?.appendOptions(options);
   }
 
@@ -253,7 +253,7 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
     this._listDropdown?.clearActiveOption();
   }
 
-  public setSelectedOptions(options: IOption[]): void {
+  public setSelectedOptions(options: IAutocompleteOption[]): void {
     if (this._listDropdown) {
       const values = options.map(o => o.value);
       this._listDropdown.setSelectedValues(values);

--- a/src/lib/autocomplete/autocomplete-constants.ts
+++ b/src/lib/autocomplete/autocomplete-constants.ts
@@ -1,7 +1,6 @@
 import { COMPONENT_NAME_PREFIX, KEYSTROKE_DEBOUNCE_THRESHOLD } from '../constants';
-import { IOption } from '../select';
 import { IListItemComponent } from '../list';
-import { IListDropdownConfig } from '../list-dropdown';
+import { IListDropdownConfig, IListDropdownOption, IListDropdownOptionGroup, ListDropdownOptionGroupBuilder } from '../list-dropdown';
 import { IPopupPosition } from '../popup';
 import { FIELD_CONSTANTS } from '../field/field-constants';
 
@@ -49,21 +48,18 @@ export const AUTOCOMPLETE_CONSTANTS = {
   events
 };
 
-export type AutocompleteOptionBuilder<T = any> = (option: IOption<T>, filterText: string, parentElement: IListItemComponent) => HTMLElement;
-export type AutocompleteOptionGroupBuilder<T = any> = (option: IAutocompleteOptionGroup<T>) => HTMLElement;
-export type AutocompleteFilterCallback<T = any> = (filterText: string, value: T | null) => Array<IOption<T>> | IAutocompleteOptionGroup[] | Promise<Array<IOption<T>> | IAutocompleteOptionGroup[]>;
-export type AutocompleteSelectedTextBuilder<T = any> = (selectedOptions: Array<IOption<T>>) => string;
+export type AutocompleteOptionBuilder<T = any> = (option: IAutocompleteOption<T>, filterText: string, parentElement: IListItemComponent) => HTMLElement;
+export type AutocompleteOptionGroupBuilder<T = any> = ListDropdownOptionGroupBuilder<T>;
+export type AutocompleteFilterCallback<T = any> = (filterText: string, value: T | null) => IAutocompleteOption<T>[] | IAutocompleteOptionGroup<T>[] | Promise<IAutocompleteOption<T>[] | IAutocompleteOptionGroup<T>[]>;
+export type AutocompleteSelectedTextBuilder<T = any> = (selectedOptions: Array<IAutocompleteOption<T>>) => string;
 
 export enum AutocompleteMode {
   Default = 'default',
   Stateless = 'stateless'
 }
 
-export interface IAutocompleteOptionGroup<T = any> {
-  text?: string;
-  builder?: AutocompleteOptionGroupBuilder;
-  options: Array<IOption<T>>;
-}
+export interface IAutocompleteOption<T = any> extends IListDropdownOption<T> {}
+export interface IAutocompleteOptionGroup<T = any> extends IListDropdownOptionGroup<T> {}
 
 export interface IAutocompletePopupConfiguration {
   filterText: string;

--- a/src/lib/autocomplete/autocomplete-foundation.ts
+++ b/src/lib/autocomplete/autocomplete-foundation.ts
@@ -3,15 +3,14 @@ import { highlightTextHTML } from '../core';
 import { IListItemComponent } from '../list';
 import { IListDropdownConfig, IListDropdownOption, ListDropdownAsyncStyle, ListDropdownFooterBuilder, ListDropdownHeaderBuilder, ListDropdownOptionBuilder } from '../list-dropdown';
 import { IListDropdownAwareFoundation, ListDropdownAwareFoundation } from '../list-dropdown/list-dropdown-aware-foundation';
-import { IOption, IOptionGroup } from '../select';
 import { IAutocompleteAdapter } from './autocomplete-adapter';
-import { AutocompleteFilterCallback, AutocompleteMode, AutocompleteOptionBuilder, AutocompleteSelectedTextBuilder, AUTOCOMPLETE_CONSTANTS, IAutocompleteOptionGroup, IAutocompleteSelectEventData } from './autocomplete-constants';
+import { AutocompleteFilterCallback, AutocompleteMode, AutocompleteOptionBuilder, AutocompleteSelectedTextBuilder, AUTOCOMPLETE_CONSTANTS, IAutocompleteOption, IAutocompleteOptionGroup, IAutocompleteSelectEventData } from './autocomplete-constants';
 import { getSelectedOption, isOptionType, optionEqualPredicate, OptionType } from './autocomplete-utils';
 
 export interface IAutocompleteFoundation extends IListDropdownAwareFoundation {
   mode: AutocompleteMode;
   multiple: boolean;
-  value: string | string[] | IOption | IOption[] | null | undefined;
+  value: string | string[] | IAutocompleteOption | IAutocompleteOption[] | null | undefined;
   debounce: number;
   filterOnFocus: boolean;
   allowUnmatched: boolean;
@@ -22,7 +21,7 @@ export interface IAutocompleteFoundation extends IListDropdownAwareFoundation {
   isInitialized: boolean;
   open: boolean;
   matchKey: string | null | undefined;
-  appendOptions(options: IOption[] | IAutocompleteOptionGroup[]): void;
+  appendOptions(options: IAutocompleteOption[] | IAutocompleteOptionGroup[]): void;
   beforeValueChange: (value: any) => boolean | Promise<boolean>;
 }
 
@@ -41,11 +40,11 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
   private _optionBuilder?: AutocompleteOptionBuilder | null;
   private _filter?: AutocompleteFilterCallback | null;
   private _selectedTextBuilder: AutocompleteSelectedTextBuilder;
-  private _options: IOption[] | IAutocompleteOptionGroup[] = [];
+  private _options: IAutocompleteOption[] | IAutocompleteOptionGroup[] = [];
   private _filterText = '';
-  private _selectedOptions: IOption[] = [];
+  private _selectedOptions: IAutocompleteOption[] = [];
   private _values: any[] = [];
-  private _pendingFilterPromises: Array<Promise<IOption[] | IOptionGroup[]>> = [];
+  private _pendingFilterPromises: Array<Promise<IAutocompleteOption[] | IAutocompleteOptionGroup[]>> = [];
   private _identifier: string;
   private _matchKey?: string | null = null;
   private _filterFn: () => Promise<void>;
@@ -149,11 +148,11 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     this._adapter.intializeInputAccessibility(this._identifier);
   }
 
-  private get _flatOptions(): IOption[] {
+  private get _flatOptions(): IAutocompleteOption[] {
     if (isOptionType(this._options, OptionType.Group)) {
-      return (this._options as IAutocompleteOptionGroup[]).reduce((previousValue, currentValue) => previousValue.concat(currentValue.options), [] as IOption[]) as IOption[];
+      return (this._options as IAutocompleteOptionGroup[]).reduce((previousValue, currentValue) => previousValue.concat(currentValue.options), [] as IAutocompleteOption[]);
     }
-    return this._options as IOption[];
+    return this._options as IAutocompleteOption[];
   }
 
   private _onClick(evt: MouseEvent): void {
@@ -338,7 +337,7 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     }
   }
 
-  private _executeFilter(sendFilterText = true, sendValue = false): Promise<IOption[] | IAutocompleteOptionGroup[]> {
+  private _executeFilter(sendFilterText = true, sendValue = false): Promise<IAutocompleteOption[] | IAutocompleteOptionGroup[]> {
     if (!this._filter || typeof this._filter !== 'function') {
       throw new Error('A filter callback must be provided. Did you set the "filter" property?');
     }
@@ -347,7 +346,7 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     const filterText = sendFilterText ? this._filterText : '';
     const value = sendValue ? this._getValue() : null;
 
-    return new Promise<IOption[] | IAutocompleteOptionGroup[]>((resolve, reject) => {
+    return new Promise<IAutocompleteOption[] | IAutocompleteOptionGroup[]>((resolve, reject) => {
       return Promise.resolve(filter(filterText, value))
         .then(options => {
           this._options = options;
@@ -485,10 +484,10 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
   private _sortSelectedOptions(): void {
     // When in multiple selection mode, we need to make sure that the selected options appear at the top of the list
     if (this._multiple && this._selectedOptions.length && isOptionType(this._options, OptionType.Option)) {
-      const selectedOptions: IOption[] = [];
-      const unselectedOptions: IOption[] = [];
+      const selectedOptions: IAutocompleteOption[] = [];
+      const unselectedOptions: IAutocompleteOption[] = [];
 
-      (this._options as IOption[]).forEach(option => {
+      (this._options as IAutocompleteOption[]).forEach(option => {
         if (this._selectedOptions.find(o => optionEqualPredicate(o, option.value, this._matchKey))) {
           selectedOptions.push(option);
         } else {
@@ -523,7 +522,7 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
 
     const select = (): void => {
       const flatOptions = this._flatOptions;
-      const option = flatOptions.find(o => optionEqualPredicate(o, selectedValue, this._matchKey)) as IOption;
+      const option = flatOptions.find(o => optionEqualPredicate(o, selectedValue, this._matchKey)) as IAutocompleteOption;
       const value = option ? option.value : '';
       const label = option ? option.label : '';
 
@@ -664,7 +663,7 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     this._closeDropdown();
   }
 
-  private async _applyValue(value: string | string[] | IOption | IOption[] | null | undefined): Promise<void> {
+  private async _applyValue(value: string | string[] | IAutocompleteOption | IAutocompleteOption[] | null | undefined): Promise<void> {
     let values: any[] = [];
     this._selectedOptions = [];
 
@@ -680,8 +679,8 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     }
 
     if (isOptionType(values, OptionType.Option)) {
-      this._values = values.map((o: IOption) => o.value);
-      this._selectedOptions = values as IOption[];
+      this._values = values.map((o: IAutocompleteOption) => o.value);
+      this._selectedOptions = values as IAutocompleteOption[];
     } else {
       this._values = values as any[];
     }
@@ -720,7 +719,7 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     }
   }
 
-  private _updateSelectedOptions(values: Array<any | IOption>): void {
+  private _updateSelectedOptions(values: Array<any | IAutocompleteOption>): void {
     const flatOptions = [...this._flatOptions, ...this._selectedOptions];
 
     if (this._selectedOptions.length) {
@@ -728,7 +727,7 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     }
 
     if (isOptionType(values, OptionType.Option)) {
-      for (const option of values as IOption[]) {
+      for (const option of values as IAutocompleteOption[]) {
         const actualOption = flatOptions.find(o => optionEqualPredicate(o, option.value, this._matchKey));
         if (actualOption) {
           this._selectedOptions.push(actualOption);
@@ -777,11 +776,11 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
   }
 
   /** Gets/sets the value of the component. */
-  public get value(): string | string[] | IOption | IOption[] | null | undefined {
+  public get value(): string | string[] | IAutocompleteOption | IAutocompleteOption[] | null | undefined {
     return this._getValue();
   }
-  public set value(value: string | string[] | IOption | IOption[] | null | undefined) {
-    let values: Array<string | IOption | IOption[] | string[]> = [];
+  public set value(value: string | string[] | IAutocompleteOption | IAutocompleteOption[] | null | undefined) {
+    let values: Array<string | IAutocompleteOption | IAutocompleteOption[] | string[]> = [];
 
     if (value == null) {
       values = [];
@@ -957,11 +956,11 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     this._observeScrollThreshold = value;
   }
 
-  public appendOptions(options: IOption[] | IAutocompleteOptionGroup[]): void {
+  public appendOptions(options: IAutocompleteOption[] | IAutocompleteOptionGroup[]): void {
     if (!this._isDropdownOpen) {
       return;
     }
-    this._options = [...this._options, ...options] as IOption[] | IAutocompleteOptionGroup[];
+    this._options = [...this._options, ...options] as IAutocompleteOption[] | IAutocompleteOptionGroup[];
     this._adapter.appendOptions(options);
   }
 

--- a/src/lib/autocomplete/autocomplete-utils.ts
+++ b/src/lib/autocomplete/autocomplete-utils.ts
@@ -1,5 +1,4 @@
-import { IOption } from '../select';
-import { IAutocompleteOptionGroup } from './autocomplete-constants';
+import { IAutocompleteOption, IAutocompleteOptionGroup } from './autocomplete-constants';
 import { isDefined, isObject, isDeepEqual } from '@tylertech/forge-core';
 
 /** The available option types. */
@@ -10,19 +9,19 @@ export enum OptionType { Option, Group }
  * @param options The options either grouped or individual.
  * @param type The type of option to detect.
  */
-export function isOptionType(options: IOption[] | IAutocompleteOptionGroup[], type: OptionType): boolean {
-  const isOptionGroups = options.some((o: IOption | IAutocompleteOptionGroup) => isDefined(o) && isObject(o) && o.hasOwnProperty('options') && (o.hasOwnProperty('text') || o.hasOwnProperty('builder')));
-  const isOptionTypes = options.some((o: IOption | IAutocompleteOptionGroup) => isDefined(o) && isObject(o) && o.hasOwnProperty('label') && o.hasOwnProperty('value'));
+export function isOptionType(options: IAutocompleteOption[] | IAutocompleteOptionGroup[], type: OptionType): boolean {
+  const isOptionGroups = options.some((o: IAutocompleteOption | IAutocompleteOptionGroup) => isDefined(o) && isObject(o) && o.hasOwnProperty('options') && (o.hasOwnProperty('text') || o.hasOwnProperty('builder')));
+  const isOptionTypes = options.some((o: IAutocompleteOption | IAutocompleteOptionGroup) => isDefined(o) && isObject(o) && o.hasOwnProperty('label') && o.hasOwnProperty('value'));
   return (isOptionGroups && type === OptionType.Group) || (isOptionTypes && type === OptionType.Option);
 }
 
 /** A utility function to find the matching option in the provided options by the value provided. */
-export function getSelectedOption(options: IOption[], value: string): IOption | undefined {
+export function getSelectedOption(options: IAutocompleteOption[], value: string): IAutocompleteOption | undefined {
   return options.find(o => o.value === value);
 }
 
 /** A predicate function that will determine if an option value is equal regardless of primitive type or complex object type. */
-export function optionEqualPredicate(option: IOption, value: any, property: string | null = null): boolean {
+export function optionEqualPredicate(option: IAutocompleteOption, value: any, property: string | null = null): boolean {
   if (property) {
     if (!(property in option.value) || !(property in value)) {
       return false;

--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -6,11 +6,10 @@ import { LinearProgressComponent } from '../linear-progress';
 import { ListComponent, ListItemComponent } from '../list';
 import { IListDropdownAware, ListDropdownAware } from '../list-dropdown/list-dropdown-aware';
 import { PopupComponent } from '../popup';
-import { IOption } from '../select';
 import { SkeletonComponent } from '../skeleton';
 import { TextFieldComponent } from '../text-field';
 import { AutocompleteAdapter } from './autocomplete-adapter';
-import { AutocompleteFilterCallback, AutocompleteMode, AutocompleteOptionBuilder, AutocompleteSelectedTextBuilder, AUTOCOMPLETE_CONSTANTS, IAutocompleteOptionGroup, IAutocompleteSelectEventData } from './autocomplete-constants';
+import { AutocompleteFilterCallback, AutocompleteMode, AutocompleteOptionBuilder, AutocompleteSelectedTextBuilder, AUTOCOMPLETE_CONSTANTS, IAutocompleteOption, IAutocompleteOptionGroup, IAutocompleteSelectEventData } from './autocomplete-constants';
 import { AutocompleteFoundation } from './autocomplete-foundation';
 
 import template from './autocomplete.html';
@@ -32,7 +31,7 @@ export interface IAutocompleteComponent extends IListDropdownAware {
   beforeValueChange: (value: any) => boolean | Promise<boolean>;
   isInitialized: boolean;
   open: boolean;
-  appendOptions(options: IOption[] | IAutocompleteOptionGroup[]): void;
+  appendOptions(options: IAutocompleteOption[] | IAutocompleteOptionGroup[]): void;
   openDropdown(): void;
   closeDropdown(): void;
 }
@@ -198,7 +197,7 @@ export class AutocompleteComponent extends ListDropdownAware implements IAutocom
   public declare beforeValueChange: (value: any) => boolean | Promise<boolean>;
 
   /** Adds options to the dropdown while it is open. Has no effect if the dropdown is closed.  */
-  public appendOptions(options: IOption[] | IAutocompleteOptionGroup[]): void {
+  public appendOptions(options: IAutocompleteOption[] | IAutocompleteOptionGroup[]): void {
     this._foundation.appendOptions(options);
   }
 

--- a/src/lib/list-dropdown/list-dropdown-constants.ts
+++ b/src/lib/list-dropdown/list-dropdown-constants.ts
@@ -24,7 +24,7 @@ export const LIST_DROPDOWN_CONSTANTS = {
 export type ListDropdownOptionBuilder<T = HTMLElement> = (option: IListDropdownOption, parentElement: T) => HTMLElement | string | void;
 export type ListDropdownHeaderBuilder = () => HTMLElement;
 export type ListDropdownFooterBuilder = () => HTMLElement;
-export type ListDropdownOptionGroupBuilder = (option: IListDropdownOptionGroup) => HTMLElement;
+export type ListDropdownOptionGroupBuilder<T = any> = (option: IListDropdownOptionGroup<T>) => HTMLElement | string;
 export type ListDropdownTransformCallback = (label: string) =>  string | HTMLElement;
 export type ListDropdownIconType = 'font' | 'component';
 
@@ -49,10 +49,10 @@ export interface IListDropdownOption<T = any> extends IBaseListDropdownOption<T>
   elementAttributes?: Map<string, string>;
 }
 
-export interface IListDropdownOptionGroup {
-  options: IListDropdownOption[];
+export interface IListDropdownOptionGroup<T = any> {
   text?: string;
   builder?: ListDropdownOptionGroupBuilder;
+  options: IListDropdownOption<T>[];
 }
 
 export interface IListDropdownSelectEventData {

--- a/src/lib/list-dropdown/list-dropdown-utils.ts
+++ b/src/lib/list-dropdown/list-dropdown-utils.ts
@@ -110,7 +110,13 @@ export function createListItems(config: IListDropdownOpenConfig, listElement: IL
         const groupWrapper = document.createElement('div');
         groupWrapper.classList.add(LIST_DROPDOWN_CONSTANTS.classes.GROUP_WRAPPER);
         optionParent = groupWrapper;
-        groupWrapper.appendChild(headerElement);
+
+        if (typeof headerElement === 'string') {
+          groupWrapper.innerHTML = headerElement;
+        } else {
+          groupWrapper.appendChild(headerElement);
+        }
+
         listElement.appendChild(groupWrapper);
       }
     } else if (group.text) {
@@ -199,6 +205,20 @@ export function createListItems(config: IListDropdownOpenConfig, listElement: IL
         }
       }
 
+      // If multiple selections are enabled then we need to create and append a leading checkbox element
+      if (config.multiple) {
+        const checkboxElement = createCheckboxElement(isSelected);
+        listItemElement.appendChild(checkboxElement);
+        listItemElement.setAttribute('aria-selected', `${isSelected}`);
+        listItemElement.setAttribute('aria-checked', `${isSelected}`);
+      }
+
+      if (option.elementAttributes) {
+        option.elementAttributes.forEach((value: string, key: string) => {
+          listItemElement.setAttribute(key, value);
+        });
+      }
+
       // Leading element/icon
       if (option.leadingBuilder) {
         const element = option.leadingBuilder();
@@ -239,20 +259,6 @@ export function createListItems(config: IListDropdownOpenConfig, listElement: IL
         listItemElement.selected = true;
       }
       listItemElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
-
-      // If multiple selections are enabled then we need to create and append a leading checkbox element
-      if (config.multiple) {
-        const checkboxElement = createCheckboxElement(isSelected);
-        listItemElement.appendChild(checkboxElement);
-        listItemElement.setAttribute('aria-selected', `${isSelected}`);
-        listItemElement.setAttribute('aria-checked', `${isSelected}`);
-      }
-
-      if (option.elementAttributes) {
-        option.elementAttributes.forEach((value: string, key: string) => {
-          listItemElement.setAttribute(key, value);
-        });
-      }
 
       // If we have any child options, we need to render a child menu for this list item
       if (!option.disabled && typeof config.cascadingElementFactory === 'function' && Array.isArray(option.options) && option.options.length) {

--- a/src/stories/src/components/autocomplete/autocomplete.mdx
+++ b/src/stories/src/components/autocomplete/autocomplete.mdx
@@ -62,7 +62,8 @@ The only requirement for integration via JavaScript is that you provide a callba
   Sets the filter function. **Required.**
 
   The filter function is used by the component whenever it needs to retrieved options/suggestions to display. You can return the options
-  as an array of `IOption` objects, or you can also return a `Promise` that will be resolved with an array of objects at some later time.
+  as an array of `IAutocompleteOption` or `IAutocompleteOptionGroup` objects, or you can also return a `Promise` that will be resolved
+  with an array of those objects at some later time.
 
 </PropertyDef>
 
@@ -118,7 +119,7 @@ Gets/sets the list of classes to apply to the popup element. Can be a string of 
   
 </PropertyDef>
 
-<PropertyDef name="value" type="string | string[] | IOption | IOption[] | null" defaultValue="null">
+<PropertyDef name="value" type="string | string[] | IAutocompleteOption | IAutocompleteOption[] | null" defaultValue="null">
 
 Gets/sets the selected value(s).
   
@@ -138,7 +139,7 @@ Sets the callback that will be executed when a user selects an option. This will
 
 ## Methods
 
-<MethodDef name="appendOptions(options: IOption[] | IAutocompleteOptionGroup[]): void;">
+<MethodDef name="appendOptions(options: IAutocompleteOption[] | IAutocompleteOptionGroup[]): void;">
 
   Dynamically adds options to the end of the option list while the popup is open.
 
@@ -230,7 +231,7 @@ Below you will find the API for all custom public type declarations that you wil
 ### AutocompleteOptionBuilder
 
 ```ts
-type AutocompleteOptionBuilder<T = any> = (option: IOption<T>, filterText: string, parentElement: IListItemComponent) => HTMLElement;
+type AutocompleteOptionBuilder<T = any> = (option: IAutocompleteOption<T>, filterText: string, parentElement: IListItemComponent) => HTMLElement;
 ```
 
 ### AutocompleteOptionGroupBuilder
@@ -242,19 +243,19 @@ type AutocompleteOptionGroupBuilder<T = any> = (option: IAutocompleteOptionGroup
 ### AutocompleteFilterCallback
 
 ```ts
-type AutocompleteFilterCallback<T = any> = (filterText: string, value: T | null) => Array<IOption<T>> | IAutocompleteOptionGroup[] | Promise<Array<IOption<T>> | IAutocompleteOptionGroup[]>;
+type AutocompleteFilterCallback<T = any> = (filterText: string, value: T | null) => IAutocompleteOption<T>[] | IAutocompleteOptionGroup<T>[] | Promise<IAutocompleteOption<T>[] | IAutocompleteOptionGroup<T>[]>;
 ```
 
 ### AutocompleteOptionComparator
 
 ```ts
-type AutocompleteOptionComparator<T = any> = (optionA: IOption<T>, optionB: IOption<T>) => number;
+type AutocompleteOptionComparator<T = any> = (optionA: IAutocompleteOption<T>, optionB: IAutocompleteOption<T>) => number;
 ```
 
 ### AutocompleteSelectedTextBuilder
 
 ```ts
-type AutocompleteSelectedTextBuilder<T = any> = (selectedOptions: Array<IOption<T>>) => string;
+type AutocompleteSelectedTextBuilder<T = any> = (selectedOptions: IAutocompleteOption<T>[]) => string;
 ```
 
 ### AutocompleteMode
@@ -266,13 +267,25 @@ enum AutocompleteMode {
 }
 ```
 
-### IOption
+### IAutocompleteOption
 
 ```ts
-interface IOption<T = any>  {
+interface IAutocompleteOption<T = any>  {
   value: T;
   label: string;
   disabled?: boolean;
+  divider?: boolean;
+  optionClass?: string | string[];
+  leadingIcon?: string;
+  leadingIconClass?: string;
+  leadingIconType?: ListDropdownIconType;
+  trailingIcon?: string;
+  trailingIconClass?: string;
+  trailingIconType?: ListDropdownIconType;
+  leadingBuilder?: () => HTMLElement;
+  trailingBuilder?: () => HTMLElement;
+  options?: Array<IListDropdownOption | IListDropdownOptionGroup>;
+  elementAttributes?: Map<string, string>;
 }
 ```
 
@@ -282,7 +295,7 @@ interface IOption<T = any>  {
 interface IAutocompleteOptionGroup<T = any> {
   text?: string;
   builder?: AutocompleteOptionGroupBuilder;
-  options: Array<IOption<T>>;
+  options: IAutocompleteOption[];
 }
 ```
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The autocomplete will no longer reference the `IOption` interface from the select component. It introduces a new `IAutocompleteOption` interface (which inherits the same properties as `IOption` to avoid breaking changes). This allows access to list-dropdown properties such as `leadingIcon` that were previously not available in the typings, even though they could technically be provided.

A small fix for the render order of the leading icon/builder content when in multiple mode was included as well.

## Additional information
Fixes #271
Fixes #272 
