### PR TITLE
fix(stack): fix to allow string values to be provided to the `alignment` property/attribute (instead of just an `enum` value) when strict typing is used

### DIFF
--- a/src/lib/stack/stack-constants.ts
+++ b/src/lib/stack/stack-constants.ts
@@ -30,6 +30,9 @@ export const STACK_CONSTANTS = {
   strings
 };
 
+export type StackAlignment = 'start' | 'center' | 'end';
+
+/** @deprecated Use `StackAlignment` instead. */
 export enum StackAlignMode {
   Start = 'start',
   Center = 'center',

--- a/src/lib/stack/stack-foundation.ts
+++ b/src/lib/stack/stack-foundation.ts
@@ -1,13 +1,13 @@
 import { ICustomElementFoundation } from '@tylertech/forge-core';
 import { IStackAdapter } from './stack-adapter';
-import { STACK_CONSTANTS, StackAlignMode } from './stack-constants';
+import { StackAlignment, STACK_CONSTANTS } from './stack-constants';
 
 export interface IStackFoundation extends ICustomElementFoundation {
   inline: boolean;
   wrap: boolean;
   stretch: boolean;
   gap: string;
-  alignment: StackAlignMode;
+  alignment: StackAlignment;
 }
 
 export class StackFoundation implements IStackFoundation {
@@ -15,7 +15,7 @@ export class StackFoundation implements IStackFoundation {
   private _wrap = false;
   private _stretch = false;
   private _gap = STACK_CONSTANTS.strings.DEFAULT_GAP;
-  private _alignment = StackAlignMode.Start;
+  private _alignment: StackAlignment = 'start';
 
   constructor(private _adapter: IStackAdapter) {}
 
@@ -68,10 +68,10 @@ export class StackFoundation implements IStackFoundation {
   }
 
   /** Controls the alignment of children */
-  public get alignment(): StackAlignMode {
+  public get alignment(): StackAlignment {
     return this._alignment;
   }
-  public set alignment(value: StackAlignMode) {
+  public set alignment(value: StackAlignment) {
     if (this._alignment !== value) {
       this._alignment = value;
       this._adapter.setHostAttribute(STACK_CONSTANTS.attributes.ALIGNMENT, this._alignment);

--- a/src/lib/stack/stack.ts
+++ b/src/lib/stack/stack.ts
@@ -1,7 +1,7 @@
 import { CustomElement, attachShadowTemplate, ICustomElement, coerceBoolean, FoundationProperty } from '@tylertech/forge-core';
 import { StackAdapter } from './stack-adapter';
 import { StackFoundation } from './stack-foundation';
-import { STACK_CONSTANTS, StackAlignMode } from './stack-constants';
+import { STACK_CONSTANTS, StackAlignMode, StackAlignment } from './stack-constants';
 import { BaseComponent } from '../core/base/base-component';
 
 import template from './stack.html';
@@ -12,7 +12,7 @@ export interface IStackComponent extends ICustomElement {
   wrap: boolean;
   stretch: boolean;
   gap: string;
-  alignment: StackAlignMode;
+  alignment: StackAlignMode | StackAlignment;
 }
 
 declare global {
@@ -63,7 +63,7 @@ export class StackComponent extends BaseComponent implements IStackComponent {
         this.gap = newValue;
         break;
       case STACK_CONSTANTS.attributes.ALIGNMENT:
-        this.alignment = newValue as StackAlignMode;
+        this.alignment = newValue as StackAlignment;
         break;
     }
   }
@@ -86,5 +86,5 @@ export class StackComponent extends BaseComponent implements IStackComponent {
 
   /** Controls if stack items are at the end of the row or column */
   @FoundationProperty()
-  public declare alignment: StackAlignMode;
+  public declare alignment: StackAlignMode | StackAlignment;
 }

--- a/src/stories/src/components/stack/stack.mdx
+++ b/src/stories/src/components/stack/stack.mdx
@@ -54,7 +54,7 @@ Controls the amount of space between child elements within a stack.
 
 </PropertyDef>
 
-<PropertyDef name="alignment" type="string" defaultValue="&quot;start&quot;">
+<PropertyDef name="alignment" type="StackAlignment" defaultValue="&quot;start&quot;">
 
   Align child elements within a stack. Valid values: `start` (default), `center`, `end`.
 
@@ -82,6 +82,18 @@ Controls the amount of space between child elements within a stack.
 
 > **Tip:** Check out the MDN web docs on flex-grow to learn more: [MDN: flex-grow](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow).
 
-
 </PageSection>
 
+---
+
+<PageSection>
+
+## Types
+
+### StackAlignment
+
+```ts
+type StackAlignment = 'start' | 'center' | 'end';
+```
+
+</PageSection>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Updated the `alignment` property to accept a new `StackAlignment` type. This enables us to provide alignment values as a `string` instead of being forced by strict typing to use an `enum`.

## Additional information
Marked the `StackAlignMode` enumeration as deprecated, but it can still be used.
