### PR TITLE
fix(time-picker): improve input mask usability

### DIFF
--- a/src/dev/pages/time-picker/time-picker.html
+++ b/src/dev/pages/time-picker/time-picker.html
@@ -13,7 +13,7 @@ include('./src/partials/page.ejs', {
       { type: 'switch', id: 'opt-time-picker-masked', label: 'Masked', defaultValue: true },
       { type: 'switch', id: 'opt-time-picker-mask-format', label: 'Show mask format' },
       { type: 'switch', id: 'opt-time-picker-now', label: 'Show now option' },
-      { type: 'switch', id: 'opt-time-picker-hour-options', label: 'Show hour options' },
+      { type: 'switch', id: 'opt-time-picker-hour-options', label: 'Show hour options', defaultValue: true },
       { type: 'switch', id: 'opt-time-picker-custom-options', label: 'Show custom options' },
       { type: 'switch', id: 'opt-time-picker-custom-callbacks', label: 'Use custom callbacks' },
       { type: 'switch', id: 'opt-time-picker-allow-dropdown', label: 'Allow dropdown', defaultValue: true },

--- a/src/lib/core/mask/intermediate-time-parser.ts
+++ b/src/lib/core/mask/intermediate-time-parser.ts
@@ -1,14 +1,18 @@
 import { InputMask } from 'imask';
 import { ITimeInputMaskOptions } from './time-input-mask';
+import { TimeSegmentParser, TimeSegmentType } from './time-segment-parser';
 
 export class IntermediateTimeParser {
+  private segmentParser: TimeSegmentParser;
+
   constructor(
     private _char: string,
-    private _instance: InputMask<IMask.AnyMaskedOptions>,
-    private _options: ITimeInputMaskOptions) {}
+    private _mask: InputMask<IMask.AnyMaskedOptions>) {
+    this.segmentParser = new TimeSegmentParser(this._mask.value, this._char);
+  }
 
   public get value(): string {
-    return this._isAllSelected ? '' : this._instance.unmaskedValue;
+    return this._isAllSelected ? '' : this._mask.value.replace(/\s+|_/g, '');
   }
 
   public get numChar(): number {
@@ -19,39 +23,37 @@ export class IntermediateTimeParser {
     return String(this.numChar).padStart(2, '0');
   }
 
-  public get segments(): string[] {
-    return this.value.split(':').filter(s => !!s);
-  }
-
   private get _isAllSelected(): boolean {
     // eslint-disable-next-line @typescript-eslint/dot-notation
-    return this._instance['_selection']?.end === this._instance.value.length;
+    const { start, end } = this._mask['_selection'];
+    return start === 0 && end > 0 && end === this._mask.value.length;
   }
 
   /** Determines if this is the first non-zero hours character being entered. */
   public get isFirstHoursChar(): boolean {
-    return this._instance.cursorPos === 1 && this.numChar > 0;
+    return this._mask.cursorPos === 1 && this.numChar > 0;
   }
 
   /** Determines if this is the first minutes char being entered */
   public get isFirstMinutesChar(): boolean {
-    return [3, 4].includes(this._instance.cursorPos) && this.numChar > 5;
+    return [3, 4].includes(this._mask.cursorPos) && this.segmentParser.minutes.length !== 2;
   }
 
   public get isFirstSecondsChar(): boolean {
-    return [6, 7].includes(this._instance.cursorPos) && this.numChar > 5;
+    return [6, 7].includes(this._mask.cursorPos) && this.segmentParser.seconds.length !== 2;
   }
 
   public get isFinalHoursChar(): boolean {
-    return this._instance.cursorPos === 2 && this.value.length === 1;
+    // console.log('this._mask.cursorPos === 2 && this.segmentParser.hours.length === 2', this._mask.cursorPos, this.segmentParser.hours.length);
+    return this._mask.cursorPos === 3 && this.segmentParser.hours.length === 2;
   }
 
   public get isFinalMinutesChar(): boolean {
-    return this._instance.cursorPos === 5 && this.value.length === 4;
+    return this._mask.cursorPos === 6 && this.segmentParser.minutes.length === 2;
   }
 
   public get isFinalSecondsChar(): boolean {
-    return this._instance.cursorPos === 8 && this.value.length === 6;
+    return this._mask.cursorPos === 9 && this.segmentParser.seconds.length === 2;
   }
 
   public get isInitialEntry(): boolean {
@@ -59,14 +61,101 @@ export class IntermediateTimeParser {
   }
 
   public get hasOnlyHoursSegment(): boolean {
-    return this.segments.length === 1;
+    return !!this.segmentParser.hours && !this.segmentParser.minutes && !this.segmentParser.seconds;
   }
 
   public get hoursSegmentNum(): number {
-    return Number(this.segments[0]);
+    return Number(this.segmentParser.hours);
+  }
+
+  public get minutesSegmentNum(): number {
+    return Number(this.segmentParser.minutes);
+  }
+
+  public get secondsSegmentNum(): number {
+    return Number(this.segmentParser.seconds);
   }
 
   public get canOverwriteHoursChar(): boolean {
-    return this._instance.cursorPos === 3 && this.hoursSegmentNum < 3;
+    return this._mask.cursorPos === 3 && !!this.segmentParser.hours.length && this.hoursSegmentNum < 3;
   }
+
+  public get canOverwriteMinutesChar(): boolean {
+    return [5, 6].includes(this._mask.cursorPos) && !!this.segmentParser.minutes.length && this.minutesSegmentNum < 60;
+  }
+
+  public get canOverwriteSecondsChar(): boolean {
+    return [8, 9].includes(this._mask.cursorPos) && !!this.segmentParser.seconds.length && this.secondsSegmentNum < 60;
+  }
+
+  public patchUnmaskedValue(value: string, cursorPos?: number): void {
+    this._mask.unmaskedValue = value;
+    if (cursorPos !== undefined) {
+      window.requestAnimationFrame(() => this._mask.updateCursor(cursorPos));
+    }
+  }
+
+  // public process(): string {
+  //   const segmentParser = new TimeSegmentParser(this._mask.value, this._char);
+  //   const { segment, value } = segmentParser.getSegmentByCursorPosition(this._mask.cursorPos);
+
+  //   // We don't handle any parsing of meridiem values
+  //   if (segment === 'meridiem') {
+  //     return this._char;
+  //   }
+
+  //   const isSegmentFirstEntry = value.length === 1;
+  //   const isSegmentLastEntry = value.length > 1;
+
+  //   if (isSegmentFirstEntry) {
+  //     // console.log('First segment entry:', segment);
+  //     segmentParser.patchSegmentValue(segment, value);
+  //     this.patchUnmaskedValue(segmentParser.toString(), this._getCursorPositionBySegment(segment));
+  //   } else if (isSegmentLastEntry) {
+  //     // console.log('Last segment entry:', segment);
+  //     const numNewSegment = Number(`${value}${this._char}`);
+  //     if (numNewSegment <= (segment === 'hours' ? 12 : 59)) {
+  //       segmentParser.patchSegmentValue(segment, String(numNewSegment));
+  //       this.patchUnmaskedValue(segmentParser.toString(), this._getCursorPositionBySegment(segment));
+  //     }
+  //   } else {
+  //     // console.log('Overwrite segment:', segment, value);
+  //     const numValue = Number(value);
+
+  //     if (segment === 'hours') {
+  //       if (numValue <= 12 || (this._options.use24HourTime && numValue <= 23)) {
+  //         segmentParser.patchSegmentValue(segment, String(numValue));
+  //       } else {
+  //         segmentParser.patchSegmentValue('minutes', `${this._mask.value}${this.asPaddedChar}`);
+  //       }
+  //     } else {
+  //       if (numValue < 60) {
+  //         segmentParser.patchSegmentValue(segment, String(numValue));
+  //       } else {
+  //         let newSegment = segment;
+  //         if (segment === 'minutes' && this._options.showSeconds) {
+  //           newSegment = 'seconds';
+  //         }
+  //         segmentParser.patchSegmentValue(newSegment, `${this._mask.value}${this.asPaddedChar}`);
+  //       }
+  //     }
+
+  //     this.patchUnmaskedValue(segmentParser.toString(), this._getCursorPositionBySegment(segment) + 1);
+  //   }
+
+  //   return ':';
+  // }
+
+  // private _getCursorPositionBySegment(segment: TimeSegmentType): number {
+  //   switch (segment) {
+  //     case 'hours':
+  //       return 2;
+  //     case 'minutes':
+  //       return 5;
+  //     case 'seconds':
+  //       return 8;
+  //     default:
+  //       return 11;
+  //   }
+  // }
 }

--- a/src/lib/core/mask/intermediate-time-parser.ts
+++ b/src/lib/core/mask/intermediate-time-parser.ts
@@ -1,0 +1,72 @@
+import { InputMask } from 'imask';
+import { ITimeInputMaskOptions } from './time-input-mask';
+
+export class IntermediateTimeParser {
+  constructor(
+    private _char: string,
+    private _instance: InputMask<IMask.AnyMaskedOptions>,
+    private _options: ITimeInputMaskOptions) {}
+
+  public get value(): string {
+    return this._isAllSelected ? '' : this._instance.unmaskedValue;
+  }
+
+  public get numChar(): number {
+    return Number(this._char);
+  }
+
+  public get asPaddedChar(): string {
+    return String(this.numChar).padStart(2, '0');
+  }
+
+  public get segments(): string[] {
+    return this.value.split(':').filter(s => !!s);
+  }
+
+  private get _isAllSelected(): boolean {
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    return this._instance['_selection']?.end === this._instance.value.length;
+  }
+
+  /** Determines if this is the first non-zero hours character being entered. */
+  public get isFirstHoursChar(): boolean {
+    return this._instance.cursorPos === 1 && this.numChar > 0;
+  }
+
+  /** Determines if this is the first minutes char being entered */
+  public get isFirstMinutesChar(): boolean {
+    return [3, 4].includes(this._instance.cursorPos) && this.numChar > 5;
+  }
+
+  public get isFirstSecondsChar(): boolean {
+    return [6, 7].includes(this._instance.cursorPos) && this.numChar > 5;
+  }
+
+  public get isFinalHoursChar(): boolean {
+    return this._instance.cursorPos === 2 && this.value.length === 1;
+  }
+
+  public get isFinalMinutesChar(): boolean {
+    return this._instance.cursorPos === 5 && this.value.length === 4;
+  }
+
+  public get isFinalSecondsChar(): boolean {
+    return this._instance.cursorPos === 8 && this.value.length === 6;
+  }
+
+  public get isInitialEntry(): boolean {
+    return this.value.length === 0;
+  }
+
+  public get hasOnlyHoursSegment(): boolean {
+    return this.segments.length === 1;
+  }
+
+  public get hoursSegmentNum(): number {
+    return Number(this.segments[0]);
+  }
+
+  public get canOverwriteHoursChar(): boolean {
+    return this._instance.cursorPos === 3 && this.hoursSegmentNum < 3;
+  }
+}

--- a/src/lib/core/mask/time-input-mask.ts
+++ b/src/lib/core/mask/time-input-mask.ts
@@ -74,36 +74,47 @@ export class TimeInputMask {
     if (typeof this._options.prepareCallback === 'function') {
       return this._options.prepareCallback.call(null, value, masked, flags, this._mask);
     }
-    return this._prepareDefault(value, flags, maskInstance).toUpperCase();
-  }
 
-  private _prepareDefault(char: string, flags: IMask.AppendFlags, maskInstance: InputMask<IMask.AnyMaskedOptions>): string {
-    if (!flags.input || !char.length || !maskInstance) {
-      return char;
+    if (!flags.input || !value.length || !maskInstance) {
+      return value.toUpperCase();
     }
 
-    const parser = new IntermediateTimeParser(char, maskInstance, this._options);
+    // Whenever we paste text we don't care to send it through our custom prepare logic,
+    // so just return the character being processed.
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    if (maskInstance['_inputEvent']?.inputType !== 'insertText') {
+      return value;
+    }
 
+    // const parser = new IntermediateTimeParser(value, maskInstance, this._options);
+    // return parser.process();
+    return this._prepareDefault(value, maskInstance).toUpperCase();
+  }
+
+  private _prepareDefault(char: string, maskInstance: InputMask<IMask.AnyMaskedOptions>): string {
+    const parser = new IntermediateTimeParser(char, maskInstance);
+
+    // Handle non-numeric character entry here
     if (!isNumeric(char)) {
       // Before we ignore this character let's do some checks for common scenarios where the user enters a colon to help with coercion
       if (char === ':') {
         if (parser.isFinalHoursChar) {
           // The user attempted to press the colon key after entering a single hour character so let's pad the value
-          this._setMaskedValueAdjusted(parser.value.padStart(2, '0'), 3);
+          parser.patchUnmaskedValue(parser.value.padStart(2, '0'), 3);
           return char;
         }
 
         if (parser.isFinalMinutesChar) {
           // The user attempted to press the colon key after entering a single minute character so let's pad the value
           const newValue = `${parser.value.substring(0, 3)}${parser.value[3].padStart(2, '0').padStart(2, '0')}`;
-          this._setMaskedValueAdjusted(newValue, 5);
+          parser.patchUnmaskedValue(newValue, 5);
           return char;
         }
 
         if (this._options.showSeconds && parser.isFinalSecondsChar) {
           // The user attempted to press the colon key after entering a single second character so let's pad the value
           const newValue = `${parser.value.substring(0, 6)}${parser.value[5].padStart(2, '0')}${parser.value.slice(8)}`;
-          this._setMaskedValueAdjusted(newValue, 8);
+          parser.patchUnmaskedValue(newValue, 8);
           return char;
         }
       }
@@ -114,7 +125,7 @@ export class TimeInputMask {
     if (parser.isInitialEntry && parser.isFirstHoursChar) {
       // Replace just the hours segment with the padded value and update cursor position
       const newValue = `${parser.asPaddedChar}${parser.value.slice(2)}`;
-      this._setMaskedValueAdjusted(newValue, 2);
+      parser.patchUnmaskedValue(newValue, 2);
       return ':';
     }
 
@@ -124,35 +135,59 @@ export class TimeInputMask {
       if (numNewHour <= 12 || (this._options.use24HourTime && numNewHour <= 23)) {
         // Overwrite the hours segment with the entered char concatenated with the previous entry value
         const newValue = String(numNewHour);
-        this._setMaskedValueAdjusted(newValue, 3);
+        parser.patchUnmaskedValue(newValue, 3);
         return ':';
       }
     }
-    
+
+    // Check if we are entering the last hour value and automatically move to the minutes segment for next entry
+    if (parser.value.length + 1 === 2) {
+      return `${char}:`;
+    }
+
     // Attempt to pad a leading zero to the minutes segment
     if (parser.isFirstMinutesChar) {
       // Replace just the minute segment with the padded value and update cursor position
       const newValue = `${parser.value.substring(0, 3)}${parser.asPaddedChar}${parser.value.slice(5)}`;
-      this._setMaskedValueAdjusted(newValue, 5);
+      parser.patchUnmaskedValue(newValue, 5);
       return ':';
     }
     
-    // Attempt to pad a leading zero to the seconds segment
-    if (this._options.showSeconds && parser.isFirstSecondsChar) {
-      // Replace just the second segment with the padded value and update cursor position
-      const newValue = `${parser.value.substring(0, 6)}${parser.asPaddedChar}${parser.value.slice(8)}`;
-      this._setMaskedValueAdjusted(newValue, 8);
-      return ':';
+    // Attempt to overwrite the minutes (w/leading zero)
+    if (parser.canOverwriteMinutesChar) {
+      const numNewMins = +`${parser.minutesSegmentNum}${parser.numChar}`;
+      if (numNewMins < 60) {
+        const newValuePadded = String(numNewMins).padStart(2, '0');
+        // Overwrite the hours segment with the entered char concatenated with the previous entry value
+        const newValueStr = `${parser.value.substring(0, 3)}${newValuePadded}${parser.value.slice(5)}`;
+        parser.patchUnmaskedValue(newValueStr, 5);
+        return ':';
+      }
+    }
+
+    if (this._options.showSeconds) {
+      // Attempt to pad a leading zero to the seconds segment
+      if (parser.isFirstSecondsChar) {
+        // Replace just the seconds segment with the padded value and update cursor position
+        const newValue = `${parser.value.substring(0, 6)}${parser.asPaddedChar}${parser.value.slice(8)}`;
+        parser.patchUnmaskedValue(newValue, 8);
+        return ':';
+      }
+      
+      // Attempt to overwrite the minutes (w/leading zero)
+      if (parser.canOverwriteSecondsChar) {
+        const numNewSeconds = +`${parser.secondsSegmentNum}${parser.numChar}`;
+        if (numNewSeconds < 60) {
+          const newValuePadded = String(numNewSeconds).padStart(2, '0');
+          // Overwrite the seconds segment with the entered char concatenated with the previous entry value
+          const newValueStr = `${parser.value.substring(0, 6)}${newValuePadded}${parser.value.slice(8)}`;
+          parser.patchUnmaskedValue(newValueStr, 8);
+          return ':';
+        }
+      }
     }
 
     return char;
-  }
-
-  private _setMaskedValueAdjusted(value: string, cursorPos?: number): void {
-    this._mask.unmaskedValue = value;
-    if (cursorPos !== undefined) {
-      window.requestAnimationFrame(() => this._mask.updateCursor(cursorPos));
-    }
   }
 
   private _getMaskFormat(): string {

--- a/src/lib/core/mask/time-segment-parser.ts
+++ b/src/lib/core/mask/time-segment-parser.ts
@@ -15,8 +15,8 @@ const SEGMENT_INDEX_DICT: Record<TimeSegmentType, number> = {
 export class TimeSegmentParser {
   private _segments: string[];
 
-  constructor(private _timeStr: string, private _char: string) {
-    this._segments = this._parseSegments(_timeStr);
+  constructor(timeStr: string) {
+    this._segments = this._parseSegments(timeStr);
   }
 
   public get hours(): string {
@@ -33,6 +33,10 @@ export class TimeSegmentParser {
 
   public get meridiem(): string {
     return this._segments[SEGMENT_INDEX_DICT.meridiem];
+  }
+
+  public applyValue(timeStr: string): void {
+    this._segments = this._parseSegments(timeStr);
   }
 
   public patchSegmentValue(type: TimeSegmentType, value: string): string {
@@ -52,30 +56,4 @@ export class TimeSegmentParser {
     const [hours = '', minutes = '', seconds = ''] = time.split(':');
     return [hours, minutes, seconds, meridiem];
   }
-
-  // public getSegmentByCursorPosition(pos: number): ISegmentDescriptor {
-  //   const intermediateTimeStr = `${this._timeStr.substring(0, pos - 1)}${this._char}${this._timeStr.substring(pos - 1)}`;
-  //   const [hours, minutes, seconds, meridiem] = this._parseSegments(intermediateTimeStr);
-
-  //   if ([1, 2].includes(pos) && this._isSegmentValidAtPosition(0, intermediateTimeStr)) {
-  //     return { segment: 'hours', value: hours };
-  //   }
-    
-  //   // if ([3, 4, 5, 6].includes(pos) && isNumber(+intermediateTimeStr[5]) && isNumber(+intermediateTimeStr[6])) {
-  //   if ([3, 4, 5].includes(pos) && this._isSegmentValidAtPosition(3, intermediateTimeStr)) {
-  //     return { segment: 'minutes', value: minutes };
-  //   }
-    
-  //   // if (this._allowSeconds && [6, 7, 8, 9].includes(pos) && this._isSegmentValidAtPosition(6, intermediateTimeStr)) {
-  //   // // if ([6, 7, 8, 9].includes(pos) && isNumber(+intermediateTimeStr[8]) && isNumber(+intermediateTimeStr[9])) {
-  //   //   return { segment: 'seconds', value: seconds };
-  //   // }
-
-  //   return { segment: 'meridiem', value: meridiem };
-  // }
-
-  // private _isSegmentValidAtPosition(start: number, timeStr: string): boolean {
-  //   const segment = timeStr.substring(start, start + 3);
-  //   return isNumber(+segment.substring(-2));
-  // }
 }

--- a/src/lib/core/mask/time-segment-parser.ts
+++ b/src/lib/core/mask/time-segment-parser.ts
@@ -1,0 +1,81 @@
+export type TimeSegmentType = 'hours' | 'minutes' | 'seconds' | 'meridiem';
+
+export interface ISegmentDescriptor {
+  segment: TimeSegmentType;
+  value: string;
+}
+
+const SEGMENT_INDEX_DICT: Record<TimeSegmentType, number> = {
+  hours: 0,
+  minutes: 1,
+  seconds: 2,
+  meridiem: 3
+};
+
+export class TimeSegmentParser {
+  private _segments: string[];
+
+  constructor(private _timeStr: string, private _char: string) {
+    this._segments = this._parseSegments(_timeStr);
+  }
+
+  public get hours(): string {
+    return this._segments[SEGMENT_INDEX_DICT.hours];
+  }
+
+  public get minutes(): string {
+    return this._segments[SEGMENT_INDEX_DICT.minutes];
+  }
+
+  public get seconds(): string {
+    return this._segments[SEGMENT_INDEX_DICT.seconds];
+  }
+
+  public get meridiem(): string {
+    return this._segments[SEGMENT_INDEX_DICT.meridiem];
+  }
+
+  public patchSegmentValue(type: TimeSegmentType, value: string): string {
+    const index = SEGMENT_INDEX_DICT[type];
+    this._segments[index] = value.padStart(2, '0');
+    return this._segments[index];
+  }
+
+  public toString(): string {
+    const [hours, minutes, seconds, meridiem] = this._segments;
+    const timeStr = [hours, minutes, seconds].filter(v => !!v.length);
+    return `${timeStr.join(':')}${meridiem}`;
+  }
+
+  private _parseSegments(timeStr: string): string[] {
+    const [time, meridiem = ''] = timeStr.trim().replace(/\s+|_/g, '').split(/([AaPp][Mm]?)/);
+    const [hours = '', minutes = '', seconds = ''] = time.split(':');
+    return [hours, minutes, seconds, meridiem];
+  }
+
+  // public getSegmentByCursorPosition(pos: number): ISegmentDescriptor {
+  //   const intermediateTimeStr = `${this._timeStr.substring(0, pos - 1)}${this._char}${this._timeStr.substring(pos - 1)}`;
+  //   const [hours, minutes, seconds, meridiem] = this._parseSegments(intermediateTimeStr);
+
+  //   if ([1, 2].includes(pos) && this._isSegmentValidAtPosition(0, intermediateTimeStr)) {
+  //     return { segment: 'hours', value: hours };
+  //   }
+    
+  //   // if ([3, 4, 5, 6].includes(pos) && isNumber(+intermediateTimeStr[5]) && isNumber(+intermediateTimeStr[6])) {
+  //   if ([3, 4, 5].includes(pos) && this._isSegmentValidAtPosition(3, intermediateTimeStr)) {
+  //     return { segment: 'minutes', value: minutes };
+  //   }
+    
+  //   // if (this._allowSeconds && [6, 7, 8, 9].includes(pos) && this._isSegmentValidAtPosition(6, intermediateTimeStr)) {
+  //   // // if ([6, 7, 8, 9].includes(pos) && isNumber(+intermediateTimeStr[8]) && isNumber(+intermediateTimeStr[9])) {
+  //   //   return { segment: 'seconds', value: seconds };
+  //   // }
+
+  //   return { segment: 'meridiem', value: meridiem };
+  // }
+
+  // private _isSegmentValidAtPosition(start: number, timeStr: string): boolean {
+  //   const segment = timeStr.substring(start, start + 3);
+  //   return isNumber(+segment.substring(-2));
+  // }
+}

--- a/src/lib/list-dropdown/list-dropdown-adapter.ts
+++ b/src/lib/list-dropdown/list-dropdown-adapter.ts
@@ -17,6 +17,7 @@ export interface IListDropdownAdapter {
   getSelectedOptionIndex(): number;
   getActiveOptionIdByIndex(index: number): string | null;
   toggleOptionMultiple(index: number, isSelected: boolean): void;
+  scrollOptionIntoView(index: number): void;
   scrollSelectedOptionIntoView(animate?: boolean): void;
   activateSelectedOption(config: IListDropdownOpenConfig): void;
   activateOption(index: number, activeChangeCallback: ((id: string) => void) | undefined, animate?: boolean): void;
@@ -169,6 +170,13 @@ export class ListDropdownAdapter implements IListDropdownAdapter {
     const listItems = this._getListItemElements();
     if (listItems.length && listItems[index]) {
       this._toggleSelectedOption(listItems[index], isSelected);
+    }
+  }
+
+  public scrollOptionIntoView(index: number, animate = true): void {
+    const listItem = this._getListItemElements()[index];
+    if (listItem) {
+      this._scrollListItemIntoView(listItem, animate ? 'smooth' : 'auto', 'center');
     }
   }
 

--- a/src/lib/list-dropdown/list-dropdown-constants.ts
+++ b/src/lib/list-dropdown/list-dropdown-constants.ts
@@ -76,6 +76,7 @@ export interface IListDropdownConfig<T = any> {
   selectedValues?: T[];
   multiple?: boolean;
   activeStartIndex?: number;
+  visibleStartIndex?: number;
   transform?: ListDropdownTransformCallback;
   allowBusy?: boolean;
   asyncStyle?: ListDropdownAsyncStyle;

--- a/src/lib/list-dropdown/list-dropdown-foundation.ts
+++ b/src/lib/list-dropdown/list-dropdown-foundation.ts
@@ -137,6 +137,8 @@ export class ListDropdownFoundation implements IListDropdownFoundation {
       this._adapter.scrollSelectedOptionIntoView(false);
     } else if (this._config.selectedValues && this._config.selectedValues.length) {
       this._adapter.scrollSelectedOptionIntoView(false);
+    } else if (typeof this._config.visibleStartIndex === 'number' && this._nonDividerOptions[this._config.visibleStartIndex]) {
+      this._adapter.scrollOptionIntoView(this._config.visibleStartIndex);
     }
   }
 

--- a/src/lib/list-dropdown/list-dropdown-utils.ts
+++ b/src/lib/list-dropdown/list-dropdown-utils.ts
@@ -1,9 +1,8 @@
-import { addClass, getEventPath, isDefined, isObject, isDeepEqual } from '@tylertech/forge-core';
+import { addClass, getEventPath, isDeepEqual, isDefined, isObject } from '@tylertech/forge-core';
 import { tylIconCheckBox, tylIconCheckBoxOutlineBlank } from '@tylertech/tyler-icons/standard';
 import { ICON_CLASS_NAME } from '../constants';
 import { ILinearProgressComponent, LINEAR_PROGRESS_CONSTANTS } from '../linear-progress';
 import { IListComponent, LIST_CONSTANTS } from '../list/list';
-import { IListItemComponent, LIST_ITEM_CONSTANTS } from '../list/list-item';
 import { IPopupComponent, PopupAnimationType, POPUP_CONSTANTS } from '../popup';
 import { ISkeletonComponent, SKELETON_CONSTANTS } from '../skeleton';
 import { IListDropdownCascadingElementFactoryConfig, IListDropdownOpenConfig, IListDropdownOption, IListDropdownOptionGroup, ListDropdownAsyncStyle, ListDropdownIconType, ListDropdownType, LIST_DROPDOWN_CONSTANTS } from './list-dropdown-constants';

--- a/src/lib/time-picker/time-picker-adapter.ts
+++ b/src/lib/time-picker/time-picker-adapter.ts
@@ -37,6 +37,8 @@ export interface ITimePickerAdapter extends BaseAdapter<ITimePickerComponent> {
   emitInputEvent(type: string, data?: any): void;
   setInputReadonly(value: boolean): void;
   setToggleDisabled(value: boolean): void;
+  hasActiveOption(): boolean;
+  activateOptionByIndex(index: number): void;
   activateFirstOption(): void;
   getActiveOption(): IListDropdownOption | undefined;
 }
@@ -246,6 +248,14 @@ export class TimePickerAdapter extends BaseAdapter<ITimePickerComponent> impleme
         }
       }
     }
+  }
+
+  public hasActiveOption(): boolean {
+    return (this._listDropdown?.getActiveOptionIndex() ?? -1) >= 0;
+  }
+
+  public activateOptionByIndex(index: number): void {
+    this._listDropdown?.activateOption(index);
   }
 
   public activateFirstOption(): void {

--- a/src/lib/time-picker/time-picker-component-delegate.ts
+++ b/src/lib/time-picker/time-picker-component-delegate.ts
@@ -57,11 +57,7 @@ export class TimePickerComponentDelegate extends FormFieldComponentDelegate<ITim
   }
 
   public onInput(listener: (value: string) => void): void {
-    if (this._element.masked) {
-      this._element.addEventListener(TIME_PICKER_CONSTANTS.events.INPUT, (evt: CustomEvent<string>) => listener(evt.detail ?? ''));
-    } else {
-      this._textFieldDelegate.inputElement.addEventListener('input', evt => listener((evt.target as HTMLInputElement).value));
-    }
+    this._element.addEventListener(TIME_PICKER_CONSTANTS.events.INPUT, (evt: CustomEvent<string>) => listener(evt.detail ?? ''));
   }
 
   public onFocus(listener: (evt: FocusEvent) => void): void {

--- a/src/lib/time-picker/time-picker-foundation.ts
+++ b/src/lib/time-picker/time-picker-foundation.ts
@@ -73,6 +73,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
   
   // Internal state vars
   private _isInitialized = false;
+  private _dropdownConfig: IListDropdownConfig<ITimePickerOptionValue> | undefined;
 
   // Listeners
   private _inputListener: (evt: Event) => void;
@@ -191,19 +192,30 @@ export class TimePickerFoundation implements ITimePickerFoundation {
           evt.preventDefault();
           if (!this._open) {
             this._openDropdown();
-            this._adapter.activateFirstOption();
+            if (typeof this._dropdownConfig?.visibleStartIndex === 'number' && this._dropdownConfig.visibleStartIndex >= 0) {
+              this._adapter.activateOptionByIndex(this._dropdownConfig?.visibleStartIndex);
+            } else {
+              this._adapter.activateFirstOption();
+            }
             // TODO: Should we cycle the hours, minutes, seconds, or meridiem where the cursor is instead of opening the dropdown?
           } else {
-            this._adapter.propagateKey(evt.code);
+            if (!this._adapter.hasActiveOption()) {
+              this._trySetActiveOption();
+            } else {
+              this._adapter.propagateKey(evt.code);
+            }
           }
         }
         break;
-      case 'Up':
       case 'ArrowUp':
         if (this._allowDropdown) {
           evt.preventDefault();
           if (this._open) {
-            this._adapter.propagateKey(evt.code);
+            if (!this._adapter.hasActiveOption()) {
+              this._trySetActiveOption();
+            } else {
+              this._adapter.propagateKey(evt.code);
+            }
           } else {
             // TODO: cycle the hours, minutes, seconds, or meridiem where the cursor is
           }
@@ -233,6 +245,12 @@ export class TimePickerFoundation implements ITimePickerFoundation {
           }
         }
         break;
+    }
+  }
+
+  private _trySetActiveOption(): void {
+    if (!this._adapter.hasActiveOption() && typeof this._dropdownConfig?.visibleStartIndex === 'number' && this._dropdownConfig.visibleStartIndex >= 0) {
+      this._adapter.activateOptionByIndex(this._dropdownConfig?.visibleStartIndex);
     }
   }
 
@@ -543,7 +561,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
     
     const selectableOptions = options.filter(o => !o.divider && !o.disabled);
     let selectedValues: ITimePickerOptionValue[] = [];
-    let activeStartIndex: number | undefined;
+    let visibleStartIndex = 0;
     
     // Find closest match in list of time options and activate/select it
     if (options.length) {
@@ -554,29 +572,25 @@ export class TimePickerFoundation implements ITimePickerFoundation {
           if (isExactMatch) {
             selectedValues = [selectableOptions[optionIndex].value];
           } else {
-            activeStartIndex = optionIndex;
+            visibleStartIndex = optionIndex;
           }
         }
-      } else if (typeof this._startTime === 'number' || this._startTime == null) {
-        // If we don't have a start time set then let's default to the current time
-        if (this._startTime == null) {
-          const date = new Date();
-          const currentTimeString = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
-          this._startTime = timeStringToMillis(currentTimeString, true, false) as number;
-        }
-
+      } else if (typeof this._startTime === 'number') {
         const optionIndex = this._findClosestOptionIndex(this._startTime, selectableOptions);
         if (optionIndex >= 0 && optionIndex < selectableOptions.length) {
-          activeStartIndex = optionIndex;
+          visibleStartIndex = optionIndex;
         }
+      } else if (this._startTime == null) {
+        // If we don't have a start time set then let's scroll the closest time to current time into view
+        visibleStartIndex = this._getOptionIndexClosestCurrent(selectableOptions);
       }
     }
 
-    const config: IListDropdownConfig<ITimePickerOptionValue> = {
+    this._dropdownConfig = {
       id: `forge-time-picker-${this._identifier}`,
       selectedValues,
       syncWidth: true,
-      activeStartIndex,
+      visibleStartIndex,
       popupClasses: this._popupClasses,
       popupStatic: true,
       type: ListDropdownType.Standard,
@@ -586,17 +600,25 @@ export class TimePickerFoundation implements ITimePickerFoundation {
       activeChangeCallback: id => this._adapter.setActiveDescendant(id),
       targetWidthCallback: () => this._adapter.getTargetElementWidth(this._popupTarget)
     };
-    this._adapter.attachDropdown(config);
+    this._adapter.attachDropdown(this._dropdownConfig);
     this._adapter.emitHostEvent(TIME_PICKER_CONSTANTS.events.OPEN, undefined, false);
   }
 
   private _closeDropdown(emitCloseEvent = false): void {
     this._open = false;
+    this._dropdownConfig = undefined;
     this._adapter.removeHostAttribute(TIME_PICKER_CONSTANTS.attributes.OPEN);
     this._adapter.detachDropdown();
     if (emitCloseEvent) {
       this._adapter.emitHostEvent(TIME_PICKER_CONSTANTS.events.CLOSE, true, false);
     }
+  }
+
+  private _getOptionIndexClosestCurrent(options: IListDropdownOption<ITimePickerOptionValue>[]): number {
+    const date = new Date();
+    const currentTimeString = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+    const currentTimeMillis = timeStringToMillis(currentTimeString, true, false) as number;
+    return this._findClosestOptionIndex(currentTimeMillis, options);
   }
 
   private _findClosestOptionIndex(value: number, options: Array<IListDropdownOption<ITimePickerOptionValue>>): number {

--- a/src/lib/time-picker/time-picker-foundation.ts
+++ b/src/lib/time-picker/time-picker-foundation.ts
@@ -408,10 +408,8 @@ export class TimePickerFoundation implements ITimePickerFoundation {
     // Convert our milliseconds to a 24-hour time string to use as our normalized value
     const timeString = millisToTimeString(millis, true, this._allowSeconds);
 
-    // If we are using an input mask, we need to dispatch our custom input event to let consumers know input happened (before our change event)
-    if (this._masked) {
-      this._adapter.emitInputEvent(TIME_PICKER_CONSTANTS.events.INPUT, timeString);
-    }
+    // Dispatch our custom input event to let consumers know raw input occurred (before our change event)
+    this._adapter.emitInputEvent(TIME_PICKER_CONSTANTS.events.INPUT, timeString);
 
     // Only emit our change event if the value is different
     if (this._value !== millis) {
@@ -612,6 +610,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
     
     if (inputValue !== formattedValue) {
       this._adapter.setInputValue(formattedValue, emitEvents);
+      this._adapter.emitInputEvent(TIME_PICKER_CONSTANTS.events.INPUT, formattedValue);
     }
   }
 

--- a/src/lib/time-picker/time-picker-foundation.ts
+++ b/src/lib/time-picker/time-picker-foundation.ts
@@ -557,7 +557,14 @@ export class TimePickerFoundation implements ITimePickerFoundation {
             activeStartIndex = optionIndex;
           }
         }
-      } else if (typeof this._startTime === 'number') {
+      } else if (typeof this._startTime === 'number' || this._startTime == null) {
+        // If we don't have a start time set then let's default to the current time
+        if (this._startTime == null) {
+          const date = new Date();
+          const currentTimeString = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+          this._startTime = timeStringToMillis(currentTimeString, true, false) as number;
+        }
+
         const optionIndex = this._findClosestOptionIndex(this._startTime, selectableOptions);
         if (optionIndex >= 0 && optionIndex < selectableOptions.length) {
           activeStartIndex = optionIndex;

--- a/src/lib/tooltip/tooltip-foundation.ts
+++ b/src/lib/tooltip/tooltip-foundation.ts
@@ -296,6 +296,9 @@ export class TooltipFoundation implements ITooltipFoundation {
     }
   }
 
+  public set open(value: boolean) {
+    this._show();
+  }
   public get open(): boolean {
     return this._isOpen;
   }

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -94,7 +94,7 @@ export class TooltipComponent extends BaseComponent implements ITooltipComponent
   public declare position: `${PopupPlacement}`;
 
   /** Gets the open state of the tooltip. */
-  @FoundationProperty({ set: false })
+  @FoundationProperty()
   public declare open: boolean;
 
   @FoundationProperty({ set: false })

--- a/src/test/spec/menu/menu.spec.ts
+++ b/src/test/spec/menu/menu.spec.ts
@@ -236,7 +236,7 @@ describe('MenuComponent', function(this: ITestContext) {
       expect(this.context.adapter.hasTargetElement()).toBeTrue();
     });
 
-    fit('should close dropdown on blur when nested dynamic toggle element is provided', async function(this: ITestContext) {
+    it('should close dropdown on blur when nested dynamic toggle element is provided', async function(this: ITestContext) {
       this.context = setupTestContext(false);
 
       const emptyContainer = document.createElement('div');

--- a/src/test/spec/time-picker/time-picker.spec.ts
+++ b/src/test/spec/time-picker/time-picker.spec.ts
@@ -363,7 +363,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     expect(changeEventSpy).not.toHaveBeenCalled();
   });
 
-  it('should set time to curent time when "n" key is pressed', function(this: ITestContext) {
+  it('should set time to current time when "n" key is pressed', function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
     const millis = getCurrentTimeOfDayMillis(false);
@@ -373,7 +373,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     expect(this.context.component.value).toBe(expectedTimeValue);
   });
 
-  it('should set time to curent time when "n" key is pressed with seconds', function(this: ITestContext) {
+  it('should set time to current time when "n" key is pressed with seconds', function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
     const millis = getCurrentTimeOfDayMillis(true);
@@ -627,44 +627,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     expect(matchingListItem.value.time).toBe(timeMillis);
   });
 
-  it('should highlight closest matching time in dropdown if time doesn\'t match exactly', async function(this: ITestContext) {
-    this.context = _createTimePickerContext();
-
-    const timeString = '08:23';
-    const closestTimeString = '08:00';
-    const closestTimeMillis = timeStringToMillis(closestTimeString, true, false);
-    this.context.component.value = timeString;
-    this.context.component.open = true;
-
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
-
-    const listItems = this.context.getListItems();
-    const selectedListItem = listItems.find(li => li.selected);
-    const activeListItem = listItems.find(li => li.active) as IListItemComponent;
-
-    expect(selectedListItem).toBeFalsy();
-    expect(activeListItem.value.time).toBe(closestTimeMillis);
-  });
-
-  it('should highlight startTime in dropdown when opened without value set', async function(this: ITestContext) {
-    this.context = _createTimePickerContext();
-
-    const startTime = '08:00';
-    const startTimeMillis = timeStringToMillis(startTime, true, false);
-    this.context.component.startTime = startTime;
-    this.context.component.open = true;
-
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
-
-    const listItems = this.context.getListItems();
-    const selectedListItem = listItems.find(li => li.selected);
-    const activeListItem = listItems.find(li => li.active) as IListItemComponent;
-
-    expect(selectedListItem).toBeFalsy();
-    expect(activeListItem.value.time).toBe(startTimeMillis);
-  });
-
-  it('should highlight first time in dropdown when opened via arrow down key', async function(this: ITestContext) {
+  it('should highlight option in dropdown when opened via arrow down key', async function(this: ITestContext) {
     this.context = _createTimePickerContext();
     this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' }));
 
@@ -673,7 +636,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     const listItems = this.context.getListItems();
     const activeListItemIndex = listItems.findIndex(li => li.active);
 
-    expect(activeListItemIndex).toBe(0);
+    expect(activeListItemIndex).toBe(this.context.foundation['_dropdownConfig'].visibleStartIndex);
   });
 
   it('should select highlighted time in dropdown when tab key is pressed', async function(this: ITestContext) {
@@ -688,7 +651,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
 
     await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
 
-    expect(this.context.component.value).toBe('00:00');
+    expect(this.context.component.value).not.toBeNull();
   });
 
   it('should select matching value in dropdown when opened when startTime is set', async function(this: ITestContext) {
@@ -850,14 +813,14 @@ describe('TimePickerComponent', function(this: ITestContext) {
     await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
 
     const listItems = this.context.getListItems();
-    let activeListItem = listItems.find(li => li.active) as IListItemComponent;
+    let activeListItemIndex = listItems.findIndex(li => li.active);
 
-    expect(listItems.indexOf(activeListItem)).toBe(-1);
+    expect(activeListItemIndex).toBe(-1);
 
     this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' }));
 
-    activeListItem = listItems.find(li => li.active) as IListItemComponent;
-    expect(listItems.indexOf(activeListItem)).toBe(0);
+    activeListItemIndex = listItems.findIndex(li => li.active);
+    expect(activeListItemIndex).toBe(this.context.foundation['_dropdownConfig'].visibleStartIndex);
   });
 
   it('should propagate up arrow key to dropdown', async function(this: ITestContext) {
@@ -867,14 +830,14 @@ describe('TimePickerComponent', function(this: ITestContext) {
     await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
 
     const listItems = this.context.getListItems();
-    let activeListItem = listItems.find(li => li.active) as IListItemComponent;
+    const originalActiveListItemIndex = listItems.findIndex(li => li.active);
 
-    expect(listItems.indexOf(activeListItem)).toBe(-1);
+    expect(originalActiveListItemIndex).toBe(-1);
 
     this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowUp' }));
 
-    activeListItem = listItems.find(li => li.active) as IListItemComponent;
-    expect(listItems.indexOf(activeListItem)).toBe(listItems.length - 1);
+    const activeListItemIndex = listItems.findIndex(li => li.active);
+    expect(activeListItemIndex).toBe(this.context.foundation['_dropdownConfig'].visibleStartIndex);
   });
 
   it('should propagate home and end key to dropdown', async function(this: ITestContext) {
@@ -886,13 +849,13 @@ describe('TimePickerComponent', function(this: ITestContext) {
     const listItems = this.context.getListItems();
 
     this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'End' }));
-    let activeListItem = listItems.find(li => li.active) as IListItemComponent;
-    expect(listItems.indexOf(activeListItem)).toBe(listItems.length - 1);
+    let activeListItemIndex = listItems.findIndex(li => li.active);
+    expect(activeListItemIndex).toBe(listItems.length - 1);
     
     this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'Home' }));
     
-    activeListItem = listItems.find(li => li.active) as IListItemComponent;
-    expect(listItems.indexOf(activeListItem)).toBe(0);
+    activeListItemIndex = listItems.findIndex(li => li.active);
+    expect(activeListItemIndex).toBe(0);
   });
 
   it('should select active option in dropdown when enter key is pressed', async function(this: ITestContext) {
@@ -908,27 +871,6 @@ describe('TimePickerComponent', function(this: ITestContext) {
 
     this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'End' }));      
     this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'Enter' }));
-
-    const selectedListItem = listItems[listItems.length - 1];
-    const selectedTimeString = millisToTimeString(selectedListItem.value.time, true, false);
-
-    expect(changeSpy).toHaveBeenCalledOnceWith(jasmine.objectContaining({ detail: selectedTimeString }));
-    expect(this.context.component.value).toBe(selectedTimeString);
-  });
-
-  it('should select active option in dropdown when number pad numpadenter key is pressed', async function(this: ITestContext) {
-    this.context = _createTimePickerContext();
-
-    const changeSpy = jasmine.createSpy('change spy');
-    this.context.component.addEventListener(TIME_PICKER_CONSTANTS.events.CHANGE, changeSpy);
-
-    this.context.component.open = true;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
-
-    const listItems = this.context.getListItems();
-
-    this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'End' }));      
-    this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'NumpadEnter' }));
 
     const selectedListItem = listItems[listItems.length - 1];
     const selectedTimeString = millisToTimeString(selectedListItem.value.time, true, false);
@@ -1053,7 +995,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context.component.open = true;
     await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
 
-    this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' }));
+    this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'Home' })); // Custom options are displayed first
     this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'Enter' }));
 
     expect(toMillisSpy).toHaveBeenCalledOnceWith(customOptions[0].value);

--- a/src/test/spec/time-picker/time-picker.spec.ts
+++ b/src/test/spec/time-picker/time-picker.spec.ts
@@ -265,6 +265,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
 
   it('should set value through input element when unmasked', function(this: ITestContext) {
     this.context = _createTimePickerContext();
+    this.context.component.masked = false;
 
     const timeValue = '1111';
     this.context.inputElement.value = timeValue;
@@ -272,9 +273,10 @@ describe('TimePickerComponent', function(this: ITestContext) {
     expect(this.context.component.value).toBeNull();
     expect(this.context.inputElement.value).toBe(timeValue);
     
-    this.context.inputElement.dispatchEvent(new Event('input'));
+    this.context.inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertText' }));
     this.context.inputElement.dispatchEvent(new Event('blur'));
     
+    expect(this.context.component.value).toBe('11:11');
     expect(this.context.inputElement.value).toBe('11:11 AM');
   });
 
@@ -1181,7 +1183,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     await tick();
     
     this.context.inputElement.value = '1';
-    this.context.inputElement.dispatchEvent(new Event('input'));
+    this.context.inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertText' }));
     await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
     await tick();
     
@@ -1193,7 +1195,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
     this.context.inputElement.value = '1111';
-    this.context.inputElement.dispatchEvent(new Event('input'));
+    this.context.inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste' }));
     this.context.inputElement.dispatchEvent(new Event('blur'));
 
     expect(this.context.inputElement.value).toBe('11:11 AM');
@@ -1203,7 +1205,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
     this.context.inputElement.value = '01:30';
-    this.context.inputElement.dispatchEvent(new Event('input'));
+    this.context.inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertText' }));
     this.context.inputElement.dispatchEvent(new Event('blur'));
 
     expect(this.context.inputElement.value).toBe('01:30 AM');
@@ -1213,7 +1215,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
     this.context.inputElement.value = '9';
-    this.context.inputElement.dispatchEvent(new Event('input'));
+    this.context.inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertText' }));
     await tick();
 
     expect(this.context.inputElement.value).toBe('09:');
@@ -1226,7 +1228,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     await tick();
 
     this.context.inputElement.value = '9';
-    this.context.inputElement.dispatchEvent(new Event('input'));
+    this.context.inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertText' }));
     await tick();
     
     expect(this.context.inputElement.value).toBe('9');
@@ -1234,7 +1236,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     
     this.context.component.masked = true;
     this.context.inputElement.value = '9';
-    this.context.inputElement.dispatchEvent(new Event('input'));
+    this.context.inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertText' }));
     await tick();
 
     expect(this.context.inputElement.value).toBe('09:');
@@ -1276,7 +1278,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
 
     const value = '120';
     this.context.inputElement.value = value;
-    this.context.inputElement.dispatchEvent(new Event('input'));
+    this.context.inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste' }));
 
     expect(coercionSpy).toHaveBeenCalledOnceWith('12:0', '12:00', false);
   });
@@ -1290,7 +1292,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
 
     const value = '120';
     this.context.inputElement.value = value;
-    this.context.inputElement.dispatchEvent(new Event('input'));
+    this.context.inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertText' }));
 
     expect(coercionSpy).toHaveBeenCalledOnceWith('120', '01:20', false);
   });
@@ -1305,7 +1307,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     const value = '120';
     this.context.inputElement.focus();
     this.context.inputElement.value = value;
-    this.context.inputElement.dispatchEvent(new Event('input'));
+    this.context.inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertText' }));
     await tick();
 
     expect(this.context.component.value).toBe('12:00');
@@ -1340,7 +1342,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
     this.context.inputElement.value = '1';
-    this.context.inputElement.dispatchEvent(new Event('input'));
+    this.context.inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertText' }));
 
     expect(this.context.component.value).toBe('01:00');
     expect(this.context.inputElement.value).toBe('01:');
@@ -1350,7 +1352,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
     this.context.inputElement.value = '2';
-    this.context.inputElement.dispatchEvent(new Event('input'));
+    this.context.inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertText' }));
 
     expect(this.context.component.value).toBe('02:00');
     expect(this.context.inputElement.value).toBe('02:');
@@ -1360,7 +1362,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
     this.context.inputElement.value = '3';
-    this.context.inputElement.dispatchEvent(new Event('input'));
+    this.context.inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertText' }));
 
     expect(this.context.component.value).toBe('03:00');
     expect(this.context.inputElement.value).toBe('03:');
@@ -1371,7 +1373,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context.component.masked = false;
 
     this.context.inputElement.value = '123';
-    this.context.inputElement.dispatchEvent(new Event('input'));
+    this.context.inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertText' }));
 
     expect(this.context.component.value).toBe('01:23');
   });
@@ -1465,7 +1467,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
 
   async function setInputValue(inputElement: HTMLInputElement, value: string): Promise<void> {
     inputElement.value = value;
-    inputElement.dispatchEvent(new Event('input'));
+    inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertText' }));
     await tick();
   }
 

--- a/src/test/spec/tooltip/tooltip.spec.ts
+++ b/src/test/spec/tooltip/tooltip.spec.ts
@@ -124,13 +124,13 @@ describe('TooltipComponent', function(this: ITestContext) {
       this.context.attach();
       await tick();
 
-      const tooltipElement = await this.context.open();
+      this.context.component.open = true;
+      await timer(TOOLTIP_CONSTANTS.numbers.DEFAULT_DELAY);
       await tick();
-      await timer();
       
       expect(this.context.component.target).toBe(targetSelector);
-      expect(tooltipElement).toBeTruthy();
-      expect(tooltipElement.textContent).toBe(this.context.component.text);
+      expect(this.context.component.tooltipElement).toBeTruthy();
+      expect(this.context.component.tooltipElement?.textContent).toBe(this.context.component.text);
     });
 
     it('should throw when unable to find target element', async function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Refactored the input masking logic with custom rules to improve usability and ease of entry.

In general the entry will follow that native `<input type="time">` more closely, along with some minor improvements for convenience. Each segment will automatically pad a leading zero upon first entry, and attempt to shift values over within a segment if possible.

## Additional information
Fixes #228
