### PR TITLE
feat: added CSS custom property for controlling the internal `border-style` on select, text-field, and chip-field

### DIFF
--- a/src/lib/field/_base.scss
+++ b/src/lib/field/_base.scss
@@ -60,7 +60,7 @@
 }
 
 // Outline
-@mixin outline-core($custom-prop-text-field-background) {
+@mixin outline-core($custom-prop-text-field-background, $custom-prop-border-style) {
   display: flex;
   position: absolute;
   top: 0;
@@ -72,7 +72,7 @@
   max-width: 100%;
   height: 100%;
   pointer-events: none;
-  border-style: solid;
+  @include theme.css-custom-property(border-style, $custom-prop-border-style, solid);
   border-width: map.get(variables.$outline, border-width, default);
   transition: mdc-animation.enter(border-color, 200ms);
   @include theme.css-custom-property(

--- a/src/lib/field/_selector.scss
+++ b/src/lib/field/_selector.scss
@@ -35,7 +35,7 @@
   @if list.index($exclude, core) == null {
     &::before {
       content: '';
-      @include base.outline-core(--#{$component-selector}-theme-background);
+      @include base.outline-core(--#{$component-selector}-theme-background, --#{$component-selector}-border-style);
     }
   }
   // Border Color

--- a/src/stories/src/components/chip-field/chip-field.mdx
+++ b/src/stories/src/components/chip-field/chip-field.mdx
@@ -152,14 +152,15 @@ Controls the floating state of the label. Call this to manually float the label.
 
 ## CSS custom Properties
 
-| Name                                                       | Description
-| :----------------------------------------------------------| :---------------
+| Name                                                      | Description
+| :---------------------------------------------------------| :---------------
 | **Field**                                                 |
 | `--forge-theme-form-field-disabled-on-background`         | Controls the disabled background-color of the field element.
 | `--forge-chip-field-height`                               | Controls the height of the field element. Default value is `3.5rem`.
 | `--forge-chip-field-margin-top`                           | Controls the margin-top of the field element. Default value is `0`.
 | **Outline**                                               |
 | `--forge-chip-field-theme-background`                     | Controls the background-color of the outline element.
+| `--forge-chip-field-border-style`                         | Controls the `border-style` (defaults to `solid`). Set to `none` to remove the border.
 | `--forge-theme-form-field-disabled-on-background`         | Controls the disabled background-color of the outline element.
 | `--mdc-theme-text-icon-on-background`                     | Controls the border-color of the outline element.
 | `--mdc-theme-text-primary-on-background`                  | Controls the hover border-color for the outline element.

--- a/src/stories/src/components/select/select.mdx
+++ b/src/stories/src/components/select/select.mdx
@@ -330,6 +330,7 @@ Sets focus to the internal button element.
 | `--forge-select-margin-top`                               | Controls the margin-top of the field element. Default value is `0`.
 | **Outline**                                               |
 | `--forge-select-theme-background`                         | Controls the background-color of the outline element.
+| `--forge-select-border-style`                             | Controls the `border-style` (defaults to `solid`). Set to `none` to remove the border.
 | `--forge-theme-form-field-disabled-on-background`         | Controls the disabled background-color of the outline element.
 | `--mdc-theme-text-icon-on-background`                     | Controls the border-color of the outline element.
 | `--mdc-theme-text-primary-on-background`                  | Controls the hover border-color for the outline element.
@@ -362,8 +363,6 @@ Sets focus to the internal button element.
 | `--mdc-theme-text-disabled-on-light`                      | Controls the disabled color of the icon elements.
 | **Placeholder**                                           |
 | `--mdc-theme-text-secondary-on-background`                | Controls the color of the placeholder element.
-
-> **Note:** To hide the border, add the following CSS declaration: `--forge-select-border-display: none;`
 
 </PageSection>
 

--- a/src/stories/src/components/text-field/text-field.mdx
+++ b/src/stories/src/components/text-field/text-field.mdx
@@ -135,6 +135,7 @@ The `default` variant is intended to be used in desktop applications.
 | `--forge-text-field-margin-top`                           | Controls the margin-top of the field element. Default value is `0`.
 | **Outline**                                               |
 | `--forge-text-field-theme-background`                     | Controls the background-color of the outline element.
+| `--forge-text-field-border-style`                         | Controls the `border-style` (defaults to `solid`). Set to `none` to remove the border.
 | `--forge-theme-form-field-disabled-on-background`         | Controls the disabled background-color of the outline element.
 | `--mdc-theme-text-icon-on-background`                     | Controls the border-color of the outline element.
 | `--mdc-theme-text-primary-on-background`                  | Controls the hover border-color for the outline element.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The following CSS custom properties have been added:
- select: `--forge-select-border-style`
- text-field: `--forge-text-field-border-display`
- chip-field: `--forge-chip-field-border-display`

The docs have been updated to reflect this in Storybook.

## Additional information
Fixes #175 

The old name referenced in the issue (`--forge-select-border-display`) was renamed to more obvious to what it now controls and that note has been removed from the docs as it was an artifact from the legacy library.
