### PR TITLE
fix(file-picker): allow for setting disabled state before child `<button>` is in DOM

### DIFF
--- a/src/lib/file-picker/file-picker-adapter.ts
+++ b/src/lib/file-picker/file-picker-adapter.ts
@@ -28,7 +28,7 @@ export interface IFilePickerAdapter extends IBaseAdapter {
 export class FilePickerAdapter extends BaseAdapter<IFilePickerComponent> implements IFilePickerAdapter {
   private _container: HTMLElement;
   private _buttonSlot: HTMLSlotElement;
-  private _button: HTMLButtonElement;
+  private _button: HTMLButtonElement | undefined;
   private _input: HTMLInputElement;
   private _inputEventListener: () => void;
 
@@ -145,11 +145,11 @@ export class FilePickerAdapter extends BaseAdapter<IFilePickerComponent> impleme
   public setDisabled(value: boolean): void {
     if (value) {
       this._container.removeEventListener('click', this._inputEventListener);
-      this._button.setAttribute('disabled', '');
+      this._button?.setAttribute('disabled', '');
       this._container.setAttribute('disabled', '');
     } else {
       this._container.addEventListener('click', this._inputEventListener);
-      this._button.removeAttribute('disabled');
+      this._button?.removeAttribute('disabled');
       this._container.removeAttribute('disabled');
     }
   }

--- a/src/lib/file-picker/file-picker-foundation.ts
+++ b/src/lib/file-picker/file-picker-foundation.ts
@@ -14,6 +14,7 @@ export interface IFilePickerFoundation extends ICustomElementFoundation {
 }
 
 export class FilePickerFoundation implements IFilePickerFoundation {
+  private _isInitialized = false;
   private _accept: string | null | undefined = null;
   private _maxSize: number | null | undefined = null;
   private _capture: string | null | undefined = null;
@@ -45,6 +46,12 @@ export class FilePickerFoundation implements IFilePickerFoundation {
 
   public initialize(): void {
     this._adapter.initializeButton();
+    this._adapter.setDisabled(this._disabled);
+    this._isInitialized = true;
+  }
+
+  public destroy(): void {
+    this._isInitialized = false;
   }
 
   private _onButtonSlotChanged(evt: Event): void {
@@ -153,11 +160,7 @@ export class FilePickerFoundation implements IFilePickerFoundation {
     if (this._accept !== value) {
       this._accept = value;
       this._adapter.setAccept(value);
-      if (value) {
-        this._adapter.setHostAttribute(FILE_PICKER_CONSTANTS.attributes.ACCEPT, value);
-      } else {
-        this._adapter.removeHostAttribute(FILE_PICKER_CONSTANTS.attributes.ACCEPT);
-      }
+      this._adapter.toggleHostAttribute(FILE_PICKER_CONSTANTS.attributes.ACCEPT, !!value, String(value));
     }
   }
 
@@ -168,11 +171,7 @@ export class FilePickerFoundation implements IFilePickerFoundation {
   public set maxSize(value: number | null | undefined) {
     if (this._maxSize !== value) {
       this._maxSize = value;
-      if (value) {
-        this._adapter.setHostAttribute(FILE_PICKER_CONSTANTS.attributes.MAX_SIZE, value.toString());
-      } else {
-        this._adapter.removeHostAttribute(FILE_PICKER_CONSTANTS.attributes.MAX_SIZE);
-      }
+      this._adapter.toggleHostAttribute(FILE_PICKER_CONSTANTS.attributes.MAX_SIZE, !!value, String(value));
     }
   }
 
@@ -184,11 +183,7 @@ export class FilePickerFoundation implements IFilePickerFoundation {
     if (this._capture !== value) {
       this._capture = value;
       this._adapter.setCapture(value);
-      if (value) {
-        this._adapter.setHostAttribute(FILE_PICKER_CONSTANTS.attributes.CAPTURE, value);
-      } else {
-        this._adapter.removeHostAttribute(FILE_PICKER_CONSTANTS.attributes.CAPTURE);
-      }
+      this._adapter.toggleHostAttribute(FILE_PICKER_CONSTANTS.attributes.CAPTURE, !!value, String(value));
     }
   }
 
@@ -200,11 +195,7 @@ export class FilePickerFoundation implements IFilePickerFoundation {
     if (this._multiple !== value) {
       this._multiple = value;
       this._adapter.setMultiple(value);
-      if (value) {
-        this._adapter.setHostAttribute(FILE_PICKER_CONSTANTS.attributes.MULTIPLE);
-      } else {
-        this._adapter.removeHostAttribute(FILE_PICKER_CONSTANTS.attributes.MULTIPLE);
-      }
+      this._adapter.toggleHostAttribute(FILE_PICKER_CONSTANTS.attributes.MULTIPLE, value);
     }
   }
 
@@ -215,12 +206,10 @@ export class FilePickerFoundation implements IFilePickerFoundation {
   public set disabled(value: boolean) {
     if (this._disabled !== value) {
       this._disabled = value;
-      this._adapter.setDisabled(value);
-      if (value) {
-        this._adapter.setHostAttribute(FILE_PICKER_CONSTANTS.attributes.DISABLED);
-      } else {
-        this._adapter.removeHostAttribute(FILE_PICKER_CONSTANTS.attributes.DISABLED);
+      if (this._isInitialized) {
+        this._adapter.setDisabled(value);
       }
+      this._adapter.toggleHostAttribute(FILE_PICKER_CONSTANTS.attributes.DISABLED, value);
     }
   }
 
@@ -233,12 +222,11 @@ export class FilePickerFoundation implements IFilePickerFoundation {
       this._compact = value;
       this._adapter.setCompact(value);
       if (value) {
-        this._adapter.setHostAttribute(FILE_PICKER_CONSTANTS.attributes.COMPACT);
         this._removeDragListeners();
       } else {
-        this._adapter.removeHostAttribute(FILE_PICKER_CONSTANTS.attributes.COMPACT);
         this._registerDragListeners();
       }
+      this._adapter.toggleHostAttribute(FILE_PICKER_CONSTANTS.attributes.COMPACT, value);
     }
   }
 
@@ -250,11 +238,7 @@ export class FilePickerFoundation implements IFilePickerFoundation {
     if (this._borderless !== value) {
       this._borderless = value;
       this._adapter.setBorderless(value);
-      if (value) {
-        this._adapter.setHostAttribute(FILE_PICKER_CONSTANTS.attributes.BORDERLESS);
-      } else {
-        this._adapter.removeHostAttribute(FILE_PICKER_CONSTANTS.attributes.BORDERLESS);
-      }
+      this._adapter.toggleHostAttribute(FILE_PICKER_CONSTANTS.attributes.BORDERLESS, value);
     }
   }
 }

--- a/src/lib/file-picker/file-picker.ts
+++ b/src/lib/file-picker/file-picker.ts
@@ -62,6 +62,10 @@ export class FilePickerComponent extends BaseComponent implements IFilePickerCom
     this._foundation.initialize();
   }
 
+  public disconnectedCallback(): void {
+    this._foundation.destroy();
+  }
+
   public attributeChangedCallback(name: string, oldValue: string, newValue: string): void {
     switch (name) {
       case FILE_PICKER_CONSTANTS.attributes.ACCEPT:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The file-picker component will now gracefully handle a child `<button>` element not being in the DOM during instead of throwing an exception assuming it is there when setting the `disabled` property.

## Additional information
Fixes #188 
