### PR TITLE
feat: allow for using `<a>` element in place of `<button>` in `<forge-button>`, `<forge-icon-button>` and `<forge-fab>` components

### DIFF
--- a/src/dev/pages/button/button.ejs
+++ b/src/dev/pages/button/button.ejs
@@ -23,6 +23,12 @@
       <forge-icon name="favorite"></forge-icon>
     </button>
   </forge-button>
+  <forge-button type="outlined">
+    <a href="javascript: alert('Anchor link button works!');">
+      <span>w/anchor tag</span>
+      <forge-icon name="open_in_new"></forge-icon>
+    </a>
+  </forge-button>
 </div>
 
 <script type="module" src="button.ts"></script>

--- a/src/dev/pages/button/button.scss
+++ b/src/dev/pages/button/button.scss
@@ -1,5 +1,5 @@
 @use '../../src/shared';
 
-button {
+button, a {
   width: 256px;
 }

--- a/src/dev/pages/button/button.ts
+++ b/src/dev/pages/button/button.ts
@@ -7,7 +7,7 @@ import '@tylertech/forge/button';
 
 // Icons
 import { IconRegistry } from '@tylertech/forge/icon';
-import { tylIconFavorite } from '@tylertech/tyler-icons/standard';
+import { tylIconFavorite, tylIconOpenInNew } from '@tylertech/tyler-icons/standard';
 import { tylIconForgeLogo } from '@tylertech/tyler-icons/custom';
 
 import '$src/shared';
@@ -15,7 +15,7 @@ import type { ButtonComponent } from '@tylertech/forge/button';
 import { isDefined } from '@tylertech/forge-core';
 import type { ISwitchComponent } from '@tylertech/forge/switch';
 
-IconRegistry.define([tylIconForgeLogo, tylIconFavorite]);
+IconRegistry.define([tylIconForgeLogo, tylIconFavorite, tylIconOpenInNew]);
 
 function getButtonElements(): NodeListOf<ButtonComponent> {
   return document.querySelectorAll('.content forge-button');

--- a/src/dev/pages/fab/fab.ejs
+++ b/src/dev/pages/fab/fab.ejs
@@ -5,6 +5,12 @@
     </button>
   </forge-fab>
 
+  <forge-fab>
+    <a href="javascript: alert('Anchor link FAB works!');" aria-label="Anchor link FAB">
+      <forge-icon name="open_in_new"></forge-icon>
+    </a>
+  </forge-fab>
+
   <forge-fab mini>
     <button type="button" aria-label="Mini FAB">
       <forge-icon name="favorite"></forge-icon>

--- a/src/dev/pages/fab/fab.ts
+++ b/src/dev/pages/fab/fab.ts
@@ -3,10 +3,11 @@ import '@tylertech/forge/floating-action-button';
 import '@tylertech/forge/floating-action-button/forge-floating-action-button.scss';
 import '@tylertech/forge/icon';
 import { IconRegistry } from '@tylertech/forge/icon';
-import { tylIconAdd, tylIconDelete, tylIconFavorite } from '@tylertech/tyler-icons/standard';
+import { tylIconAdd, tylIconDelete, tylIconFavorite, tylIconOpenInNew } from '@tylertech/tyler-icons/standard';
 
 IconRegistry.define([
   tylIconFavorite,
   tylIconAdd,
-  tylIconDelete
+  tylIconDelete,
+  tylIconOpenInNew
 ]);

--- a/src/dev/pages/icon-button/icon-button.ejs
+++ b/src/dev/pages/icon-button/icon-button.ejs
@@ -21,8 +21,8 @@
     <h3 class="forge-typography--caption">Toggle</h3>
     <forge-icon-button toggle="true" is-on="false">
       <button type="button">
-        <forge-icon name="favorite" external forge-icon-button-on></forge-icon>
-        <forge-icon name="favorite_border" external></forge-icon>
+        <forge-icon name="favorite" forge-icon-button-on></forge-icon>
+        <forge-icon name="favorite_border"></forge-icon>
       </button>
     </forge-icon-button>
   </div>
@@ -31,9 +31,18 @@
     <h3 class="forge-typography--caption">Toggle (dense)</h3>
     <forge-icon-button dense toggle is-on="false">
       <button type="button">
-        <forge-icon name="favorite" external forge-icon-button-on></forge-icon>
-        <forge-icon name="favorite_border" external></forge-icon>
+        <forge-icon name="favorite" forge-icon-button-on></forge-icon>
+        <forge-icon name="favorite_border"></forge-icon>
       </button>
+    </forge-icon-button>
+  </div>
+
+  <div>
+    <h3 class="forge-typography--caption">w/Anchor link</h3>
+    <forge-icon-button>
+      <a href="javascript: alert('Anchor link icon button works!');">
+        <forge-icon name="open_in_new"></forge-icon>
+      </a>
     </forge-icon-button>
   </div>
 </div>

--- a/src/dev/pages/icon-button/icon-button.ts
+++ b/src/dev/pages/icon-button/icon-button.ts
@@ -3,10 +3,11 @@ import '@tylertech/forge/icon';
 import '@tylertech/forge/icon-button';
 import '@tylertech/forge/icon-button/forge-icon-button.scss';
 import { IconRegistry } from '@tylertech/forge/icon';
-import { tylIconCode, tylIconFavorite, tylIconFavoriteBorder } from '@tylertech/tyler-icons/standard';
+import { tylIconCode, tylIconFavorite, tylIconFavoriteBorder, tylIconOpenInNew } from '@tylertech/tyler-icons/standard';
 
 IconRegistry.define([
   tylIconFavorite,
   tylIconFavoriteBorder,
-  tylIconCode
+  tylIconCode,
+  tylIconOpenInNew
 ]);

--- a/src/lib/button/button-constants.ts
+++ b/src/lib/button/button-constants.ts
@@ -2,6 +2,8 @@ import { COMPONENT_NAME_PREFIX } from '../constants';
 
 const elementName: keyof HTMLElementTagNameMap = `${COMPONENT_NAME_PREFIX}button`;
 
+export const ALLOWED_CHILDREN = ['button', 'a'];
+
 const classes = {
   BUTTON: 'forge-button',
   LABEL: 'forge-button__label',
@@ -14,7 +16,7 @@ const classes = {
 };
 
 const selectors = {
-  BUTTON: 'button, a',
+  BUTTON: ALLOWED_CHILDREN.join(','),
   LABEL: `span:not(.${classes.RIPPLE})`,
   ICON: 'i,forge-icon,[data-forge-button-icon]',
   RIPPLE: `.${classes.RIPPLE}`

--- a/src/lib/button/button-constants.ts
+++ b/src/lib/button/button-constants.ts
@@ -14,7 +14,7 @@ const classes = {
 };
 
 const selectors = {
-  BUTTON: 'button',
+  BUTTON: 'button, a',
   LABEL: `span:not(.${classes.RIPPLE})`,
   ICON: 'i,forge-icon,[data-forge-button-icon]',
   RIPPLE: `.${classes.RIPPLE}`

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -1,6 +1,6 @@
 import { CustomElement, ensureChildren, toggleAttribute } from '@tylertech/forge-core';
 import { BaseComponent, IBaseComponent } from '../core/base/base-component';
-import { BUTTON_CONSTANTS } from './button-constants';
+import { ALLOWED_CHILDREN, BUTTON_CONSTANTS } from './button-constants';
 import { userInteractionListener } from '../core/utils/utils';
 import { ForgeRipple } from '../ripple';
 
@@ -194,7 +194,7 @@ export class ButtonComponent extends BaseComponent implements IButtonComponent {
   private _buttonWasAdded(mutationList: MutationRecord[]): boolean {
     return mutationList.some(mutation => {
       return Array.from(mutation.addedNodes)
-        .some(node => node.nodeName.toLowerCase() === BUTTON_CONSTANTS.selectors.BUTTON);
+        .some(node => ALLOWED_CHILDREN.includes(node.nodeName.toLowerCase()));
     });
   }
 

--- a/src/lib/floating-action-button/floating-action-button-constants.ts
+++ b/src/lib/floating-action-button/floating-action-button-constants.ts
@@ -3,7 +3,7 @@ import { COMPONENT_NAME_PREFIX } from '../constants';
 const elementName: keyof HTMLElementTagNameMap = `${COMPONENT_NAME_PREFIX}fab`;
 
 const selectors = {
-  BUTTON: 'button',
+  BUTTON: 'button, a',
   ICON: 'i,forge-icon,img,svg',
   LABEL: 'span'
 };

--- a/src/lib/icon-button/icon-button-constants.ts
+++ b/src/lib/icon-button/icon-button-constants.ts
@@ -11,7 +11,7 @@ const attributes = {
 };
 
 const selectors = {
-  BUTTON: 'button',
+  BUTTON: 'button, a',
   ICON: 'i, span, svg, img, forge-icon'
 };
 

--- a/src/stories/src/components/button/button.mdx
+++ b/src/stories/src/components/button/button.mdx
@@ -25,6 +25,8 @@ adjusting native properties/attributes as needed.
   <ButtonDemo />
 </LiveDemo>
 
+> **Note:** You can substitute the `<a>` element in place of the `<button>` element if you need the button to act as an anchor link.
+
 ### With icon
 
 Make note of the `<span>` used around the button text, this is required to properly space out the icons since this component does not use shadow DOM (yet).

--- a/src/stories/src/components/fab/fab.mdx
+++ b/src/stories/src/components/fab/fab.mdx
@@ -39,6 +39,8 @@ The following is an example of the default usage of a floating action button. Ta
   <FabDemo />
 </LiveDemo>
 
+> **Note:** You can substitute the `<a>` element in place of the `<button>` element if you need the button to act as an anchor link.
+
 ### Mini
 
 The following is an example of the mini usage of a floating action button. Take note of the `aria-label` to ensure that icon-only buttons are accessible.

--- a/src/stories/src/components/icon-button/icon-button.mdx
+++ b/src/stories/src/components/icon-button/icon-button.mdx
@@ -6,7 +6,7 @@ import { IconButtonToggleCodeHtml } from './code/icon-button-toggle';
 
 # Icon button
 
-The icon-button component is nothing more than a standard HTML `<button>` with custom styling provided. Use this component to display an
+The icon-button component is nothing more than a standard HTML `<button>` or `<a>` element with custom styling provided. Use this component to display an
 interactive button that renders **only an icon**. You can also use this component to toggle between an "on" and "off" state as well.
 
 > Ensure that you add an `aria-label` attribute to the `<button>` element to ensure that the action is announced properly to screen readers.
@@ -26,6 +26,8 @@ interactive button that renders **only an icon**. You can also use this componen
 <LiveDemo dense codeHtml={IconButtonDefaultCodeHtml()}>
   <IconButtonDemo />
 </LiveDemo>
+
+> **Note:** You can substitute the `<a>` element in place of the `<button>` element if you need the button to act as an anchor link.
 
 ### Toggle
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The `<forge-button>`, `<forge-icon-button>` and `<forge-fab>` components now all supports providing an `<a>` tag as a child in place of the standard `<button>` element.

## Additional information
Closes #275 
