### PR TITLE
fix(table): fixed a bug where the `pointer` cursor could be lost when `allowRowClick` is enabled

### DIFF
--- a/src/lib/table/table-utils.ts
+++ b/src/lib/table/table-utils.ts
@@ -121,6 +121,7 @@ export class TableUtils {
     // If we are allowing click events on the table rows then attach the row click listeners
     if (configuration.clickListener) {
       TableUtils._attachRowClickListeners(tbody, configuration.clickListener, configuration.doubleClickListener);
+      TableUtils._addRowClickAttributes(tbody);
     }
 
     // Add the select column if necessary

--- a/src/test/spec/table/table.spec.ts
+++ b/src/test/spec/table/table.spec.ts
@@ -808,10 +808,29 @@ describe('TableComponent', function(this: ITestContext) {
 
     it('should set allow row click', function(this: ITestContext) {
       this.context = setupTestContext();
-      this.context.component.allowRowClick = false;
-      expect(this.context.component.allowRowClick).toBe(false, 'Expected allow row click to be false');
+      this.context.component.columnConfigurations = columns;
+      this.context.component.data = data;
+      
       this.context.component.allowRowClick = true;
-      expect(this.context.component.allowRowClick).toBe(true, 'Expected allow row click to be true');
+      expect(this.context.component.allowRowClick).withContext('Expected allow row click to be true').toBeTrue();
+
+      const hasClickableClass = Array.from(this.context.getTableElement().tBodies[0].rows)
+                                  .every(r => r.classList.contains(TABLE_CONSTANTS.classes.TABLE_BODY_ROW_CLICKABLE));
+      expect(hasClickableClass).toBeTrue();
+    });
+
+    it('should apply clickable class when data changes', function(this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.component.columnConfigurations = columns;
+      this.context.component.data = data;
+      this.context.component.allowRowClick = true;
+      
+
+      this.context.component.data = [...this.context.component.data];
+
+      const hasClickableClass = Array.from(this.context.getTableElement().tBodies[0].rows)
+                                  .every(r => r.classList.contains(TABLE_CONSTANTS.classes.TABLE_BODY_ROW_CLICKABLE));
+      expect(hasClickableClass).toBeTrue();
     });
 
     it('should set select rows from code', function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The `cursor: pointer` style will now properly stay applied on all `<tr>` elements within `<tbody>` when re-rendering the data.

## Additional information
Fixes #287 
