### PR TITLE
fix(select, autocomplete): show option label when one option is selected in multiple mode

### DIFF
--- a/src/lib/autocomplete/autocomplete-foundation.ts
+++ b/src/lib/autocomplete/autocomplete-foundation.ts
@@ -648,7 +648,11 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     } else {
       if (this._multiple) {
         if (this._values.length) {
-          return `${this._values.length} ${this._values.length === 1 ? 'option' : 'options'} selected`;
+          if (this._values.length === 1) {
+            return this._selectedOptions[0]?.label ?? '';
+          } else {
+            return `${this._values.length} options selected`;
+          }
         } else {
           return '';
         }

--- a/src/lib/select/core/base-select-foundation.ts
+++ b/src/lib/select/core/base-select-foundation.ts
@@ -366,7 +366,11 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
 
     if (this._multiple) {
       if (this._selectedLabels.length) {
-        return `${this._selectedLabels.length} ${this._selectedLabels.length === 1 ? 'option' : 'options'} selected`;
+        if (this._selectedLabels.length === 1) {
+          return this._selectedLabels[0];
+        } else {
+          return `${this._selectedLabels.length} options selected`;
+        }
       } else {
         return '';
       }

--- a/src/test/spec/autocomplete/autocomplete.spec.ts
+++ b/src/test/spec/autocomplete/autocomplete.spec.ts
@@ -191,7 +191,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       _clickListItem(1, this.context.component.popupElement);
       this.context.component.value = [DEFAULT_FILTER_OPTIONS[2]];
 
-      expect(this.context.input.value).toBe('1 option selected');
+      expect(this.context.input.value).toBe(DEFAULT_FILTER_OPTIONS[2].label);
       expect(this.context.component.open).toBe(true);
     });
 
@@ -381,6 +381,15 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       await tick();
       expect(this.context.component.value).toEqual([DEFAULT_FILTER_OPTIONS[0].value, DEFAULT_FILTER_OPTIONS[1].value]);
       expect(this.context.input.value).toBe('2 options selected');
+    });
+
+    it('should set single option value when one option is selected in multiple mode', async function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      this.context.component.filter = () => DEFAULT_FILTER_OPTIONS;
+      this.context.component.multiple = true;
+      this.context.component.value = [DEFAULT_FILTER_OPTIONS[0].value];
+      await tick();
+      expect(this.context.input.value).toBe(DEFAULT_FILTER_OPTIONS[0].label);
     });
 
     it('should set label via match key', async function (this: ITestContext) {

--- a/src/test/spec/select/select.spec.ts
+++ b/src/test/spec/select/select.spec.ts
@@ -978,6 +978,26 @@ describe('SelectComponent', function(this: ITestContext) {
       expect(this.context.component.value).toEqual([DEFAULT_OPTIONS[1].value, DEFAULT_OPTIONS[2].value]);
     });
 
+    it('should set generic selected text in multiple mode when more than one option is selected', async function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      await tick();
+      
+      this.context.component.multiple = true;
+      this.context.component.selectedIndex = [1, 2];
+
+      expect(this.context.selectedTextElement.innerText).toBe('2 options selected');
+    });
+
+    it('should set selected text to option label when one option is selected in multiple mode', async function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      await tick();
+      
+      this.context.component.multiple = true;
+      this.context.component.selectedIndex = [1];
+
+      expect(this.context.selectedTextElement.innerText).toBe(DEFAULT_OPTIONS[1].label);
+    });
+
     it('should use option builder', async function(this: ITestContext) {
       this.context = setupTestContext(true);
       await tick();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
When selecting a single option in multiple mode in both the select and autocomplete, the "selected text" will now default to showing the option label instead of "1 option selected". If more than one option is selected, it will still display the text "x options selected" as it previously did.

## Additional information
Fixes #310 
