### PR TITLE
fix(quantity-field): remove increment and decrement buttons from the tab order by default

### DIFF
--- a/src/dev/pages/quantity-field/quantity-field.ejs
+++ b/src/dev/pages/quantity-field/quantity-field.ejs
@@ -1,0 +1,19 @@
+<forge-quantity-field>
+  <label slot="label">Favorite number</label>
+  <forge-icon-button slot="decrement-button">
+    <button type="button">
+      <forge-icon name="remove_circle_outline"></forge-icon>
+    </button>
+  </forge-icon-button>
+  <forge-text-field>
+    <input type="number" style="text-align: center; width: 64px;" />
+  </forge-text-field>
+  <forge-icon-button slot="increment-button">
+    <button type="button">
+      <forge-icon name="control_point"></forge-icon>
+    </button>
+  </forge-icon-button>
+  <div slot="helper-text">Choose your favorite number</div>
+</forge-quantity-field>
+
+<script type="module" src="quantity-field.ts"></script>

--- a/src/dev/pages/quantity-field/quantity-field.html
+++ b/src/dev/pages/quantity-field/quantity-field.html
@@ -1,0 +1,8 @@
+<%-
+include('./src/partials/page.ejs', {
+  page: {
+    title: 'Quantity field',
+    includePath: './pages/quantity-field/quantity-field.ejs'
+  }
+})
+%>

--- a/src/dev/pages/quantity-field/quantity-field.ts
+++ b/src/dev/pages/quantity-field/quantity-field.ts
@@ -1,0 +1,2 @@
+import '$src/shared';
+import '@tylertech/forge/quantity-field';

--- a/src/dev/src/components.json
+++ b/src/dev/src/components.json
@@ -35,6 +35,7 @@
   { "label": "Page state", "path": "/pages/page-state/page-state.html" },
   { "label": "Paginator", "path": "/pages/paginator/paginator.html", "tags": ["table", "data"] },
   { "label": "Popup", "path": "/pages/popup/popup.html" },
+  { "label": "Quantity field", "path": "/pages/quantity-field/quantity-field.html", "tags": ["form", "field"] },
   { "label": "Radio", "path": "/pages/radio/radio.html", "tags": ["form"] },
   { "label": "Ripple", "path": "/pages/ripple/ripple.html" },
   { "label": "Scaffold", "path": "/pages/scaffold/scaffold.html" },

--- a/src/lib/quantity-field/quantity-field-adapter.ts
+++ b/src/lib/quantity-field/quantity-field-adapter.ts
@@ -5,6 +5,7 @@ import { QUANTITY_FIELD_CONSTANTS } from './quantity-field-constants';
 import { TextFieldComponent } from '../text-field';
 
 export interface IQuantityFieldAdapter extends IBaseAdapter {
+  initializeButtons(): void;
   addRootClass(name: string): void;
   removeRootClass(name: string): void;
   inputHasAttribute(name: string): boolean;
@@ -43,6 +44,15 @@ export class QuantityFieldAdapter extends BaseAdapter<IQuantityFieldComponent> i
     this._rootElement = getShadowElement(component, QUANTITY_FIELD_CONSTANTS.selectors.ROOT);
     this._incrementButtonSlot = getShadowElement(this._component, QUANTITY_FIELD_CONSTANTS.selectors.INCREMENT_BUTTON_SLOT) as HTMLSlotElement;
     this._decrementButtonSlot = getShadowElement(this._component, QUANTITY_FIELD_CONSTANTS.selectors.DECREMENT_BUTTON_SLOT) as HTMLSlotElement;
+  }
+
+  public initializeButtons(): void {
+    if (this._incrementButton && !this._incrementButton.hasAttribute('tabindex')) {
+      this._incrementButton.tabIndex = -1;
+    }
+    if (this._decrementButton && !this._decrementButton.hasAttribute('tabindex')) {
+      this._decrementButton.tabIndex = -1;
+    }
   }
 
   public addRootClass(name: string): void {

--- a/src/lib/quantity-field/quantity-field-foundation.ts
+++ b/src/lib/quantity-field/quantity-field-foundation.ts
@@ -28,6 +28,7 @@ export class QuantityFieldFoundation implements IQuantityFieldFoundation {
   public connect(): void {
     this._adapter.addInputDisabledAttributeChangeListener(() => this._syncDisabledStateOfButtons());
     this._syncDisabledStateOfButtons();
+    this._adapter.initializeButtons();
   }
 
   public disconnect(): void {

--- a/src/lib/quantity-field/quantity-field.ts
+++ b/src/lib/quantity-field/quantity-field.ts
@@ -1,4 +1,5 @@
 import { CustomElement, attachShadowTemplate, coerceBoolean, FoundationProperty } from '@tylertech/forge-core';
+import { tylIconRemoveCircleOutline, tylIconControlPoint } from '@tylertech/tyler-icons/standard';
 import { QuantityFieldAdapter } from './quantity-field-adapter';
 import { QuantityFieldFoundation } from './quantity-field-foundation';
 import { QUANTITY_FIELD_CONSTANTS } from './quantity-field-constants';
@@ -7,6 +8,7 @@ import { BaseComponent, IBaseComponent } from '../core/base/base-component';
 
 import template from './quantity-field.html';
 import styles from './quantity-field.scss';
+import { IconRegistry } from '../icon';
 
 export interface IQuantityFieldComponent extends IBaseComponent {
   invalid: boolean;
@@ -44,6 +46,11 @@ export class QuantityFieldComponent extends BaseComponent implements IQuantityFi
     super();
     attachShadowTemplate(this, template, styles);
     this._foundation = new QuantityFieldFoundation(new QuantityFieldAdapter(this));
+
+    IconRegistry.define([
+      tylIconRemoveCircleOutline,
+      tylIconControlPoint
+    ]);
   }
 
   public connectedCallback(): void {

--- a/src/stories/src/components/quantity-field/quantity-field.mdx
+++ b/src/stories/src/components/quantity-field/quantity-field.mdx
@@ -27,6 +27,9 @@ If the user is unlikely to use the increment and decrement buttons to get to the
   <QuantityFieldDemo/>
 </LiveDemo>
 
+> By default the increment and decrement buttons are removed from the tab order. If you would like them to be included,
+> place a `tabindex="0"` attribute on each of the `<button>` elements.
+
 </PageSection>
 
 <PageSection>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The `<forge-quantity-field>` will now attempt to set `tabindex="-1"` on the increment and decrement `<button>` elements during initialization (if a `tabindex` attribute does not already exist). This allows for developers to opt-in to including them in the tab order if they choose, otherwise for keyboard users the up & down arrow keys control the increment and decrement actions respectively.

## Additional information
Fixes #253 
