### PR TITLE
fix(linear-progress): updated the default `buffer` state to be `1` instead of `0`

### DIFF
--- a/src/dev/pages/linear-progress/linear-progress.ts
+++ b/src/dev/pages/linear-progress/linear-progress.ts
@@ -9,8 +9,6 @@ const visibleToggle = document.getElementById('opt-visible') as ISwitchComponent
 modeSelect.addEventListener('change', ({ detail: value }) => {
   if (value === 'determinate' || value === 'indeterminate') {
     linearProgress.determinate = value === 'determinate';
-    linearProgress.buffer = 1;
-
     linearProgress.progress = value === 'indeterminate' ? 0 : 0.25;
   } else {
     linearProgress.determinate = true;

--- a/src/lib/linear-progress/linear-progress.ts
+++ b/src/lib/linear-progress/linear-progress.ts
@@ -43,7 +43,7 @@ export class LinearProgressComponent extends BaseComponent implements ILinearPro
   private _mdcLinearProgress: MDCLinearProgress;
   private _determinate = false;
   private _progress = 0;
-  private _buffer = 0;
+  private _buffer = 1;
   private _visible = true;
   private _progressbarElement: HTMLElement;
 

--- a/src/stories/src/components/linear-progress/code/linear-progress-determinate.ts
+++ b/src/stories/src/components/linear-progress/code/linear-progress-determinate.ts
@@ -1,3 +1,3 @@
 export const LinearProgressDeterminateCodeHtml = () => {
-  return `<forge-linear-progress determinate progress="0.5" buffer="1"></forge-linear-progress>`;
+  return `<forge-linear-progress determinate progress="0.5"></forge-linear-progress>`;
 };

--- a/src/stories/src/components/linear-progress/linear-progress.mdx
+++ b/src/stories/src/components/linear-progress/linear-progress.mdx
@@ -60,7 +60,7 @@ The progress amount (between `0` and `1`) of the indicator. Only valid in determ
 
 </PropertyDef>
 
-<PropertyDef name="buffer" type="number" defaultValue="0">
+<PropertyDef name="buffer" type="number" defaultValue="1">
 
 The buffer amount (between `0` and `1`) of the indicator. Only valid in determinate state.
 

--- a/src/test/spec/linear-progress/linear-progress.spec.ts
+++ b/src/test/spec/linear-progress/linear-progress.spec.ts
@@ -63,7 +63,7 @@ describe('LinearProgressComponent', function(this:ITestContext) {
 
   it('should have correct buffer by default', function(this:ITestContext) {
     this.context = setupTestContext(true);
-    expect(this.context.component.buffer).toBe(0);
+    expect(this.context.component.buffer).toBe(1);
     expect(this.context.getBufferBar().style.flexBasis).toBe('100%');
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The default `buffer` value was set to `0` previously which meant that every time the `determinate` mode was was used that developers have to set the `buffer` property to `1`. This is inconvenient and we should cater to the more common use case.

This component will now default the `buffer` state to `1` which means that you won't see the buffering dots animation when just using the default determinate mode now. A developer will no longer need to set the `buffer` state to `1` manually every time they want to use a determinate progress bar. The buffering functionality should be opt-in only when it's needed.

This is technically a "breaking change" because if a developer is expecting that the buffer state starts at `0` (to show the buffer dots animation) then that will technically not happen anymore, BUT given that if they are using the buffering functionality to begin with they will need to update the buffer state anyway as-needed... Given this reasoning, I would not consider this a breaking change that affects any existing code out there, and it won't cause any build errors either.
