### PR TITLE
feat(app-bar-profile-button): added new `avatarIcon` property to allow for rendering an icon from the `IconRegistry` instead of text

### DIFF
--- a/src/lib/app-bar/profile-button/app-bar-profile-button-adapter.ts
+++ b/src/lib/app-bar/profile-button/app-bar-profile-button-adapter.ts
@@ -1,7 +1,8 @@
-import { getLightElement, notChildEventListener, getActiveElement } from '@tylertech/forge-core';
+import { getLightElement, notChildEventListener, getActiveElement, removeAllChildren } from '@tylertech/forge-core';
+import { IconComponentDelegate } from '../../icon';
 import { AVATAR_CONSTANTS, IAvatarComponent } from '../../avatar';
 import { BaseAdapter, IBaseAdapter } from '../../core/base/base-adapter';
-import { IPopupComponent, PopupAnimationType, PopupPlacement, POPUP_CONSTANTS } from '../../popup';
+import { IPopupComponent, PopupAnimationType, POPUP_CONSTANTS } from '../../popup';
 import { IProfileCardComponent, PROFILE_CARD_CONSTANTS } from '../../profile-card';
 import { IAppBarProfileButtonComponent } from './app-bar-profile-button';
 import { IAppBarProfileCardConfig, APP_BAR_PROFILE_BUTTON_CONSTANTS } from './app-bar-profile-button-constants';
@@ -14,6 +15,7 @@ export interface IAppBarProfileButtonAdapter extends IBaseAdapter {
   closePopup(): void;
   requestFocus(): void;
   setAvatarText(value: string): void;
+  setAvatarIcon(value: string): void;
   setAvatarLetterCount(value: number): void;
   setAvatarImageUrl(value: string): void;
   setSignOutButtonText(value: string): void;
@@ -52,6 +54,7 @@ export class AppBarProfileButtonAdapter extends BaseAdapter<IAppBarProfileButton
     this._profileCardElement.signOutText = profileCardConfig.signOutButtonText;
     this._profileCardElement.profileText = profileCardConfig.profileButtonText;
     this._profileCardElement.avatarText = profileCardConfig.avatarText;
+    this._profileCardElement.avatarIcon = profileCardConfig.avatarIcon;
     this._profileCardElement.avatarImageUrl = profileCardConfig.avatarImageUrl;
     this._profileCardElement.avatarLetterCount = profileCardConfig.avatarLetterCount;
     this._profileCardElement.addEventListener(PROFILE_CARD_CONSTANTS.events.PROFILE, () => profileListener());
@@ -92,6 +95,16 @@ export class AppBarProfileButtonAdapter extends BaseAdapter<IAppBarProfileButton
 
   public setAvatarText(value: string): void {
     this._avatarElement.text = value;
+    removeAllChildren(this._avatarElement);
+  }
+
+  public setAvatarIcon(value: string): void {
+    if (value) {
+      const iconDelegate = new IconComponentDelegate({ props: { name: value }});
+      this._avatarElement.replaceChildren(iconDelegate.element);
+    } else {
+      removeAllChildren(this._avatarElement);
+    }
   }
 
   public setAvatarLetterCount(value: number): void {

--- a/src/lib/app-bar/profile-button/app-bar-profile-button-constants.ts
+++ b/src/lib/app-bar/profile-button/app-bar-profile-button-constants.ts
@@ -8,6 +8,7 @@ const attributes = {
   AVATAR_IMAGE_URL: 'avatar-image-url',
   AVATAR_LETTER_COUNT: 'avatar-letter-count',
   AVATAR_TEXT: 'avatar-text',
+  AVATAR_ICON: 'avatar-icon',
   SIGN_OUT_BUTTON: 'sign-out-button',
   PROFILE_BUTTON: 'profile-button',
   SIGN_OUT_BUTTON_TEXT: 'sign-out-button-text',
@@ -33,6 +34,7 @@ export interface IAppBarProfileCardConfig {
   signOutButtonText: string;
   profileButtonText: string;
   avatarText: string;
+  avatarIcon: string;
   avatarImageUrl: string;
   avatarLetterCount: number;
 }

--- a/src/lib/app-bar/profile-button/app-bar-profile-button-foundation.ts
+++ b/src/lib/app-bar/profile-button/app-bar-profile-button-foundation.ts
@@ -10,6 +10,7 @@ export interface IAppBarProfileButtonFoundation extends ICustomElementFoundation
   avatarImageUrl: string;
   avatarLetterCount: number;
   avatarText: string;
+  avatarIcon: string;
   signOutButton: boolean;
   profileButton: boolean;
   signOutButtonText: string;
@@ -24,6 +25,7 @@ export class AppBarProfileButtonFoundation implements IAppBarProfileButtonFounda
   private _avatarImageUrl: string;
   private _avatarLetterCount = AVATAR_CONSTANTS.numbers.DEFAULT_LETTER_COUNT;
   private _avatarText: string;
+  private _avatarIcon: string;
   private _showSignOutButton = PROFILE_CARD_CONSTANTS.defaults.SHOW_SIGN_OUT_BUTTON;
   private _showProfileButton = PROFILE_CARD_CONSTANTS.defaults.SHOW_PROFILE_BUTTON;
   private _signOutButtonText = PROFILE_CARD_CONSTANTS.defaults.SIGN_OUT_BUTTON_TEXT;
@@ -52,6 +54,7 @@ export class AppBarProfileButtonFoundation implements IAppBarProfileButtonFounda
     this._adapter.setAvatarImageUrl(this._avatarImageUrl);
     this._adapter.setAvatarLetterCount(this._avatarLetterCount);
     this._adapter.setAvatarText(this._avatarText);
+    this._adapter.setAvatarIcon(this._avatarIcon);
     this._isInitialized = true;
   }
 
@@ -115,6 +118,7 @@ export class AppBarProfileButtonFoundation implements IAppBarProfileButtonFounda
       signOutButtonText: this._signOutButtonText,
       profileButtonText: this._profileButtonText,
       avatarText: this._avatarText,
+      avatarIcon: this._avatarIcon,
       avatarImageUrl: this._avatarImageUrl,
       avatarLetterCount: this._avatarLetterCount
     };
@@ -195,7 +199,20 @@ export class AppBarProfileButtonFoundation implements IAppBarProfileButtonFounda
       this._avatarText = value;
       if (this._isInitialized) {
         this._adapter.setAvatarText(this._avatarText);
-        this._adapter.setHostAttribute(APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.AVATAR_TEXT, this._avatarText);
+        this._adapter.toggleHostAttribute(APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.AVATAR_TEXT, !!this._avatarText, this._avatarText);
+      }
+    }
+  }
+
+  public get avatarIcon(): string {
+    return this._avatarIcon;
+  }
+  public set avatarIcon(value: string) {
+    if (this._avatarIcon !== value) {
+      this._avatarIcon = value;
+      if (this._isInitialized) {
+        this._adapter.setAvatarIcon(this._avatarIcon);
+        this._adapter.toggleHostAttribute(APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.AVATAR_ICON, !!this._avatarIcon, this._avatarIcon);
       }
     }
   }

--- a/src/lib/app-bar/profile-button/app-bar-profile-button.ts
+++ b/src/lib/app-bar/profile-button/app-bar-profile-button.ts
@@ -8,6 +8,7 @@ import { AvatarComponent } from '../../avatar';
 import { PopupComponent } from '../../popup';
 import { TooltipComponent } from '../../tooltip';
 import { BaseComponent, IBaseComponent } from '../../core/base/base-component';
+import { IconComponent } from '../../icon';
 
 import template from './app-bar-profile-button.html';
 
@@ -15,6 +16,7 @@ export interface IAppBarProfileButtonComponent extends IBaseComponent {
   avatarImageUrl: string;
   avatarLetterCount: number;
   avatarText: string;
+  avatarIcon: string;
   fullName: string;
   email: string;
   signOutButton: boolean;
@@ -42,6 +44,7 @@ declare global {
     PopupComponent,
     ProfileCardComponent,
     IconButtonComponent,
+    IconComponent,
     AvatarComponent,
     TooltipComponent
   ]
@@ -54,6 +57,7 @@ export class AppBarProfileButtonComponent extends BaseComponent implements IAppB
       APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.AVATAR_IMAGE_URL,
       APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.AVATAR_LETTER_COUNT,
       APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.AVATAR_TEXT,
+      APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.AVATAR_ICON,
       APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.SIGN_OUT_BUTTON,
       APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.PROFILE_BUTTON,
       APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.SIGN_OUT_BUTTON_TEXT,
@@ -98,6 +102,9 @@ export class AppBarProfileButtonComponent extends BaseComponent implements IAppB
       case APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.AVATAR_TEXT:
         this.avatarText = newValue;
         break;
+      case APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.AVATAR_ICON:
+        this.avatarIcon = newValue;
+        break;
       case APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.SIGN_OUT_BUTTON:
         this.signOutButton = coerceBoolean(newValue);
         break;
@@ -130,6 +137,9 @@ export class AppBarProfileButtonComponent extends BaseComponent implements IAppB
 
   @FoundationProperty()
   public declare avatarText: string;
+
+  @FoundationProperty()
+  public declare avatarIcon: string;
 
   @FoundationProperty()
   public declare signOutButton: boolean;

--- a/src/lib/profile-card/profile-card-adapter.ts
+++ b/src/lib/profile-card/profile-card-adapter.ts
@@ -1,6 +1,7 @@
-import { emitEvent, getShadowElement } from '@tylertech/forge-core';
+import { getShadowElement, removeAllChildren } from '@tylertech/forge-core';
 import { IAvatarComponent } from '../avatar';
 import { BaseAdapter, IBaseAdapter } from '../core/base/base-adapter';
+import { IconComponentDelegate } from '../icon';
 import { IToolbarComponent } from '../toolbar';
 import { IProfileCardComponent } from './profile-card';
 import { PROFILE_CARD_CONSTANTS } from './profile-card-constants';
@@ -9,6 +10,7 @@ export interface IProfileCardAdapter extends IBaseAdapter {
   setFullName(value: string): void;
   setEmail(value: string): void;
   setAvatarText(value: string): void;
+  setAvatarIcon(value: string): void;
   setAvatarImageUrl(value: string): void;
   setAvatarLetterCount(count: number): void;
   setActionToolbarVisibility(isVisible: boolean): void;
@@ -55,6 +57,16 @@ export class ProfileCardAdapter extends BaseAdapter<IProfileCardComponent> imple
   public setAvatarText(value: string): void {
     this._component.setAttribute(PROFILE_CARD_CONSTANTS.attributes.AVATAR_TEXT, value);
     this._avatarElement.text = value;
+    removeAllChildren(this._avatarElement);
+  }
+
+  public setAvatarIcon(value: string): void {
+    if (value) {
+      const iconDelegate = new IconComponentDelegate({ props: { name: value }});
+      this._avatarElement.replaceChildren(iconDelegate.element);
+    } else {
+      removeAllChildren(this._avatarElement);
+    }
   }
 
   public setAvatarImageUrl(value: string): void {

--- a/src/lib/profile-card/profile-card-constants.ts
+++ b/src/lib/profile-card/profile-card-constants.ts
@@ -10,6 +10,7 @@ const attributes = {
   SIGN_OUT_TEXT: 'sign-out-text',
   PROFILE_TEXT: 'profile-text',
   AVATAR_TEXT: 'avatar-text',
+  AVATAR_ICON: 'avatar-icon',
   AVATAR_IMAGE_URL: 'avatar-image-url',
   AVATAR_LETTER_COUNT: 'avatar-letter-count'
 };

--- a/src/lib/profile-card/profile-card-foundation.ts
+++ b/src/lib/profile-card/profile-card-foundation.ts
@@ -9,6 +9,7 @@ export interface IProfileCardFoundation extends ICustomElementFoundation {
   signOut: boolean;
   profile: boolean;
   avatarText: string;
+  avatarIcon: string;
   avatarImageUrl: string;
   avatarLetterCount: number;
 }
@@ -17,6 +18,7 @@ export class ProfileCardFoundation implements IProfileCardFoundation {
   private _fullName: string;
   private _email: string;
   private _avatarText: string;
+  private _avatarIcon: string;
   private _avatarImageUrl: string;
   private _avatarLetterCount: number;
   private _showSignOutButton = PROFILE_CARD_CONSTANTS.defaults.SHOW_SIGN_OUT_BUTTON;
@@ -96,6 +98,16 @@ export class ProfileCardFoundation implements IProfileCardFoundation {
     if (this._avatarText !== value) {
       this._avatarText = value;
       this._adapter.setAvatarText(this._avatarText);
+    }
+  }
+
+  public get avatarIcon(): string {
+    return this._avatarIcon;
+  }
+  public set avatarIcon(value: string) {
+    if (this._avatarIcon !== value) {
+      this._avatarIcon = value;
+      this._adapter.setAvatarIcon(this._avatarIcon);
     }
   }
 

--- a/src/lib/profile-card/profile-card.ts
+++ b/src/lib/profile-card/profile-card.ts
@@ -18,6 +18,7 @@ export interface IProfileCardComponent extends IBaseComponent {
   signOutText: string;
   profileText: string;
   avatarText: string;
+  avatarIcon: string;
   avatarImageUrl: string;
   avatarLetterCount: number;
 }
@@ -56,6 +57,7 @@ export class ProfileCardComponent extends BaseComponent implements IProfileCardC
       PROFILE_CARD_CONSTANTS.attributes.SIGN_OUT_TEXT,
       PROFILE_CARD_CONSTANTS.attributes.PROFILE_TEXT,
       PROFILE_CARD_CONSTANTS.attributes.AVATAR_TEXT,
+      PROFILE_CARD_CONSTANTS.attributes.AVATAR_ICON,
       PROFILE_CARD_CONSTANTS.attributes.AVATAR_IMAGE_URL,
       PROFILE_CARD_CONSTANTS.attributes.AVATAR_LETTER_COUNT
     ];
@@ -96,6 +98,9 @@ export class ProfileCardComponent extends BaseComponent implements IProfileCardC
       case PROFILE_CARD_CONSTANTS.attributes.AVATAR_TEXT:
         this.avatarText = newValue;
         break;
+      case PROFILE_CARD_CONSTANTS.attributes.AVATAR_ICON:
+        this.avatarIcon = newValue;
+        break;
       case PROFILE_CARD_CONSTANTS.attributes.AVATAR_IMAGE_URL:
         this.avatarImageUrl = newValue;
         break;
@@ -125,6 +130,9 @@ export class ProfileCardComponent extends BaseComponent implements IProfileCardC
 
   @FoundationProperty()
   public declare avatarText: string;
+
+  @FoundationProperty()
+  public declare avatarIcon: string;
 
   @FoundationProperty()
   public declare avatarImageUrl: string;

--- a/src/stories/src/components/app-bar-profile/app-bar-profile-args.ts
+++ b/src/stories/src/components/app-bar-profile/app-bar-profile-args.ts
@@ -1,9 +1,10 @@
 export interface IAppBarProfileProps {
   fullName: string;
   email: string;
-  avatarImageUrl: string;
   avatarLetterCount: number;
   avatarText: string;
+  useAvatarImage: boolean;
+  useAvatarIcon: boolean;
   signOutButton: boolean;
   profileButton: boolean;
 }
@@ -23,13 +24,6 @@ export const argTypes = {
       category: 'Properties',
     },
   },
-  avatarImageUrl: {
-    control: 'text',
-    description: '',
-    table: {
-      category: 'Properties',
-    },
-  },
   avatarLetterCount: {
     control: 'number',
     description: '',
@@ -39,6 +33,20 @@ export const argTypes = {
   },
   avatarText: {
     control: 'text',
+    description: '',
+    table: {
+      category: 'Properties',
+    },
+  },
+  useAvatarImage: {
+    control: 'boolean',
+    description: '',
+    table: {
+      category: 'Properties',
+    },
+  },
+  useAvatarIcon: {
+    control: 'boolean',
     description: '',
     table: {
       category: 'Properties',

--- a/src/stories/src/components/app-bar-profile/app-bar-profile.mdx
+++ b/src/stories/src/components/app-bar-profile/app-bar-profile.mdx
@@ -86,6 +86,12 @@ profileButton.profileCardBuilder = () => {
 
 </PropertyDef>
 
+<PropertyDef name="avatarIcon" type="string" defaultValue="undefined">
+
+  Sets the icon name to render using a `<forge-icon>` element instead of text. You must register the icon in the `IconRegistry` to use this.
+
+</PropertyDef>
+
 <PropertyDef name="signOutButton" type="boolean" defaultValue="true">
 
   Gets/sets the visibility of the "Sign out" button.
@@ -164,22 +170,6 @@ profileButton.profileCardBuilder = () => {
 <PageSection>
 
 ## Types
-
-### IProfileCardConfig
-
-```ts
-interface IAppBarProfileCardConfig {
-  fullName: string;
-  email: string;
-  signOut: boolean;
-  profile: boolean;
-  signOutButtonText: string;
-  profileButtonText: string;
-  avatarText: string;
-  avatarImageUrl: string;
-  avatarLetterCount: number;
-}
-```
 
 ### AppBarProfileButtonProfileCardBuilder
 

--- a/src/stories/src/components/app-bar-profile/app-bar-profile.stories.tsx
+++ b/src/stories/src/components/app-bar-profile/app-bar-profile.stories.tsx
@@ -5,6 +5,7 @@ import { ForgeAppBar, ForgeAppBarProfileButton, ForgeIcon } from '@tylertech/for
 import { IconRegistry } from '@tylertech/forge';
 import { tylIconForgeLogo } from '@tylertech/tyler-icons/custom';
 import { IAppBarProfileProps, argTypes } from './app-bar-profile-args';
+import { tylIconPerson } from '@tylertech/tyler-icons/standard';
 
 const MDX = require('./app-bar-profile.mdx').default;
 
@@ -14,9 +15,6 @@ export default {
   parameters: { 
     docs: { 
       page: MDX
-    },
-    controls: {
-      disable: true
     }
   }
 } as Meta;
@@ -24,14 +22,15 @@ export default {
 export const Default: Story<IAppBarProfileProps> = ({
   fullName = 'First Last',
   email = 'first.last@tylertech.com',
-  avatarImageUrl = 'https://en.gravatar.com/userimage/27084046/aa996f464ca8f1ea69769cef1b76fbf9.jpg',
   avatarLetterCount = 2,
-  avatarText = 'FL',
+  avatarText = 'First Last',
+  useAvatarImage = false,
+  useAvatarIcon = false,
   signOutButton = true,
   profileButton = true,
 }) => {
   useEffect(() => {
-    IconRegistry.define(tylIconForgeLogo);
+    IconRegistry.define([tylIconForgeLogo, tylIconPerson]);
   }, []);
 
   function showToast(msg: string): void {
@@ -46,9 +45,10 @@ export const Default: Story<IAppBarProfileProps> = ({
       <ForgeAppBarProfileButton
         fullName={fullName}
         email={email}
-        avatarImageUrl={avatarImageUrl}
+        avatarImageUrl={useAvatarImage && !useAvatarIcon ? 'https://en.gravatar.com/userimage/27084046/aa996f464ca8f1ea69769cef1b76fbf9.jpg' : null}
         avatarLetterCount={avatarLetterCount}
-        avatarText={avatarText}
+        avatarText={!useAvatarIcon ? avatarText : null}
+        avatarIcon={useAvatarIcon ? 'person' : null}
         signOutButton={signOutButton}
         profileButton={profileButton}
         on-forge-profile-card-sign-out={() => showToast('Sign out button clicked')}
@@ -61,9 +61,10 @@ export const Default: Story<IAppBarProfileProps> = ({
 Default.args = {
   fullName: 'First Last',
   email: 'first.last@tylertech.com',
-  avatarImageUrl: 'https://en.gravatar.com/userimage/27084046/aa996f464ca8f1ea69769cef1b76fbf9.jpg',
   avatarLetterCount: 2,
   avatarText: 'First Last',
+  useAvatarImage: false,
+  useAvatarIcon: false,
   signOutButton: true,
   profileButton: true,
 } as IAppBarProfileProps;

--- a/src/test/spec/app-bar/profile-button/app-bar-profile-button.spec.ts
+++ b/src/test/spec/app-bar/profile-button/app-bar-profile-button.spec.ts
@@ -3,12 +3,14 @@ import { tick, timer } from '@tylertech/forge-testing';
 import { defineAppBarProfileButtonComponent, IAppBarProfileButtonComponent, AppBarProfileButtonComponent, APP_BAR_PROFILE_BUTTON_CONSTANTS } from '@tylertech/forge/app-bar/profile-button';
 import { ProfileCardComponent, PROFILE_CARD_CONSTANTS } from '@tylertech/forge/profile-card';
 import { PopupComponent, POPUP_CONSTANTS } from '@tylertech/forge/popup';
+import { IIconComponent } from '@tylertech/forge/icon';
 
 const fullName = 'Jane Doe';
 const email = 'jane.doe@gmail.com';
 const avatarImageUrl = 'https://cdn.forge.tylertech.com/v1/images/spot/artistry-spot.svg';
 const avatarLetterCount = 1;
 const avatarText = 'OP';
+const avatarIcon = 'person';
 
 interface ITestContext {
   context: ITestAppBarProfileButtonContext;
@@ -122,6 +124,28 @@ describe('AppBarProfileButtonComponent', function(this: ITestContext) {
     this.context.component.setAttribute(APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.AVATAR_TEXT, avatarText);
     expect(this.context.component.avatarText).toBe(avatarText, `AvatarText property should be ${avatarText}`);
     expect(this.context.component.getAttribute(APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.AVATAR_TEXT)).toBe(avatarText, `avatarText attribute should be ${avatarText}`);
+  });
+
+  it('should set avatar icon via property', function(this: ITestContext) {
+    this.context = setupTestContext();
+    this.context.component.avatarIcon = avatarIcon;
+
+    const iconEl = this.context.component.querySelector('forge-avatar > forge-icon') as IIconComponent;
+    expect(iconEl).toBeTruthy();
+    expect(iconEl.name).toBe(avatarIcon);
+    expect(this.context.component.avatarIcon).toBe(avatarIcon);
+    expect(this.context.component.getAttribute(APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.AVATAR_ICON)).toBe(avatarIcon);
+  });
+
+  it('should set avatar icon via attribute', function(this: ITestContext) {
+    this.context = setupTestContext();
+    this.context.component.setAttribute(APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.AVATAR_ICON, avatarIcon);
+
+    const iconEl = this.context.component.querySelector('forge-avatar > forge-icon') as IIconComponent;
+    expect(iconEl).toBeTruthy();
+    expect(iconEl.name).toBe(avatarIcon);
+    expect(this.context.component.avatarIcon).toBe(avatarIcon);
+    expect(this.context.component.getAttribute(APP_BAR_PROFILE_BUTTON_CONSTANTS.attributes.AVATAR_ICON)).toBe(avatarIcon);
   });
 
   it('should set show sign out button via property', async function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Added the ability to provide an icon name to be rendered within the `<forge-avatar>` element. This requires that the icon be registered with the `IconRegistry`, and it will take precedence over the `avatarText` and `avatarImageUrl` values.

## Additional information
The reason for this change is to support applications that don't have user first/last name information to instead render a generic icon.
