### PR TITLE
fix(chip-field): fixed a bug where addon-end slot was not expanding full height as the field grew

### DIFF
--- a/src/dev/pages/chip-field/chip-field.ejs
+++ b/src/dev/pages/chip-field/chip-field.ejs
@@ -1,6 +1,6 @@
 <div class="vert">
   <forge-chip-field id="demo-simple-chip-field">
-    <label slot="label" for="demo-chip-field-input">Choose state</label>
+    <label slot="label" for="demo-chip-field-input">Test label</label>
     <input type="text" id="demo-chip-field-input">
   </forge-chip-field>
 

--- a/src/lib/chip-field/_selector.scss
+++ b/src/lib/chip-field/_selector.scss
@@ -2,19 +2,18 @@
 @use './base';
 
 @mixin field {
-  .forge-chip-field {
-    // Core
-    @include base.field-core;
-    // Height
-    &:not(.forge-field--dense):not(.forge-field--roomy) {
-      @include base.field-height(default, --forge-chip-field-height);
-    }
-    &.forge-field--roomy:not(.forge-field--dense) {
-      @include base.field-height(roomy, --forge-chip-field-height);
-    }
-    &.forge-field--dense:not(.forge-field--roomy) {
-      @include base.field-height(dense, --forge-chip-field-height);
-    }
+  // Core
+  @include base.field-core;
+
+  // Height
+  &:not(.forge-field--dense):not(.forge-field--roomy) {
+    @include base.field-height(default, --forge-chip-field-height);
+  }
+  &.forge-field--roomy:not(.forge-field--dense) {
+    @include base.field-height(roomy, --forge-chip-field-height);
+  }
+  &.forge-field--dense:not(.forge-field--roomy) {
+    @include base.field-height(dense, --forge-chip-field-height);
   }
 }
 

--- a/src/lib/chip-field/chip-field.scss
+++ b/src/lib/chip-field/chip-field.scss
@@ -1,6 +1,6 @@
 @use './mixins';
 
-@include mixins.core-styles();
+@include mixins.core-styles;
 
 :host {
   @include mixins.host;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The `addon-end` container will now properly grow with the field height.

![image](https://user-images.githubusercontent.com/2653457/236007856-953470f6-c44f-4317-90b7-f8ad8b5312bc.png)

Some other internal styles were not being applied properly due to incorrect selector nesting, such as height CSS custom properties, and those will now work properly as well as a side effect of this.

## Additional information
Fixes #216 
