### PR TITLE
fix: stop propagation on `Escape` key events

### DIFF
--- a/src/lib/autocomplete/autocomplete-foundation.ts
+++ b/src/lib/autocomplete/autocomplete-foundation.ts
@@ -290,6 +290,7 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
       case 'Escape':
         if (this._isDropdownOpen) {
           evt.preventDefault();
+          evt.stopPropagation();
           this._closeDropdown();
         }
         break;

--- a/src/lib/calendar/calendar-foundation.ts
+++ b/src/lib/calendar/calendar-foundation.ts
@@ -298,6 +298,7 @@ export class CalendarFoundation implements ICalendarFoundation {
       case 'Escape':
         if (this._view !== 'date') {
           evt.preventDefault();
+          evt.stopPropagation();
           this._closeMenu(false, true);
         }
         break;

--- a/src/lib/date-picker/base/base-date-picker-foundation.ts
+++ b/src/lib/date-picker/base/base-date-picker-foundation.ts
@@ -253,8 +253,9 @@ export abstract class BaseDatePickerFoundation<TAdapter extends IBaseDatePickerA
 
     switch (evt.key) {
       case 'Escape':
-        evt.preventDefault();
         if (this._open) {
+          evt.preventDefault();
+          evt.stopPropagation();
           this._closeCalendar(true);
         }
         break;

--- a/src/lib/menu/menu-foundation.ts
+++ b/src/lib/menu/menu-foundation.ts
@@ -174,6 +174,7 @@ export class MenuFoundation extends CascadingListDropdownAwareFoundation<IMenuOp
       case 'Escape':
         if (this._open) {
           evt.preventDefault();
+          evt.stopPropagation();
           this._closeDropdown();
         }
         break;

--- a/src/lib/select/core/base-select-foundation.ts
+++ b/src/lib/select/core/base-select-foundation.ts
@@ -404,6 +404,7 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
 
     if (isEscapeKey) {
       evt.preventDefault();
+      evt.stopPropagation();
       if (this._open) {
         this._closeDropdown();
         return;

--- a/src/lib/time-picker/time-picker-foundation.ts
+++ b/src/lib/time-picker/time-picker-foundation.ts
@@ -181,6 +181,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
       case 'Escape':
         if (this._open) {
           evt.preventDefault();
+          evt.stopPropagation();
           this._closeDropdown(true);
         }
         break;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
All components that currently handle the `Escape` key will now call `stopPropagation()` on the `keydown` event (if they are handling it themselves) so that it doesn't bubble to other elements, such as the `<forge-dialog>` causing it to inadvertently close as well.

## Additional information
Fixes #300 
