### PR TITLE
fix(select): fixed a bug where filtering options with uppercase letters was not working

### DIFF
--- a/src/lib/select/core/base-select-foundation.ts
+++ b/src/lib/select/core/base-select-foundation.ts
@@ -519,8 +519,8 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
       this._filterTimeout = undefined;
     }, 300);
     this._options = this._adapter.getOptions();
-    // TODO(kieran.nichols): Enhance this to cycle through closest matches (see the native select)
-    const matchedOption = this._flatOptions.find(option => !option.disabled && option.label.toLowerCase().startsWith(this._filterString));
+    // TODO: Enhance this to cycle through closest matches (see the native select)
+    const matchedOption = this._flatOptions.find(option => !option.disabled && option.label.toLowerCase().startsWith(this._filterString.toLowerCase()));
     if (matchedOption) {
       const optionIndex = this._flatOptions.indexOf(matchedOption);
       if (this._open) {

--- a/src/test/spec/select/select.spec.ts
+++ b/src/test/spec/select/select.spec.ts
@@ -832,6 +832,19 @@ describe('SelectComponent', function(this: ITestContext) {
       _expectActiveOption(this.context.component.popupElement, 1);
       _expectPopupVisibility(this.context.component.popupElement, true);
     });
+
+    it('should highlight first match when filtering with uppercase characters', async function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      await tick();
+      
+      await _triggerPopupOpen(this.context.component);
+      
+      _sendFilterKey(this.context.component, 'T', 84);
+      await timer();
+
+      _expectActiveOption(this.context.component.popupElement, 1);
+      _expectPopupVisibility(this.context.component.popupElement, true);
+    });
     
     it('should highlight match when filtering quickly while popup is open', async function(this: ITestContext) {
       this.context = setupTestContext(true);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Filtering options while using caps lock or the shift key will now properly use a case-insensitive "starts with" strategy.

## Additional information
Fixes #316 
