### PR TITLE
feat(table): provided the column index to the `TableTemplateBuilder`

### DIFF
--- a/src/dev/pages/table/table.ts
+++ b/src/dev/pages/table/table.ts
@@ -3,7 +3,7 @@ import '@tylertech/forge/table';
 import '@tylertech/forge/table/forge-table.scss';
 import './table.scss';
 import { TextFieldComponentDelegate } from '@tylertech/forge/text-field';
-import { CellAlign, IColumnConfiguration, IconRegistry, ISelectComponent, ISortedColumn, ISwitchComponent, ITableComponent, ITableSortMultipleEventData, ITableTemplateBuilderResult, SelectComponentDelegate, SortDirection } from '@tylertech/forge';
+import { ButtonComponentDelegate, CellAlign, IColumnConfiguration, IconRegistry, ISelectComponent, ISortedColumn, ISwitchComponent, ITableComponent, ITableSortMultipleEventData, ITableTemplateBuilderResult, SelectComponentDelegate, SortDirection } from '@tylertech/forge';
 import { PositionPlacement } from '@tylertech/forge-core';
 import { tylIconChevronRight, tylIconDelete, tylIconEdit, tylIconMoreVert } from '@tylertech/tyler-icons/standard';
 
@@ -49,7 +49,7 @@ const columnConfigurations: IColumnConfiguration[] = [
   {
     header: 'Player name',
     property: 'name',
-    template: (_index, _parent, { name }) => name,
+    template: (_index, _parent, { name }, _colIndex) => name,
     sortable: true,
     initialSort: { direction: SortDirection.Descending, sortOrder: 1 } as ISortedColumn,
     headerTemplate: () => Promise.resolve('<span>Player names</span>'),
@@ -77,7 +77,11 @@ const columnConfigurations: IColumnConfiguration[] = [
     filterDelegate: new SelectComponentDelegate({ props: { options: positionOptions, placeholder: 'Filter position...' }})
   },
   { template: getMenuColumnTemplate, resizable: false, align: CellAlign.Center, headerCellStyle: { width: '50px' }, stopCellTemplateClickPropagation: true },
-  { template: getExpandRowColumnTemplate, resizable: false, align: CellAlign.Center, headerCellStyle: { width: '50px' } }
+  {
+    filter: true,
+    filterDelegate: new ButtonComponentDelegate({ options: { text: 'Clear filters '} }),
+    template: getExpandRowColumnTemplate, resizable: false, align: CellAlign.Center, headerCellStyle: { width: '50px' }
+  }
 ];
 
 let sortDirection = 'DESC';

--- a/src/lib/table/types.ts
+++ b/src/lib/table/types.ts
@@ -1,8 +1,10 @@
+import { BaseComponentDelegate, IBaseComponentDelegate, IBaseComponentDelegateOptions } from '../core';
 import { IFormFieldComponentDelegate } from '../core/delegates/form-field-component-delegate';
 import { TableRow } from './table-row';
 
-export declare type TableViewTemplate = string | HTMLElement | TableTemplateBuilder;
-export declare type TableTemplateBuilder<T = any> = (rowIndex: number, div: HTMLElement, rowData: T) => HTMLElement | string | ITableTemplateBuilderResult | undefined | Promise<HTMLElement | string | undefined | ITableTemplateBuilderResult>;
+export declare type TableViewTemplate = string | HTMLElement | TableViewTemplateBuilder;
+export declare type TableViewTemplateBuilder<T = any> = (rowIndex: number, div: HTMLElement, rowData: T) => HTMLElement | string | ITableViewTemplateBuilderResult | undefined | Promise<HTMLElement | string | undefined | ITableViewTemplateBuilderResult>;
+export declare type TableTemplateBuilder<T = any> = (rowIndex: number, div: HTMLElement, rowData: T, columnIndex: number) => HTMLElement | string | ITableTemplateBuilderResult | undefined | Promise<HTMLElement | string | undefined | ITableTemplateBuilderResult>;
 export declare type TableHeaderTemplateBuilder = (rowIndex: number, div: HTMLElement, columConfig: IColumnConfiguration) => HTMLElement | string | Promise<HTMLElement | string>;
 export declare type TableHeaderSelectAllTemplate = () => HTMLElement | string | Promise<HTMLElement | string>;
 export declare type TableRowCreatedCallback = (rowElement: HTMLTableRowElement, rowIndex: number, rowData: any) => void;
@@ -56,7 +58,7 @@ export interface IColumnConfiguration {
   width?: string | number;
   transform?: (value: any) => any | Promise<any>;
   filter?: boolean;
-  filterDelegate?: IFormFieldComponentDelegate<any> | TableFilterDelegateFactory;
+  filterDelegate?: IFormFieldComponentDelegate<any> | BaseComponentDelegate<HTMLElement, IBaseComponentDelegateOptions> | TableFilterDelegateFactory;
   filterDebounceTime?: number;
   cellStyle?: Partial<CSSStyleDeclaration>;
   headerCellStyle?: Partial<CSSStyleDeclaration>;
@@ -152,7 +154,7 @@ export enum TableFilterType {
 }
 
 export type TableFilterListener<T = any> = (value: T, columnIndex: number) => void;
-export type TableFilterDelegateFactory<T extends HTMLElement = any> = () => IFormFieldComponentDelegate<T>;
+export type TableFilterDelegateFactory<T extends HTMLElement = any> = () => IFormFieldComponentDelegate<T> | IBaseComponentDelegate<HTMLElement>;
 export type TableLayoutType = 'auto' | 'fixed';
 
 export interface ITableFilterEventData<T = any> {
@@ -172,3 +174,5 @@ export interface ITableTemplateBuilderResult {
   content: HTMLElement | string;
   stopClickPropagation?: boolean;
 }
+
+export interface ITableViewTemplateBuilderResult extends ITableTemplateBuilderResult {}

--- a/src/stories/src/components/table/table.mdx
+++ b/src/stories/src/components/table/table.mdx
@@ -450,7 +450,13 @@ type TableViewTemplate = string | HTMLElement | TableTemplateBuilder;
 ### TableTemplateBuilder
 
 ```ts
-type type TableTemplateBuilder<T = any> = (rowIndex: number, div: HTMLElement, rowData: T) => HTMLElement | string | ITableTemplateBuilderResult | Promise<HTMLElement | string | ITableTemplateBuilderResult>;
+type TableTemplateBuilder<T = any> = (rowIndex: number, div: HTMLElement, rowData: T, columnIndex: number) => HTMLElement | string | ITableTemplateBuilderResult | undefined | Promise<HTMLElement | string | undefined | ITableTemplateBuilderResult>;
+```
+
+### TableViewTemplateBuilder
+
+```ts
+type TableViewTemplateBuilder<T = any> = (rowIndex: number, div: HTMLElement, rowData: T) => HTMLElement | string | ITableViewTemplateBuilderResult | undefined | Promise<HTMLElement | string | undefined | ITableViewTemplateBuilderResult>;
 ```
 
 ### TableHeaderTemplateBuilder
@@ -744,6 +750,12 @@ interface ITableTemplateBuilderResult {
   content: HTMLElement | string;
   stopClickPropagation?: boolean;
 }
+```
+
+### ITableViewTemplateBuilderResult
+
+```ts
+interface ITableViewTemplateBuilderResult extends ITableTemplateBuilderResult {}
 ```
 
 </PageSection>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The `TableTemplateBuilder` callback (the `template` property on a column configuration) will now provide the column index to the callback for convenience to avoid the need for developers to perform a lookup on the index.

Along with this change, there is a new separate `type` created for the expandable row functionality since they shared the same `TableTemplateBuilder` type but in the context of a row expanding there is no specific column associated. This callback will use the same type just named different but without the column index parameter.

Also, one other minor unrelated change was included to enable the use of non-form-related delegates to be provided to the `filterDelegate` property on a column configuration. This allows developers to pass it a `ButtonComponentDelegate` instance for example to render an element in the filter cell of a column.

## Additional information
Closes #243 
