### PR TITLE
fix(list-item): remove unused `::before` pseudo element from slotted elements

### DIFF
--- a/src/lib/list/list-item/_mixins.scss
+++ b/src/lib/list/list-item/_mixins.scss
@@ -317,8 +317,6 @@
 @mixin subtitle() {
   @include mdc-typography.typography(body2);
   @include mdc-typography.overflow-ellipsis;
-  @include mdc-typography.baseline-top(20);
-
   @include mdc-theme.property(color, text-secondary-on-background);
 
   display: block;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Nothing has been changed functionally or visually. We were previously applying the `baseline-top` mixin from MDC to slotted elements, but since we weren't providing the value with a `px` suffix it was actually not applying the `height` properly and leaving the unused `::before` pseudo element in the DOM for no reason.

We can safely remove this mixin because our design does not require it.

## Additional information
Fixes #254 
