### PR TITLE
perf: checkbox, radio, and switch will now instantiate ripple upon first user interaction

### DIFF
--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -130,19 +130,18 @@ export class ButtonComponent extends BaseComponent implements IButtonComponent {
   private async _deferRippleInitialization(): Promise<void> {
     const type = await userInteractionListener(this._buttonElement);
     if (!this._rippleInstance) {
-      this._initRipple();
+      this._rippleInstance = this._createRipple();
       if (type === 'focusin') {
-        // eslint-disable-next-line @typescript-eslint/dot-notation
-        (this._rippleInstance as ForgeRipple)['foundation'].handleFocus();
+        this._rippleInstance.handleFocus();
       }
     }
   }
 
-  private _initRipple(): void {
+  private _createRipple(): ForgeRipple {
     if (this._rippleInstance) {
       this._rippleInstance.destroy();
     }
-    this._rippleInstance = new ForgeRipple(this._buttonElement);
+    return new ForgeRipple(this._buttonElement);
   }
 
   private _initializeButtonChildren(): void {

--- a/src/lib/checkbox/checkbox-foundation.ts
+++ b/src/lib/checkbox/checkbox-foundation.ts
@@ -133,14 +133,12 @@ export class CheckboxFoundation implements ICheckboxFoundation {
     // the user interacted with the checkbox before the animation was finished.
     if (this._currentAnimationClass.length > 0) {
       clearTimeout(this._animEndLatchTimer);
-      this._adapter.forceLayout();
       this._adapter.removeRootClass(this._currentAnimationClass);
     }
     // Check to ensure that there isn't a previously existing animation class, in case for example
     // the user interacted with the checkbox before the animation was finished.
     if (this._currentAnimationClass.length > 0) {
       clearTimeout(this._animEndLatchTimer);
-      this._adapter.forceLayout();
       this._adapter.removeRootClass(this._currentAnimationClass);
     }
 
@@ -153,8 +151,6 @@ export class CheckboxFoundation implements ICheckboxFoundation {
       this._adapter.setRootClass(this._currentAnimationClass);
       this._enableAnimationEndHandler = true;
     }
-
-    this._adapter.forceLayout();
   }
 
   private _handleInputAttributeChange(): void {

--- a/src/lib/dialog/dialog-adapter.ts
+++ b/src/lib/dialog/dialog-adapter.ts
@@ -1,10 +1,6 @@
-import { getShadowElement, removeElement, deepQuerySelectorAll, getActiveElement, toggleClass } from '@tylertech/forge-core';
+import { deepQuerySelectorAll, getActiveElement, getShadowElement, removeElement, toggleClass } from '@tylertech/forge-core';
 import { BACKDROP_CONSTANTS, IBackdropComponent } from '../backdrop';
-import { CHECKBOX_CONSTANTS } from '../checkbox';
 import { BaseAdapter, IBaseAdapter } from '../core/base/base-adapter';
-import { ICON_BUTTON_CONSTANTS } from '../icon-button';
-import { RADIO_CONSTANTS } from '../radio';
-import { SWITCH_CONSTANTS } from '../switch';
 import { IDialogComponent } from './dialog';
 import { DialogPositionType, DIALOG_CONSTANTS } from './dialog-constants';
 
@@ -28,7 +24,6 @@ export interface IDialogAdapter extends IBaseAdapter {
   addRootClass(name: string): void;
   setFullscreen(value: boolean): void;
   setMoveable(value: boolean): void;
-  tryLayoutChildren(): void;
   setMoveTarget(selector: string): boolean;
   setMoveTargetHandler(type: string, listener: (evt: MouseEvent) => void): void;
   removeDragTargetHandler(type: string, listener: (evt: MouseEvent) => void): void;
@@ -155,12 +150,6 @@ export class DialogAdapter extends BaseAdapter<IDialogComponent> implements IDia
 
   public setMoveable(value: boolean): void {
     toggleClass(this._containerElement, value, DIALOG_CONSTANTS.classes.MOVEABLE);
-  }
-
-  public tryLayoutChildren(): void {
-    const layoutChildren = [ICON_BUTTON_CONSTANTS.elementName, SWITCH_CONSTANTS.elementName, CHECKBOX_CONSTANTS.elementName, RADIO_CONSTANTS.elementName];
-    const commonLayoutElements = Array.from(this._component.querySelectorAll(layoutChildren.join(','))) as any[];
-    commonLayoutElements.filter(el => typeof el.layout === 'function').forEach(el => el.layout());
   }
 
   public setMoveTarget(selector: string): boolean {

--- a/src/lib/dialog/dialog-foundation.ts
+++ b/src/lib/dialog/dialog-foundation.ts
@@ -208,13 +208,15 @@ export class DialogFoundation implements IDialogFoundation {
     if (!this._isAnimating) {
       return;
     }
+
     this._adapter.deregisterTransitionEndHandler(this._transitionEndHandler);
     this._adapter.setAnimating(false);
     this._adapter.emitHostEvent(DIALOG_CONSTANTS.events.READY);
-    this._adapter.tryLayoutChildren();
+
     if (this._moveable) {
       this._initMoveTarget();
     }
+    
     this._isAnimating = false;
   }
 

--- a/src/lib/icon-button/icon-button.ts
+++ b/src/lib/icon-button/icon-button.ts
@@ -164,20 +164,20 @@ export class IconButtonComponent extends BaseComponent implements IIconButtonCom
   private async _deferRippleInitialization(): Promise<void> {
     const type = await userInteractionListener(this._buttonElement);
     if (!this._rippleInstance) {
-      this._initRipple();
+      this._rippleInstance = this._createRipple();
       if (type === 'focusin') {
-        // eslint-disable-next-line @typescript-eslint/dot-notation
-        (this._rippleInstance as ForgeRipple)['foundation'].handleFocus();
+        this._rippleInstance.handleFocus();
       }
     }
   }
 
-  private _initRipple(): void {
+  private _createRipple(): ForgeRipple {
     if (this._rippleInstance) {
       this._rippleInstance.destroy();
     }
-    this._rippleInstance = new ForgeRipple(this._buttonElement);
-    this._rippleInstance.unbounded = true;
+    const ripple = new ForgeRipple(this._buttonElement);
+    ripple.unbounded = true;
+    return ripple;
   }
 
   private _toggleValue(): void {

--- a/src/lib/list/list-item/list-item-foundation.ts
+++ b/src/lib/list/list-item/list-item-foundation.ts
@@ -348,8 +348,7 @@ export class ListItemFoundation implements IListItemFoundation {
       if (this._ripple && !this._static && !this._rippleInstance) { // need to re-check after await
         this._rippleInstance = this._adapter.createRipple();
         if (type === 'focusin') {
-          // eslint-disable-next-line @typescript-eslint/dot-notation
-          (this._rippleInstance as ForgeRipple)['foundation'].handleFocus();
+          this._rippleInstance.handleFocus();
         }
       }
     } else if ((!this._ripple || this._static) && this._rippleInstance) {

--- a/src/lib/radio/radio-foundation.ts
+++ b/src/lib/radio/radio-foundation.ts
@@ -17,7 +17,7 @@ export class RadioFoundation implements IRadioFoundation {
 
   public connect(): void {
     this._adapter.connect();
-    this._adapter.initializeRipple();
+    this._adapter.deferRippleInitialization();
     this._focusListenerCallback = () => this._adapter.syncFocusedStateWithInput();
     this._disabledListenerCallback = () => this._adapter.syncDisabledStateWithInput();
     this._syncRadiogroupCheckStyles = () => this._adapter.syncRadiogroupCheckStyles();

--- a/src/lib/ripple/forge-ripple.ts
+++ b/src/lib/ripple/forge-ripple.ts
@@ -1,6 +1,10 @@
 import { MDCRipple, type MDCRippleAdapter, MDCRippleFoundation, type MDCRippleCapableSurface } from '@material/ripple';
 
-export class ForgeRipple extends MDCRipple {}
+export class ForgeRipple extends MDCRipple {
+  public handleFocus(): void {
+    this.foundation.handleFocus();
+  }
+}
 export class ForgeRippleFoundation extends MDCRippleFoundation {}
 export {
   MDCRippleAdapter as ForgeRippleAdapter,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Several related changes were made regarding performance concerns with how/when the MDC ripple is instantiated. Overall the goal is to delay ripple instantiation until first user interaction to avoid the overhead the ripple causes.

Changes made:
- Delay ripple instantiation until first user interaction on checkbox, radio, and switch
- Remove unnecessary `layout()` method calls in the checkbox when toggling checked state
  - Tested with 1000 checkboxes on a page and noticed very little lag after this change.
- Remove legacy code in the dialog that would attempt to call the `layout()` method on checkbox, radio, and switch to "fix" incorrect ripple alignment after opening due to `transform: scale()`.
  - This is no longer necessary given that the ripple won't be immediately instantiated.
- Updated existing implementations of this pattern on button, icon-button, and list-item to fix some syntax inconsistencies, and reduce unsafe access to protected members of `MDCRipple`.

## Additional information
Fixes #256 
Fixes #242 
