### PR TITLE
fix(expansion-panel): remove internal a11y attributes

### DIFF
--- a/src/lib/expansion-panel/expansion-panel-constants.ts
+++ b/src/lib/expansion-panel/expansion-panel-constants.ts
@@ -24,7 +24,8 @@ const events = {
 const attributes = {
   OPEN: 'open',
   ORIENTATION: 'orientation',
-  USE_ANIMATIONS: 'use-animations'
+  USE_ANIMATIONS: 'use-animations',
+  IGNORE: 'data-forge-ignore'
 };
 
 const numbers = {

--- a/src/lib/expansion-panel/expansion-panel-foundation.ts
+++ b/src/lib/expansion-panel/expansion-panel-foundation.ts
@@ -1,4 +1,4 @@
-import { debounce, ICustomElementFoundation } from '@tylertech/forge-core';
+import { debounce, getEventPath, ICustomElementFoundation } from '@tylertech/forge-core';
 import { IExpansionPanelAdapter } from './expansion-panel-adapter';
 import { EXPANSION_PANEL_CONSTANTS } from './expansion-panel-constants';
 
@@ -134,6 +134,10 @@ export class ExpansionPanelFoundation implements IExpansionPanelFoundation {
    * @param {MouseEvent} evt The click event.
    */
   private _onClick(evt: MouseEvent): void {
+    if (getEventPath(evt).find(p => p.hasAttribute && p.hasAttribute(EXPANSION_PANEL_CONSTANTS.attributes.IGNORE))) {
+      return;
+    }
+
     evt.stopPropagation();
     this._toggle();
     this._emitEvent();

--- a/src/lib/expansion-panel/expansion-panel.html
+++ b/src/lib/expansion-panel/expansion-panel.html
@@ -1,9 +1,9 @@
 <template>
   <div class="forge-expansion-panel" part="root">
-    <div class="forge-expansion-panel__header" role="button" aria-controls="content" aria-expanded="false" part="header">
+    <div class="forge-expansion-panel__header" part="header">
       <slot name="header"></slot>
     </div>
-    <div id="content" role="group" class="forge-expansion-panel__content" style="height: 0; opacity: 0; visibility: hidden;" part="content">
+    <div class="forge-expansion-panel__content" style="height: 0; opacity: 0; visibility: hidden;" part="content">
       <slot></slot>
     </div>
   </div>

--- a/src/stories/src/components/expansion-panel/expansion-panel.mdx
+++ b/src/stories/src/components/expansion-panel/expansion-panel.mdx
@@ -76,6 +76,8 @@ Gets/sets if animations are used in the expand/collapse transition.
   
 </PropertyDef>
 
+> You can use the attribute `data-forge-ignore` on elements internal to the expansion panel header in order to prevent user interactions with that element from toggling the expansion panel's state.
+
 </PageSection>
 
 ---

--- a/src/stories/src/components/expansion-panel/expansion-panel.mdx
+++ b/src/stories/src/components/expansion-panel/expansion-panel.mdx
@@ -158,9 +158,10 @@ Forces the expansion panel to expand/collapse immediately **without** transition
 
 ## Accessibility
 
+- If the user is able to click the expansion panel to toggle its state, ensure that a `<button>` element is present and clearly labeled to serve as an accessible point of interaction.
+  - Set the `aria-expanded` atribute on the button to reflect the state of the component.
+  - Set `aria-controls` on the button to reference the id of the expandable content.
 - Ensure that the user can focus on the element which activates and deactivates the expansion panel.
   - Ensure that the expansion panel can be activated by keyboard.
-- Ensure that the `aria-expanded` attribute is updated to reflect the state of the expandable panel, especially when toggling its state programmatically.
-  - This attribute is handled for you inside the expansion-panel component.
 
 </PageSection>

--- a/src/test/spec/expansion-panel/expansion-panel.spec.ts
+++ b/src/test/spec/expansion-panel/expansion-panel.spec.ts
@@ -133,11 +133,11 @@ describe('ExpansionPanelComponent', function(this: ITestContext) {
       expect(this.context.component.open).toBe(false);
     });
 
-    it('should set aria-expanded by default', function(this: ITestContext) {
-      this.context = setupTestContext(true);
-      expect(this.context.headerElement.hasAttribute('aria-expanded')).toBe(true);
-      expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('false');
-    });
+    // it('should set aria-expanded by default', function(this: ITestContext) {
+    //   this.context = setupTestContext(true);
+    //   expect(this.context.headerElement.hasAttribute('aria-expanded')).toBe(true);
+    //   expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('false');
+    // });
 
     it('should not display content by default', function(this: ITestContext) {
       this.context = setupTestContext(true);
@@ -285,13 +285,13 @@ describe('ExpansionPanelComponent', function(this: ITestContext) {
       expect(listener).toHaveBeenCalledTimes(2);
     });
 
-    it('should set aria-expanded', async function(this: ITestContext) {
-      this.context = setupTestContext(true);
-      this.context.component.open = true;
-      await tick();
-      await tick();
-      expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('true');
-    });
+    // it('should set aria-expanded', async function(this: ITestContext) {
+    //   this.context = setupTestContext(true);
+    //   this.context.component.open = true;
+    //   await tick();
+    //   await tick();
+    //   expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('true');
+    // });
 
     it('should hide header element if nothing is slotted in', async function(this: ITestContext) {
       this.context = setupTestContext(true);
@@ -309,7 +309,7 @@ describe('ExpansionPanelComponent', function(this: ITestContext) {
       this.context.component.open = true;
       await tick();
 
-      expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('true');
+      // expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('true');
       expect(getInternalPanelContent(this.context.component).clientHeight).toBe(0);
     });
 
@@ -322,7 +322,7 @@ describe('ExpansionPanelComponent', function(this: ITestContext) {
       this.context.component.open = false;
       await tick();
 
-      expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('false');
+      // expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('false');
       expect(getInternalPanelContent(this.context.component).clientHeight).toBe(0);
     });
 
@@ -334,7 +334,7 @@ describe('ExpansionPanelComponent', function(this: ITestContext) {
       panelHeader.click();
       await timer(EXPANSION_PANEL_CONSTANTS.numbers.COLLAPSE_ANIMATION_DURATION);
       expect(this.context.component.open).toBe(true);
-      expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('true');
+      // expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('true');
       expect(getInternalPanelContent(this.context.component).clientHeight).toBeGreaterThan(0);
     });
   });
@@ -365,7 +365,7 @@ describe('ExpansionPanelComponent', function(this: ITestContext) {
 
       getPanelHeader(this.context.component).click();
       expect(this.context.component.open).toBe(true);
-      expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('true');
+      // expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('true');
       expect(getInternalPanelContent(this.context.component).clientHeight).toBeGreaterThan(0);
     });
 
@@ -377,7 +377,7 @@ describe('ExpansionPanelComponent', function(this: ITestContext) {
       getPanelHeader(this.context.component).click();
 
       expect(this.context.component.open).toBe(true);
-      expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('true');
+      // expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('true');
       expect(getInternalPanelContent(this.context.component).clientWidth).toBeGreaterThan(0);
     });
 
@@ -389,7 +389,7 @@ describe('ExpansionPanelComponent', function(this: ITestContext) {
       getPanelHeader(this.context.component).click();
 
       expect(this.context.component.open).toBe(false);
-      expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('false');
+      // expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('false');
       expect(getInternalPanelContent(this.context.component).clientHeight).toBe(0);
     });
 
@@ -403,7 +403,7 @@ describe('ExpansionPanelComponent', function(this: ITestContext) {
       getPanelHeader(this.context.component).click();
 
       expect(this.context.component.open).toBe(false);
-      expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('false');
+      // expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('false');
       expect(getInternalPanelContent(this.context.component).clientWidth).toBe(0);
     });
 
@@ -414,7 +414,7 @@ describe('ExpansionPanelComponent', function(this: ITestContext) {
       this.context.component.setOpenImmediate(true);
 
       expect(this.context.component.open).toBe(true);
-      expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('true');
+      // expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('true');
       expect(getInternalPanelContent(this.context.component).clientHeight).toBeGreaterThan(0);
     });
 
@@ -427,7 +427,7 @@ describe('ExpansionPanelComponent', function(this: ITestContext) {
       this.context.component.setOpenImmediate(false);
 
       expect(this.context.component.open).toBe(false);
-      expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('false');
+      // expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('false');
       expect(getInternalPanelContent(this.context.component).clientHeight).toBe(0);
     });
 
@@ -439,14 +439,14 @@ describe('ExpansionPanelComponent', function(this: ITestContext) {
 
       this.context.component.setOpenImmediate(true);
       expect(this.context.component.open).toBe(true);
-      expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('true');
+      // expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('true');
       expect(getInternalPanelContent(this.context.component).clientWidth).toBeGreaterThan(0);
 
       await tick();
 
       this.context.component.setOpenImmediate(false);
       expect(this.context.component.open).toBe(false);
-      expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('false');
+      // expect(this.context.headerElement.getAttribute('aria-expanded')).toBe('false');
       expect(getInternalPanelContent(this.context.component).clientWidth).toBe(0);
     });
   });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N/A

## Describe the new behavior?
This removes the `role`, `aria-expanded`, and `aria-controls` attributes from the expansion panel's shadow elements. These attributes weren't contributing to accessibility and prevented consumers from managing accessibility themselves or slotting complex content into the header. The header still listens for click events to toggle panel visibility however.

Also, a `data-forge-ignore` can now be added to elements nested in the header to prevent interaction with them from toggle the panel.
