### PR TITLE
fix(date-picker): always dispatch the change event when a valid date is entered if `allowInvalidDate` is `true`

### DIFF
--- a/src/lib/date-picker/base/base-date-picker-foundation.ts
+++ b/src/lib/date-picker/base/base-date-picker-foundation.ts
@@ -427,7 +427,7 @@ export abstract class BaseDatePickerFoundation<TAdapter extends IBaseDatePickerA
   }
 
   protected _isDateValueAcceptable(value?: Date | null): boolean {
-    if (!value) {
+    if (!value || this._allowInvalidDate) {
       return true;
     }
 

--- a/src/test/spec/date-picker/date-picker.spec.ts
+++ b/src/test/spec/date-picker/date-picker.spec.ts
@@ -612,6 +612,19 @@ describe('DatePickerComponent', function(this: ITestContext) {
       expect(getInputElement(this.context.component).value).toBe(date);
     });
 
+    it('should allow value if matches disabled day of week date if allow invalid is set', function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      this.context.component.allowInvalidDate = true;
+      this.context.component.disabledDaysOfWeek = [6]; // Saturdays
+
+      const disabledDate = '01/01/2000'; // This is a Saturday
+      const expectedDate = new Date(disabledDate);
+      this.context.component.value = expectedDate;
+
+      expect(this.context.component.value).toEqual(expectedDate);
+      expect(getInputElement(this.context.component).value).toBe(disabledDate);
+    });
+
     it('should clear value when min date is set if current value is not valid', function(this: ITestContext) {
       this.context = setupTestContext(true);
       const minDate = new Date('01/01/2020');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Updated the logic that determines if the provided date value is "acceptable" (passes min, max, disabled day checks) to ignore those checks if the component is configured to allow invalid (unacceptable) dates.

This allows for the change event to be dispatched properly when the developer wants to provide these guard rails while still providing separate error messages to the user.

## Additional information
Fixes #324 
