### PR TITLE
fix(select): fixed a bug where the option group `builder` property was not being called

### DIFF
--- a/src/dev/index.ejs
+++ b/src/dev/index.ejs
@@ -1,5 +1,6 @@
 <!-- Filter field-->
 <forge-text-field>
+  <forge-icon slot="leading" name="filter_list"></forge-icon>
   <input type="text" placeholder="Filter..." id="search-field" />
   <forge-icon-button slot="trailing" dense density-level="3">
     <button type="button" id="clear-button">

--- a/src/dev/src/index.ts
+++ b/src/dev/src/index.ts
@@ -1,8 +1,9 @@
 import '$src/shared';
 import '@tylertech/forge/text-field';
 import { IconRegistry } from '@tylertech/forge/icon';
-import { tylIconClose } from '@tylertech/tyler-icons/standard';
+import { tylIconClose, tylIconFilterList } from '@tylertech/tyler-icons/standard';
 
 IconRegistry.define([
-  tylIconClose
+  tylIconClose,
+  tylIconFilterList
 ]);

--- a/src/lib/core/utils/utils.ts
+++ b/src/lib/core/utils/utils.ts
@@ -123,14 +123,3 @@ export function safeMin(...args: (number | undefined)[]): number {
 export function safeMax(...args: (number | undefined)[]): number {
   return Math.max(...args.map(arg => arg ?? Number.NEGATIVE_INFINITY));
 }
-
-/**
- * Copies properties from one object to another, much like Object.assign(), but only where properties exist in both source objects.
- * @param from The object to apply properties from.
- * @param to The object to apply property values to.
- */
-export function assignMatchingProperties(from: object, to: object): void {
-  Object.keys(from)
-    .filter(prop => prop in to)
-    .forEach(prop => to[prop] = from[prop]);
-}

--- a/src/lib/select/core/base-select-adapter.ts
+++ b/src/lib/select/core/base-select-adapter.ts
@@ -1,4 +1,4 @@
-import { isDefined, removeElement } from '@tylertech/forge-core';
+import { isDefined, isFunction, removeElement } from '@tylertech/forge-core';
 import { BaseAdapter, IBaseAdapter } from '../../core/base/base-adapter';
 import { IBaseSelectComponent } from './base-select';
 import { ListDropdown, IListDropdown } from '../../list-dropdown';
@@ -8,7 +8,6 @@ import { IOptionGroupComponent, OPTION_GROUP_CONSTANTS } from '../option-group';
 import { ISelectOption, ISelectOptionGroup, SelectOptionListenerDestructor } from './base-select-constants';
 import { isOptionGroupObject } from './select-utils';
 import { IPopupComponent, POPUP_CONSTANTS } from '../../popup';
-import { assignMatchingProperties } from '../../core/utils/utils';
 
 export interface IBaseSelectAdapter extends IBaseAdapter {
   initializeAccessibility(): void;
@@ -64,7 +63,11 @@ export abstract class BaseSelectAdapter extends BaseAdapter<IBaseSelectComponent
       return optionGroupElements.map(optionGroupElement => {
         const optionElements = Array.from(optionGroupElement.querySelectorAll(OPTION_CONSTANTS.elementName)) as IOptionComponent[];
         const options = this._createOptionsFromElements(optionElements);
-        return { text: optionGroupElement.label, options } as ISelectOptionGroup;
+        return {
+          text: optionGroupElement.label,
+          builder: optionGroupElement.builder,
+          options
+        } as ISelectOptionGroup;
       });
     } else {
       const optionElements = Array.from(this._component.querySelectorAll(OPTION_CONSTANTS.elementName)) as IOptionComponent[];
@@ -225,14 +228,13 @@ export abstract class BaseSelectAdapter extends BaseAdapter<IBaseSelectComponent
 
   private _createOptionGroupElement(group: ISelectOptionGroup): HTMLElement {
     const optionGroupElement = document.createElement('forge-option-group');
-    assignMatchingProperties(group, optionGroupElement);
-    optionGroupElement.label = group.text ?? '';
+    Object.assign(optionGroupElement, group);
     return optionGroupElement;
   }
 
   private _createOptionElement(option: ISelectOption): HTMLElement {
     const optionElement = document.createElement('forge-option');
-    assignMatchingProperties(option, optionElement);
+    Object.assign(optionElement, option);
     optionElement.textContent = option.label;
     return optionElement;
   }

--- a/src/lib/select/core/select-utils.ts
+++ b/src/lib/select/core/select-utils.ts
@@ -15,7 +15,7 @@ export function isSelectOptionType(options: ISelectOption[] | ISelectOptionGroup
 }
 
 export function isOptionGroupObject(o: ISelectOption | ISelectOptionGroup): o is ISelectOptionGroup {
-  return isDefined(o) && isObject(o) && o.hasOwnProperty('options') && o.hasOwnProperty('text');
+  return isDefined(o) && isObject(o) && o.hasOwnProperty('options');
 }
 
 export function isOptionObject(o: ISelectOption | ISelectOptionGroup): o is ISelectOption {

--- a/src/lib/select/option-group/option-group.ts
+++ b/src/lib/select/option-group/option-group.ts
@@ -1,5 +1,5 @@
 import { CustomElement } from '@tylertech/forge-core';
-import { ListDropdownOptionGroupBuilder } from '@tylertech/forge/list-dropdown';
+import { ListDropdownOptionGroupBuilder } from '../../list-dropdown/list-dropdown-constants';
 import { BaseComponent, IBaseComponent } from '../../core/base/base-component';
 import { ISelectOption, ISelectOptionGroup } from '../core';
 import { OPTION_GROUP_CONSTANTS } from './option-group-constants';

--- a/src/lib/select/option-group/option-group.ts
+++ b/src/lib/select/option-group/option-group.ts
@@ -1,8 +1,10 @@
 import { CustomElement } from '@tylertech/forge-core';
+import { ListDropdownOptionGroupBuilder } from '@tylertech/forge/list-dropdown';
 import { BaseComponent, IBaseComponent } from '../../core/base/base-component';
+import { ISelectOption, ISelectOptionGroup } from '../core';
 import { OPTION_GROUP_CONSTANTS } from './option-group-constants';
 
-export interface IOptionGroupComponent extends IBaseComponent {
+export interface IOptionGroupComponent extends Required<ISelectOptionGroup>, IBaseComponent {
   label: string;
 }
 
@@ -50,5 +52,19 @@ export class OptionGroupComponent extends BaseComponent implements IOptionGroupC
       this._label = value || '';
       this.setAttribute(OPTION_GROUP_CONSTANTS.attributes.LABEL, this._label);
     }
+  }
+
+  /** The child options of this group. */
+  public declare options: ISelectOption[];
+
+  /** The builder function for the group content. */
+  public declare builder: ListDropdownOptionGroupBuilder;
+
+  /** The text content for the group. */
+  public get text(): string {
+    return this._label;
+  }
+  public set text(value: string) {
+    this.label = value;
   }
 }

--- a/src/test/spec/select/select.spec.ts
+++ b/src/test/spec/select/select.spec.ts
@@ -1313,9 +1313,15 @@ describe('SelectComponent', function(this: ITestContext) {
       await tick();
       
       await tick();
+
+      function optionGroupBuilder() {
+        return '<div>Custom group header</div>';
+      }
+
       this.context.component.options = [
         {
           text: '',
+          builder: optionGroupBuilder,
           options: [
             { label: 'option-1', value: 1, disabled: true, leadingBuilder: () => document.createElement('div'), metadata: 'test-meta' } as any,
           ]
@@ -1334,12 +1340,13 @@ describe('SelectComponent', function(this: ITestContext) {
       const optionElements = this.context.component.querySelectorAll(OPTION_CONSTANTS.elementName);
 
       expect(optionGroupElements[0].label).toBe('');
+      expect(optionGroupElements[0].builder).toBe(optionGroupBuilder);
       expect(optionGroupElements[1].label).toBe('group');
 
       expect(optionElements[0].label).toBe('option-1');
       expect(optionElements[0].disabled).toBeTrue();
       expect(optionElements[0].leadingBuilder).toBeTruthy();
-      expect('metadata' in optionElements[0]).toBeFalse();
+      expect('metadata' in optionElements[0]).toBeTrue();
 
       expect(optionElements[2].label).toBe('option-3');
       expect(optionElements[2].optionClass).toEqual(['test-cls']);

--- a/src/tsconfig-test.json
+++ b/src/tsconfig-test.json
@@ -18,5 +18,5 @@
       "@tylertech/forge/*": ["lib/*"]
     }
   },
-  "exclude": ["demo", "stories"]
+  "exclude": ["dev", "stories"]
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The `builder` property on `<forge-option-group>` elements (among other properties) will now correctly propagate to the list-dropdown.

## Additional information
Fixes #260 
