### PR TITLE
fix(dialog): fixed a bug where moving the dialog within a scroll container would calculate an incorrect position

### DIFF
--- a/src/lib/dialog/dialog-foundation.ts
+++ b/src/lib/dialog/dialog-foundation.ts
@@ -237,8 +237,8 @@ export class DialogFoundation implements IDialogFoundation {
     this._adapter.captureActiveElement();
     const bounds = this._adapter.getSurfaceBounds();
     this._moveContext = {
-      top: evt.clientY - bounds.top,
-      left: evt.clientX - bounds.left,
+      top: evt.pageY - bounds.top,
+      left: evt.pageX - bounds.left,
       height: bounds.height,
       width: bounds.width
     };

--- a/src/test/spec/dialog/dialog.spec.ts
+++ b/src/test/spec/dialog/dialog.spec.ts
@@ -468,7 +468,7 @@ describe('DialogComponent', function(this: ITestContext) {
     const mousedownSpy = spyOn(this.context.component['_foundation'], '_onMoveTargetMouseDown').and.callThrough();
     const mousemoveSpy = spyOn(this.context.component['_foundation'], '_onMoveTargetMouseMove').and.callThrough();
     const mouseupSpy = spyOn(this.context.component['_foundation'], '_onMoveTargetMouseUp').and.callThrough();
-    moveTarget.dispatchEvent(new MouseEvent('mousedown', { clientX: 100, clientY: 100 } as any));
+    moveTarget.dispatchEvent(new MouseEvent('mousedown', { pageX: 100, pageY: 100 } as any));
     document.dispatchEvent(new MouseEvent('mousemove', { pageX: 150, pageY: 150 } as any));
     document.dispatchEvent(new MouseEvent('mouseup'));
     


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The dialog was incorrectly using `clientX` and `clientY` coordinates from the `mousedown` which has side effects if the page can scroll causing the element to be incorrectly positioned. The component will now properly utilize the `pageX` and `pageY` coordinates to account for this.
