### PR TITLE
fix(menu): fixed toggle element initialization

### DIFF
--- a/src/lib/menu/menu-constants.ts
+++ b/src/lib/menu/menu-constants.ts
@@ -9,7 +9,7 @@ const classes = {
 };
 
 const selectors = {
-  TOGGLE: `.${COMPONENT_NAME_PREFIX}menu__toggle, [${elementName}-toggle], button, [type=button]`,
+  TOGGLE: `.${elementName}__toggle,[${elementName}-toggle],button,[type=button],[role=button],a,[tabindex]:not([tabindex^="-"])`,
   MENU_LIST: 'forge-list'
 };
 

--- a/src/lib/menu/menu-foundation.ts
+++ b/src/lib/menu/menu-foundation.ts
@@ -93,7 +93,7 @@ export class MenuFoundation extends CascadingListDropdownAwareFoundation<IMenuOp
     }
     this._applyMode();
     this._adapter.addTargetListener('keydown', this._keydownListener, true);
-    this._adapter.addTargetListener('blur', this._blurListener);
+    this._adapter.addTargetListener('focusout', this._blurListener);
   }
 
   private _destroyInteractionListeners(): void {
@@ -101,7 +101,7 @@ export class MenuFoundation extends CascadingListDropdownAwareFoundation<IMenuOp
       return;
     }
     this._adapter.removeTargetListener('keydown', this._clickListener);
-    this._adapter.removeTargetListener('blur', this._blurListener);
+    this._adapter.removeTargetListener('focusout', this._blurListener);
     this._adapter.removeTargetListener('click', this._clickListener);
     this._detachCascadingListeners();
   }

--- a/src/lib/menu/menu.ts
+++ b/src/lib/menu/menu.ts
@@ -1,4 +1,4 @@
-import { attachShadowTemplate, coerceBoolean, CustomElement, ensureChildren, FoundationProperty, isDefined } from '@tylertech/forge-core';
+import { attachShadowTemplate, coerceBoolean, CustomElement, ensureChild, FoundationProperty, isDefined } from '@tylertech/forge-core';
 import { tylIconArrowRight } from '@tylertech/tyler-icons/standard';
 import { CircularProgressComponent } from '../circular-progress';
 import { IconRegistry } from '../icon';
@@ -9,7 +9,6 @@ import { IPopupPosition, PopupComponent, PopupPlacement } from '../popup';
 import { MenuAdapter } from './menu-adapter';
 import { IMenuActiveChangeEventData, IMenuOption, IMenuOptionGroup, IMenuSelectEventData, MenuMode, MenuOptionBuilder, MenuOptionFactory, MENU_CONSTANTS } from './menu-constants';
 import { MenuFoundation } from './menu-foundation';
-
 import template from './menu.html';
 import styles from './menu.scss';
 
@@ -87,10 +86,10 @@ export class MenuComponent extends ListDropdownAware implements IMenuComponent {
   }
 
   public connectedCallback(): void {
-    if (this.children.length) {
+    if (this.querySelector(MENU_CONSTANTS.selectors.TOGGLE)) {
       this._foundation.initialize();
     } else {
-      ensureChildren(this).then(() => this._foundation.initialize());
+      ensureChild(this, MENU_CONSTANTS.selectors.TOGGLE).then(() => this._foundation.initialize());
     }
   }
 

--- a/src/test/spec/menu/menu.spec.ts
+++ b/src/test/spec/menu/menu.spec.ts
@@ -1,16 +1,15 @@
-import { getShadowElement, removeElement } from '@tylertech/forge-core';
-import { dispatchKeyEvent, tick, timer } from '@tylertech/forge-testing';
 import {
   defineMenuComponent,
-  IListComponent,
-  IMenuComponent,
+  IListComponent, IListItemComponent, IMenuAdapter, IMenuComponent,
+  IMenuFoundation,
   IMenuOption,
   IPopupComponent,
   LIST_ITEM_CONSTANTS,
   MENU_CONSTANTS,
-  POPUP_CONSTANTS,
-  IListItemComponent
+  POPUP_CONSTANTS
 } from '@tylertech/forge';
+import { getShadowElement, removeElement } from '@tylertech/forge-core';
+import { tick, timer } from '@tylertech/forge-testing';
 import { ICON_CLASS_NAME } from '@tylertech/forge/constants';
 
 interface ITestContext {
@@ -19,6 +18,9 @@ interface ITestContext {
 
 interface ITestMenuContext {
   component: IMenuComponent;
+  foundation: IMenuFoundation;
+  adapter: IMenuAdapter;
+  fixture: HTMLElement;
   getToggleElement(): HTMLElement;
   destroy(): void;
 }
@@ -203,6 +205,58 @@ describe('MenuComponent', function(this: ITestContext) {
   });
 
   describe('toggle element', function(this: ITestContext) {
+    it('should await dynamic toggle element', async function(this: ITestContext) {
+      this.context = setupTestContext(false);
+
+      await tick();
+      expect(this.context.adapter.hasTargetElement()).toBeFalse();
+
+      const toggleElement = createToggleElement();
+      this.context.component.appendChild(toggleElement);
+      await tick();
+
+      expect(this.context.adapter.hasTargetElement()).toBeTrue();
+    });
+
+    it('should await nested dynamic toggle element', async function(this: ITestContext) {
+      this.context = setupTestContext(false);
+
+      // Create and append an empty child element
+      const emptyContainer = document.createElement('div');
+      this.context.component.appendChild(emptyContainer);
+      await tick();
+
+      expect(this.context.adapter.hasTargetElement()).toBeFalse();
+      
+      // Create the toggle element and append to the empty child element
+      const toggleElement = createToggleElement();
+      emptyContainer.appendChild(toggleElement);
+      await tick();
+
+      expect(this.context.adapter.hasTargetElement()).toBeTrue();
+    });
+
+    fit('should close dropdown on blur when nested dynamic toggle element is provided', async function(this: ITestContext) {
+      this.context = setupTestContext(false);
+
+      const emptyContainer = document.createElement('div');
+      this.context.component.appendChild(emptyContainer);
+      await tick();
+
+      const toggleElement = createToggleElement();
+      emptyContainer.appendChild(toggleElement);
+      await tick();
+
+      toggleElement.focus();
+      toggleElement.click();
+      expect(this.context.component.open).toBeTrue();
+      expect(document.activeElement).toBe(toggleElement);
+
+      toggleElement.blur();
+      expect(this.context.component.open).toBeFalse();
+      expect(document.activeElement).not.toBe(toggleElement);
+    });
+
     it(`when clicked should open the menu`, function(this: ITestContext) {
       this.context = setupTestContext();
       this.context.getToggleElement().click();
@@ -691,15 +745,22 @@ describe('MenuComponent', function(this: ITestContext) {
     });
   });
 
-  function setupTestContext(): ITestMenuContext {
+  function setupTestContext(appendToggle = true): ITestMenuContext {
     const fixture = document.createElement('div');
     fixture.id = 'menu-test-fixture';
-    const component = document.createElement(MENU_CONSTANTS.elementName) as IMenuComponent;
-    component.appendChild(createToggleElement());
+    const component = document.createElement(MENU_CONSTANTS.elementName);
+    const foundation = component['_foundation'] as IMenuFoundation;
+    const adapter = foundation['_adapter'] as IMenuAdapter;
+    if (appendToggle) {
+      component.appendChild(createToggleElement());
+    }
     fixture.appendChild(component);
     document.body.appendChild(fixture);
     return {
       component,
+      foundation,
+      adapter,
+      fixture,
       getToggleElement: () => component.querySelector('button') as HTMLButtonElement,
       destroy: () => removeElement(fixture)
     };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
- Updated selector list for detecting toggle elements
- Updated the `connectedCallback()` to wait for a specific toggle element from the selector list before initializing
- Use the `focusout` event instead of `blur` to allow for detecting focus being lost from any child element (nested or not)

## Additional information
Fixes #249 
