### PR TITLE
feat(autocomplete): add `filterFocusFirst` property

### DIFF
--- a/src/dev/pages/autocomplete/autocomplete.html
+++ b/src/dev/pages/autocomplete/autocomplete.html
@@ -18,6 +18,7 @@ include('./src/partials/page.ejs', {
       { type: 'text-field', inputType: 'number', label: 'Option limit', id: 'autocomplete-option-limit', defaultValue: 100 },
       { type: 'switch', label: 'Multiple', id: 'autocomplete-multiple' },
       { type: 'switch', label: 'Filter on focus', id: 'autocomplete-filter-on-focus', defaultValue: true },
+      { type: 'switch', label: 'Filter focus first', id: 'autocomplete-filter-focus-first', defaultValue: true },
       { type: 'switch', label: 'Allow unmatched', id: 'autocomplete-allow-unmatched' },
       { type: 'switch', label: 'Simulate async', id: 'autocomplete-simulate-async' },
       { type: 'switch', label: 'Use scroll observer', id: 'autocomplete-scroll-observer' },

--- a/src/dev/pages/autocomplete/autocomplete.ts
+++ b/src/dev/pages/autocomplete/autocomplete.ts
@@ -63,6 +63,11 @@ filterOnFocusToggle.addEventListener('forge-switch-select', ({ detail: selected 
   autocomplete.filterOnFocus = selected;
 });
 
+const filterFocusFirstToggle = document.querySelector('#autocomplete-filter-focus-first') as HTMLInputElement;
+filterFocusFirstToggle.addEventListener('forge-switch-select', ({ detail: selected }) => {
+  autocomplete.filterFocusFirst = selected;
+});
+
 const itemBuilderToggle = document.querySelector('#autocomplete-item-builder') as HTMLInputElement;
 itemBuilderToggle.addEventListener('forge-switch-select', ({ detail: selected }) => {
   autocomplete.optionBuilder = selected ? itemBuilder : undefined;

--- a/src/lib/autocomplete/autocomplete-constants.ts
+++ b/src/lib/autocomplete/autocomplete-constants.ts
@@ -11,6 +11,7 @@ const attributes = {
   MULTIPLE: 'multiple',
   DEBOUNCE: 'debounce',
   FILTER_ON_FOCUS: 'filter-on-focus',
+  FILTER_FOCUS_FIRST: 'filter-focus-first',
   ALLOW_UNMATCHED: 'allow-unmatched',
   POPUP_TARGET: 'popup-target',
   POPUP_CLASSES: 'popup-classes',

--- a/src/lib/autocomplete/autocomplete-foundation.ts
+++ b/src/lib/autocomplete/autocomplete-foundation.ts
@@ -13,6 +13,7 @@ export interface IAutocompleteFoundation extends IListDropdownAwareFoundation {
   value: string | string[] | IAutocompleteOption | IAutocompleteOption[] | null | undefined;
   debounce: number;
   filterOnFocus: boolean;
+  filterFocusFirst: boolean;
   allowUnmatched: boolean;
   popupTarget: string;
   filterText: string;
@@ -38,6 +39,7 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
   private _allowUnmatched = false;
   private _popupTarget: string;
   private _filterOnFocus = true;
+  private _filterFocusFirst = true;
   private _optionBuilder?: AutocompleteOptionBuilder | null;
   private _filter?: AutocompleteFilterCallback | null;
   private _selectedTextBuilder: AutocompleteSelectedTextBuilder;
@@ -369,6 +371,10 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     if (this._options.length) {
       const sendFilterText = this._allowUnmatched && !this._selectedOptions.length;
       this._dropdownReady({ userTriggered: sendFilterText });
+
+      if (this._filterFocusFirst && this._filterText) {
+        this._adapter.activateFirstOption();
+      }
     } else {
       this._closeDropdown();
     }
@@ -802,7 +808,6 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     this._applyValue(value);
   }
 
-
   /** Gets/sets filter on focus settings which controls whether the dropdown displays automatically when focused. */
   public get filterOnFocus(): boolean {
     return this._filterOnFocus;
@@ -811,6 +816,17 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     if (this._filterOnFocus !== value) {
       this._filterOnFocus = value;
       this._adapter.setHostAttribute(AUTOCOMPLETE_CONSTANTS.attributes.FILTER_ON_FOCUS, isDefined(this._filterOnFocus) ? this._filterOnFocus.toString() : '');
+    }
+  }
+
+  /** Gets/sets whether the first option in the dropdown will be focused automatically when opened or not. */
+  public get filterFocusFirst(): boolean {
+    return this._filterFocusFirst;
+  }
+  public set filterFocusFirst(value: boolean) {
+    if (this._filterFocusFirst !== value) {
+      this._filterFocusFirst = value;
+      this._adapter.toggleHostAttribute(AUTOCOMPLETE_CONSTANTS.attributes.FILTER_FOCUS_FIRST, this._filterFocusFirst);
     }
   }
 

--- a/src/lib/autocomplete/autocomplete-foundation.ts
+++ b/src/lib/autocomplete/autocomplete-foundation.ts
@@ -369,9 +369,6 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     if (this._options.length) {
       const sendFilterText = this._allowUnmatched && !this._selectedOptions.length;
       this._dropdownReady({ userTriggered: sendFilterText });
-      if (this._filterText) {
-        this._adapter.activateFirstOption();
-      }
     } else {
       this._closeDropdown();
     }

--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -21,6 +21,7 @@ export interface IAutocompleteComponent extends IListDropdownAware {
   value: any;
   debounce: number;
   filterOnFocus: boolean;
+  filterFocusFirst: boolean;
   allowUnmatched: boolean;
   matchKey: string | null | undefined;
   popupTarget: string;
@@ -74,6 +75,7 @@ export class AutocompleteComponent extends ListDropdownAware implements IAutocom
       AUTOCOMPLETE_CONSTANTS.attributes.MULTIPLE,
       AUTOCOMPLETE_CONSTANTS.attributes.DEBOUNCE,
       AUTOCOMPLETE_CONSTANTS.attributes.FILTER_ON_FOCUS,
+      AUTOCOMPLETE_CONSTANTS.attributes.FILTER_FOCUS_FIRST,
       AUTOCOMPLETE_CONSTANTS.attributes.ALLOW_UNMATCHED,
       AUTOCOMPLETE_CONSTANTS.attributes.POPUP_TARGET,
       AUTOCOMPLETE_CONSTANTS.attributes.POPUP_CLASSES,
@@ -123,6 +125,9 @@ export class AutocompleteComponent extends ListDropdownAware implements IAutocom
       case AUTOCOMPLETE_CONSTANTS.attributes.FILTER_ON_FOCUS:
         this.filterOnFocus = coerceBoolean(newValue);
         break;
+      case AUTOCOMPLETE_CONSTANTS.attributes.FILTER_FOCUS_FIRST:
+        this.filterFocusFirst = coerceBoolean(newValue);
+        break;
       case AUTOCOMPLETE_CONSTANTS.attributes.ALLOW_UNMATCHED:
         this.allowUnmatched = coerceBoolean(newValue);
         break;
@@ -160,6 +165,10 @@ export class AutocompleteComponent extends ListDropdownAware implements IAutocom
   /** Gets/sets filter on focus settings which controls whether the dropdown displays automatically when focused. */
   @FoundationProperty()
   public declare filterOnFocus: boolean;
+
+  /** Gets/sets whether the first option in the dropdown will be focused automatically when opened or not. */
+  @FoundationProperty()
+  public declare filterFocusFirst: boolean;
 
   /** Controls whether unmatched text entered by the user will stay visible an option in the dropdown is not found. */
   @FoundationProperty()

--- a/src/stories/src/components/autocomplete/autocomplete-args.ts
+++ b/src/stories/src/components/autocomplete/autocomplete-args.ts
@@ -4,6 +4,7 @@ export interface IAutocompleteProps {
   allowUnmatched: boolean;
   debounce: number;
   filterOnFocus: boolean;
+  filterFocusFirst: boolean;
   mode: AutocompleteMode;
   multiple: boolean;
   observeScroll: boolean;
@@ -25,6 +26,12 @@ export const argTypes = {
     }
   },
   filterOnFocus: {
+    control: 'boolean',
+    table: {
+      category: 'Properties'
+    }
+  },
+  filterFocusFirst: {
     control: 'boolean',
     table: {
       category: 'Properties'

--- a/src/stories/src/components/autocomplete/autocomplete.mdx
+++ b/src/stories/src/components/autocomplete/autocomplete.mdx
@@ -73,6 +73,12 @@ The only requirement for integration via JavaScript is that you provide a callba
 
 </PropertyDef>
 
+<PropertyDef name="filterFocusFirst" type="boolean" defaultValue="true">
+
+  Controls whether the first option in the dropdown is focused, **only when triggered by filter text being entered**.
+
+</PropertyDef>
+
 <PropertyDef name="mode" type="AutocompleteMode" defaultValue="&quot;default&quot;">
 
   Gets/sets the interaction mode. Valid values: `"default"` (default), `"stateless"`.

--- a/src/stories/src/components/autocomplete/autocomplete.stories.tsx
+++ b/src/stories/src/components/autocomplete/autocomplete.stories.tsx
@@ -23,6 +23,7 @@ export const Default: Story<IAutocompleteProps> = ({
   allowUnmatched = false,
   debounce = 500,
   filterOnFocus = true,
+  filterFocusFirst = true,
   mode = 'default',
   multiple = false,
   observeScrollThreshold = 0,
@@ -35,6 +36,7 @@ export const Default: Story<IAutocompleteProps> = ({
       allowUnmatched={allowUnmatched}
       debounce={debounce}
       filterOnFocus={filterOnFocus}
+      filterFocusFirst={filterFocusFirst}
       mode={mode}
       multiple={multiple}
       observeScrollThreshold={observeScrollThreshold}
@@ -60,6 +62,7 @@ Default.args = {
   allowUnmatched: false,
   debounce: 500,
   filterOnFocus: true,
+  filterFocusFirst: true,
   mode: 'default',
   multiple: false,
   observeScroll: false,

--- a/src/test/spec/autocomplete/autocomplete.spec.ts
+++ b/src/test/spec/autocomplete/autocomplete.spec.ts
@@ -775,7 +775,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       expect(activeListItemIndex).toBe(expectedSelectedIndex);
     });
 
-    it('should activate first option when filtering', async function(this: ITestContext) {
+    it('should not activate first option when filtering', async function(this: ITestContext) {
       this.context = setupTestContext(true);
       this.context.component.filter = () => DEFAULT_FILTER_OPTIONS;
       this.context.input.focus();
@@ -789,7 +789,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       await tick();
 
       const activeListItemIndex = _getActiveListItemIndex(this.context.component.popupElement);
-      expect(activeListItemIndex).toBe(0);
+      expect(activeListItemIndex).toBe(-1);
     });
 
     it('should not activate first option when clearing filter text', async function(this: ITestContext) {

--- a/src/test/spec/autocomplete/autocomplete.spec.ts
+++ b/src/test/spec/autocomplete/autocomplete.spec.ts
@@ -775,9 +775,27 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       expect(activeListItemIndex).toBe(expectedSelectedIndex);
     });
 
-    it('should not activate first option when filtering', async function(this: ITestContext) {
+    it('should activate first option when filtering', async function(this: ITestContext) {
       this.context = setupTestContext(true);
       this.context.component.filter = () => DEFAULT_FILTER_OPTIONS;
+      this.context.input.focus();
+      this.context.component.openDropdown();
+
+      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+
+      this.context.input.value = 'o';
+      this.context.input.dispatchEvent(new Event('input'));
+      await timer(AUTOCOMPLETE_CONSTANTS.numbers.DEFAULT_DEBOUNCE_TIME);
+      await tick();
+
+      const activeListItemIndex = _getActiveListItemIndex(this.context.component.popupElement);
+      expect(activeListItemIndex).toBe(0);
+    });
+
+    it('should not activate first option if filterFocusFirst is false', async function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      this.context.component.filter = () => DEFAULT_FILTER_OPTIONS;
+      this.context.component.filterFocusFirst = false;
       this.context.input.focus();
       this.context.component.openDropdown();
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
When filtering options by typing, the dropdown will focus the first option automatically. This change adds a new `filterFocusFirst` configuration property that defaults to `true` to retain the existing functionality, but allows for a developer to set it to `false` to stop the first option from being automatically focused if desired.

## Additional information
This came up due to an application needing to allow for submitting a form via the enter key (specifically when using `allowUnmatched` and composed with a chip-field), and it was confusing for users that the selection was changing because the first option was always automatically activated in the dropdown.
