### PR TITLE
fix(busy-indicator): fixed various accessibility issues

### DIFF
--- a/src/lib/busy-indicator/_mixins.scss
+++ b/src/lib/busy-indicator/_mixins.scss
@@ -136,6 +136,7 @@
   @include mdc-theme.property(color, text-secondary-on-background);
 
   flex: 1 auto;
+  margin-block: 0;
 
   &:nth-child(2) {
     margin-left: 16px;

--- a/src/lib/busy-indicator/busy-indicator.html
+++ b/src/lib/busy-indicator/busy-indicator.html
@@ -1,10 +1,10 @@
 <template>
   <forge-backdrop part="backdrop" fixed></forge-backdrop>
-  <div class="forge-busy-indicator__surface" role="alertdialog" aria-modal="true" part="surface" tabindex="0">
-    <h1 class="forge-busy-indicator__title" part="title">Loading</h1>
+  <div class="forge-busy-indicator__surface" role="alert" aria-labelledby="title" aria-describedby="message" part="surface" tabindex="0">
+    <h1 id="title" class="forge-busy-indicator__title" part="title">Loading</h1>
     <div class="forge-busy-indicator__message-container" part="message-container">
       <forge-circular-progress class="forge-busy-indicator__spinner" part="spinner" aria-hidden="true"></forge-circular-progress>
-      <p class="forge-busy-indicator__message" part="message" aria-atomic="true" aria-live="polite"></p>
+      <p id="message" class="forge-busy-indicator__message" part="message"></p>
       <forge-button class="forge-busy-indicator__forge-cancel-button" part="cancel-button">
         <button type="button" class="forge-busy-indicator__cancel-button" part="cancel-button-element">Cancel</button>
       </forge-button>

--- a/src/lib/busy-indicator/busy-indicator.html
+++ b/src/lib/busy-indicator/busy-indicator.html
@@ -1,16 +1,16 @@
 <template>
   <forge-backdrop part="backdrop" fixed></forge-backdrop>
-  <aside class="forge-busy-indicator__surface" role="alertdialog" aria-modal="true" part="surface" tabindex="0">
-    <h3 class="forge-busy-indicator__title" part="title">Loading</h3>
+  <div class="forge-busy-indicator__surface" role="alertdialog" aria-modal="true" part="surface" tabindex="0">
+    <h1 id="title" class="forge-busy-indicator__title" part="title">Loading</h1>
     <div class="forge-busy-indicator__message-container" part="message-container">
-      <forge-circular-progress class="forge-busy-indicator__spinner" part="spinner"></forge-circular-progress>
-      <span class="forge-busy-indicator__message" part="message"></span>
+      <forge-circular-progress class="forge-busy-indicator__spinner" part="spinner" aria-hidden="true"></forge-circular-progress>
+      <p id="message" class="forge-busy-indicator__message" part="message" aria-atomic="true" aria-live="polite"></p>
       <forge-button class="forge-busy-indicator__forge-cancel-button" part="cancel-button">
-        <button class="forge-busy-indicator__cancel-button" part="cancel-button-element">Cancel</button>
+        <button type="button" class="forge-busy-indicator__cancel-button" part="cancel-button-element">Cancel</button>
       </forge-button>
     </div>
     <div class="forge-busy-indicator__progress-container" part="progress-bar-container">
-      <forge-linear-progress part="progress-bar"></forge-linear-progress>
+      <forge-linear-progress part="progress-bar" aria-hidden="true"></forge-linear-progress>
     </div>
-  </aside>
+  </div>
 </template>

--- a/src/lib/busy-indicator/busy-indicator.html
+++ b/src/lib/busy-indicator/busy-indicator.html
@@ -1,10 +1,10 @@
 <template>
   <forge-backdrop part="backdrop" fixed></forge-backdrop>
   <div class="forge-busy-indicator__surface" role="alertdialog" aria-modal="true" part="surface" tabindex="0">
-    <h1 id="title" class="forge-busy-indicator__title" part="title">Loading</h1>
+    <h1 class="forge-busy-indicator__title" part="title">Loading</h1>
     <div class="forge-busy-indicator__message-container" part="message-container">
       <forge-circular-progress class="forge-busy-indicator__spinner" part="spinner" aria-hidden="true"></forge-circular-progress>
-      <p id="message" class="forge-busy-indicator__message" part="message" aria-atomic="true" aria-live="polite"></p>
+      <p class="forge-busy-indicator__message" part="message" aria-atomic="true" aria-live="polite"></p>
       <forge-button class="forge-busy-indicator__forge-cancel-button" part="cancel-button">
         <button type="button" class="forge-busy-indicator__cancel-button" part="cancel-button-element">Cancel</button>
       </forge-button>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
- Use `<div>` instead of `<aside>` since we set `role` anyway
- Replace `<h3>` with `<h1>`
- Hide `<forge-circular-progress>` and `<forge-linear-progress>` from the AOM using `aria-hidden="true"` because these elements are intended to decorative.
- Use an ARIA live region on the message text and convert to a `<p>` tag.

## Additional information
Fixes #255 
