### PR TITLE
feat(autocomplete): added new `filterText` property/attribute to allow for setting the filter text state manually (only applies when `allowUnmatched` is enabled)

### DIFF
--- a/src/lib/autocomplete/autocomplete-adapter.ts
+++ b/src/lib/autocomplete/autocomplete-adapter.ts
@@ -21,6 +21,7 @@ export interface IAutocompleteAdapter extends IBaseAdapter {
   appendOptions(options: IAutocompleteOption[] | IAutocompleteOptionGroup[]): void;
   setSelectedText(value: string): void;
   getInputValue(): string;
+  setInputValue(value: string): void;
   selectInputValue(): void;
   setDismissListener(listener: () => void): void;
   toggleOptionMultiple(index: number, selected: boolean): void;
@@ -156,6 +157,10 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
 
   public getInputValue(): string {
     return this._inputElement.value;
+  }
+
+  public setInputValue(value: string): void {
+    this._inputElement.value = value;
   }
 
   public selectInputValue(): void {

--- a/src/lib/autocomplete/autocomplete-constants.ts
+++ b/src/lib/autocomplete/autocomplete-constants.ts
@@ -20,6 +20,7 @@ const attributes = {
   SYNC_POPUP_WIDTH: 'sync-popup-width',
   OPEN: 'open',
   MATCH_KEY: 'match-key',
+  FILTER_TEXT: 'filter-text',
   DROPDOWN_ICON_OPEN: 'data-forge-dropdown-icon-open'
 };
 

--- a/src/lib/autocomplete/autocomplete-foundation.ts
+++ b/src/lib/autocomplete/autocomplete-foundation.ts
@@ -15,6 +15,7 @@ export interface IAutocompleteFoundation extends IListDropdownAwareFoundation {
   filterOnFocus: boolean;
   allowUnmatched: boolean;
   popupTarget: string;
+  filterText: string;
   optionBuilder: AutocompleteOptionBuilder | null | undefined;
   filter: AutocompleteFilterCallback | null | undefined;
   selectedTextBuilder: AutocompleteSelectedTextBuilder;
@@ -228,10 +229,10 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     this._filterFn();
   }
 
-  private async _debounceFilter(): Promise<void> {
+  private async _debounceFilter({ checkFocus = true } = {}): Promise<void> {
     // There is the potential that the user could have started a filter, then moved focus to another element
     // while a debounced filter is running. This check detects that scenario and stops all pending filters.
-    if (!this._adapter.hasFocus()) {
+    if (!checkFocus && !this._adapter.hasFocus()) {
       this._pendingFilterPromises = [];
       if (this._isDropdownOpen) {
         this._closeDropdown();
@@ -846,6 +847,28 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
   public set popupTarget(value: string) {
     if (this._popupTarget !== value) {
       this._popupTarget = value;
+    }
+  }
+
+  /**
+   * Gets/sets the filter text.
+   * 
+   * Setting the filter text only applies when allowUnmatched is enabled.
+   */
+  public get filterText(): string {
+    return this._filterText;
+  }
+  public set filterText(value: string) {
+    if (this._filterText !== value) {
+      this._filterText = this._allowUnmatched ? value : '';
+
+      if (this._isInitialized && this._allowUnmatched) {
+        this._adapter.setInputValue(this._filterText);
+
+        if (this._isDropdownOpen) {
+          this._debounceFilter({ checkFocus: false });
+        }
+      }
     }
   }
 

--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -24,6 +24,7 @@ export interface IAutocompleteComponent extends IListDropdownAware {
   allowUnmatched: boolean;
   matchKey: string | null | undefined;
   popupTarget: string;
+  filterText: string;
   filter: AutocompleteFilterCallback | null | undefined;
   optionBuilder: AutocompleteOptionBuilder | null | undefined;
   selectedTextBuilder: AutocompleteSelectedTextBuilder;
@@ -81,7 +82,8 @@ export class AutocompleteComponent extends ListDropdownAware implements IAutocom
       AUTOCOMPLETE_CONSTANTS.attributes.OPTION_LIMIT,
       AUTOCOMPLETE_CONSTANTS.attributes.SYNC_POPUP_WIDTH,
       AUTOCOMPLETE_CONSTANTS.attributes.OPEN,
-      AUTOCOMPLETE_CONSTANTS.attributes.MATCH_KEY
+      AUTOCOMPLETE_CONSTANTS.attributes.MATCH_KEY,
+      AUTOCOMPLETE_CONSTANTS.attributes.FILTER_TEXT
     ];
   }
 
@@ -133,6 +135,9 @@ export class AutocompleteComponent extends ListDropdownAware implements IAutocom
       case AUTOCOMPLETE_CONSTANTS.attributes.MATCH_KEY:
         this.matchKey = newValue;
         break;
+      case AUTOCOMPLETE_CONSTANTS.attributes.FILTER_TEXT:
+        this.filterText = newValue;
+        break;
     }
   }
 
@@ -163,6 +168,14 @@ export class AutocompleteComponent extends ListDropdownAware implements IAutocom
   /** Gets/sets the selector that will be used to find an element to attach the popup to. Defaults to the input element. */
   @FoundationProperty()
   public declare popupTarget: string;
+
+  /**
+   * Gets/sets the filter text.
+   * 
+   * Setting the filter text only applies when allowUnmatched is enabled.
+   */
+  @FoundationProperty()
+  public declare filterText: string;
 
   /** Sets the option builder callback that will be executed when building the option list in the dropdown. */
   @FoundationProperty()

--- a/src/stories/src/components/autocomplete/autocomplete.mdx
+++ b/src/stories/src/components/autocomplete/autocomplete.mdx
@@ -130,6 +130,14 @@ Gets/sets the selected value(s).
 Sets the callback that will be executed when a user selects an option. This will allow you to cancel or validate the selection prior to the UI being updated.
   
 </PropertyDef>
+
+<PropertyDef name="filterText" type="string" defaultValue="''">
+
+Gets/sets the filter text.
+
+Setting the filter text only applies when `allowUnmatched` is enabled.
+  
+</PropertyDef>
  
 </PageSection>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
A new `filterText` property/attribute is available on the `<forge-autocomplete>`. This property is only useful when `allowUnmatched` is `true`, but it allows the developer to manually update the internal filter text state. It will also set the `value` property on the child `<input>` element, and if the dropdown is currently open when set then it will execute the filter.

## Additional information
Closes #141
