### PR TITLE
fix(stack): fix stretch styles

### DIFF
--- a/src/lib/stack/_mixins.scss
+++ b/src/lib/stack/_mixins.scss
@@ -27,7 +27,7 @@
 
 @mixin stretch() {
   ::slotted(*) {
-    flex-grow: var(--forge-stack-stretch, 0);
+    flex: var(--forge-stack-stretch, initial);
   }
 }
 

--- a/src/lib/stack/stack.scss
+++ b/src/lib/stack/stack.scss
@@ -3,12 +3,9 @@
 
 :host {
   display: block;
-  height: 100%;
 }
 
 :host([inline]) {
-  height: auto;
-  
   .forge-stack {
     @include mixins.inline;
   }

--- a/src/lib/stack/stack.scss
+++ b/src/lib/stack/stack.scss
@@ -17,6 +17,10 @@
   }
 }
 
+:host([stretch]:not([inline])) {
+  height: 100%;
+}
+
 :host([stretch]) {
   --forge-stack-stretch: 1;
 }

--- a/src/stories/src/components/stack/stack.mdx
+++ b/src/stories/src/components/stack/stack.mdx
@@ -78,9 +78,9 @@ Controls the amount of space between child elements within a stack.
 
 | Name                                          | Description
 | :---------------------------------------------| :----------------
-| `--forge-stack-stretch`                         | Controls the flex grow factor of a child element within the stack.
+| `--forge-stack-stretch`                       | Controls the `flex` shorthand property of a child element within the stack.
 
-> **Tip:** Check out the MDN web docs on flex-grow to learn more: [MDN: flex-grow](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow).
+> **Tip:** Check out the MDN web docs on `flex` to learn more: [MDN: flex](https://developer.mozilla.org/en-US/docs/Web/CSS/flex).
 
 
 </PageSection>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? 
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
- Remove the default `height: 100%` style that is applied to the host element by default since this could lead to confusion, and can easily be set by consumers already. This style will now only be applied when `stretch` is used while **not** `inline`.
- Swapped the `flex-grow` style property to reference the shorthand `flex` style for more flexibility, as well as a better default for stretched stack items.
