### PR TITLE
feat(toolbar): various toolbar improvements

### DIFF
--- a/src/dev/pages/toolbar/toolbar.html
+++ b/src/dev/pages/toolbar/toolbar.html
@@ -4,8 +4,10 @@ include('./src/partials/page.ejs', {
     title: 'Toolbar',
     includePath: './pages/toolbar/toolbar.ejs',
     options: [
-      { type: 'switch', id: 'toolbar-inverted', label: 'Inverted' },
-      { type: 'switch', id: 'toolbar-border', label: 'Show border', defaultValue: true }
+      { type: 'switch', id: 'toolbar-opt-inverted', label: 'Inverted' },
+      { type: 'switch', id: 'toolbar-opt-border', label: 'Show border', defaultValue: true },
+      { type: 'switch', id: 'toolbar-opt-has-padding', label: 'Has padding', defaultValue: true },
+      { type: 'switch', id: 'toolbar-opt-auto-height', label: 'Auto height' }
     ]
   }
 })

--- a/src/dev/pages/toolbar/toolbar.scss
+++ b/src/dev/pages/toolbar/toolbar.scss
@@ -6,12 +6,20 @@
   align-items: center;
   width: 100%;
   padding: 8px;
+  margin-block: 8px;
 
   &:first-child {
-    margin-right: 8px;
+    margin-inline-end: 8px;
   }
 
   &:last-child {
-    margin-left: 8px;
+    margin-inline-start: 8px;
   }
 }
+
+forge-toolbar[auto-height] {
+  .placeholder-container {
+    height: 100px;
+  }
+}
+

--- a/src/dev/pages/toolbar/toolbar.ts
+++ b/src/dev/pages/toolbar/toolbar.ts
@@ -2,19 +2,18 @@ import '$src/shared';
 import '@tylertech/forge/toolbar';
 import './toolbar.scss';
 import type { IToolbarComponent, ISwitchComponent} from '@tylertech/forge';
+import { toggleAttribute } from '@tylertech/forge-core';
 
 const toolbar = document.querySelector('#toolbar') as IToolbarComponent;
 
-const invertedToggle = document.querySelector('#toolbar-inverted') as ISwitchComponent;
-invertedToggle.addEventListener('forge-switch-select', ({ detail: selected }) => {
-  toolbar.inverted = selected;
-});
+const invertedToggle = document.querySelector('#toolbar-opt-inverted') as ISwitchComponent;
+invertedToggle.addEventListener('forge-switch-select', ({ detail: selected }) => toolbar.inverted = selected);
 
-const showBorderToggle = document.querySelector('#toolbar-border') as ISwitchComponent;
-showBorderToggle.addEventListener('forge-switch-select', ({ detail: selected }) => {
-  if (selected) {
-    toolbar.removeAttribute('no-border');
-  } else {
-    toolbar.setAttribute('no-border', '');
-  }
-});
+const showBorderToggle = document.querySelector('#toolbar-opt-border') as ISwitchComponent;
+showBorderToggle.addEventListener('forge-switch-select', ({ detail: selected }) => toggleAttribute(toolbar, !selected, 'no-border'));
+
+const hasPaddingToggle = document.querySelector('#toolbar-opt-has-padding') as ISwitchComponent;
+hasPaddingToggle.addEventListener('forge-switch-select', ({ detail: selected }) => toggleAttribute(toolbar, !selected, 'no-padding'));
+
+const autoHeightToggle = document.querySelector('#toolbar-opt-auto-height') as ISwitchComponent;
+autoHeightToggle.addEventListener('forge-switch-select', ({ detail: selected }) => toggleAttribute(toolbar, selected, 'auto-height'));

--- a/src/lib/toolbar/_mixins.scss
+++ b/src/lib/toolbar/_mixins.scss
@@ -6,8 +6,7 @@
   @include mdc-theme.property(background-color, surface);
   @include theme.css-custom-property(min-height, --forge-toolbar-min-height, variables.$min-height);
   @include theme.css-custom-property(height, --forge-toolbar-height, variables.$height);
-  @include theme.css-custom-property(padding-left, --forge-toolbar-padding, variables.$padding);
-  @include theme.css-custom-property(padding-right, --forge-toolbar-padding, variables.$padding);
+  @include theme.css-custom-property(padding-inline, --forge-toolbar-padding, variables.$padding);
   @include theme.css-custom-property(border-bottom, --forge-toolbar-border-bottom, variables.$border-bottom);
   @include theme.css-custom-property(border-top-left-radius, --forge-toolbar-border-top-left-radius, 0);
   @include theme.css-custom-property(border-top-right-radius, --forge-toolbar-border-top-right-radius, 0);

--- a/src/lib/toolbar/toolbar.html
+++ b/src/lib/toolbar/toolbar.html
@@ -2,6 +2,7 @@
   <div class="forge-toolbar" part="root">
     <div class="forge-toolbar__section forge-toolbar__section--align-start" part="section-start">
       <slot name="start"></slot>
+      <slot></slot>
     </div>
     <div class="forge-toolbar__section forge-toolbar__section--align-center" part="section-center">
       <slot name="center"></slot>

--- a/src/lib/toolbar/toolbar.scss
+++ b/src/lib/toolbar/toolbar.scss
@@ -1,3 +1,4 @@
+@use '../theme';
 @use './mixins';
 
 @include mixins.core-styles;
@@ -14,6 +15,18 @@
 :host([no-border]) {
   .forge-toolbar {
     border: none;
+  }
+}
+
+:host([no-padding]) {
+  .forge-toolbar {
+    @include theme.css-custom-property(padding-inline, --forge-toolbar-padding, 0);
+  }
+}
+
+:host([auto-height]) {
+  .forge-toolbar {
+    @include theme.css-custom-property(height, --forge-toolbar-height, auto);
   }
 }
 

--- a/src/stories/src/components/toolbar/toolbar.mdx
+++ b/src/stories/src/components/toolbar/toolbar.mdx
@@ -38,7 +38,25 @@ Controls whether a border bottom (default) or top (true) is used.
 
 <PropertyDef prop={false} name="no-border" type="string">
 
-Disables the internal `border-top` or `border-bottom` styles. **This can only be applied via an attribute**.
+Disables the internal `border-top` or `border-bottom` styles.
+
+**Note: This can only be applied via an attribute**.
+
+</PropertyDef>
+
+<PropertyDef prop={false} name="no-padding" type="string">
+
+Sets the internal `padding` style to `0`.
+
+**Note: This can only be applied via an attribute**.
+
+</PropertyDef>
+
+<PropertyDef prop={false} name="auto-height" type="string">
+
+Forces the internal container to use `height: auto` for dynamic content that doesn't fit the static height.
+
+**Note: This can only be applied via an attribute**.
 
 </PropertyDef>
 
@@ -48,11 +66,12 @@ Disables the internal `border-top` or `border-bottom` styles. **This can only be
 
 ## Slots
 
-| Name                              | Description
-| :---------------------------------| :----------------
-| `start`                             | Places content at the beginning of the toolbar.
-| `center`                            | Places content at the center of the toolbar.
-| `end`                               | Places content at the end of the toolbar.
+| Name              | Description
+| :-----------------| :----------------
+| `default`           | The default (unnamed) slot is an alias to the `start` slot and places content at the beginning of the toolbar.
+| `start`           | Places content at the beginning of the toolbar.
+| `center`          | Places content at the center of the toolbar.
+| `end`             | Places content at the end of the toolbar.
 
 </PageSection>
 
@@ -79,7 +98,7 @@ Disables the internal `border-top` or `border-bottom` styles. **This can only be
 | `--forge-theme-border-color`                  | Controls the border-color of the toolbar.
 | `--forge-toolbar-height`                      | Controls the height.
 | `--forge-toolbar-min-height`                  | Controls the minimum height.
-| `--forge-toolbar-padding`                     | Controls the left and right padding.
+| `--forge-toolbar-padding`                     | Controls the left and right padding using the `padding-inline` style.
 | `--forge-toolbar-border-bottom`               | Controls the style for the bottom border. Can be set to "none" for no border.
 | `--forge-toolbar-border-top`                  | Controls the style for the top border. Can be set to "none" for no border. **only applies when inverted.**
 | `--forge-toolbar-border-top-left-radius`      | Sets the top left border radius.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
- Added new `no-padding` attribute (no JavaScript property) to set internal `padding-inline` to `0`
- Added new `auto-height` attribute (no JavaScript property) to set internal `height` to `auto` for dynamically sized toolbars
- Switched from using both `padding-left` and `padding-right` to only `padding-inline`. This allows for setting the inline padding with a single property and to enable developers to customize the start (previously left) and end (previously right) padding separately.
- Added a default (unnamed) slot. This is the same as the `start` slot, but now that a default slot exists where content is most commonly placed, it becomes easier to use without causing questions/confusion when content doesn't render.

## Additional information
This is in response to me personally using this component and realizing some of its drawbacks, and based on feedback from others about various features that could make it easier to use and provide more flexibility.
