### PR TITLE
fix(split-view): query only immediate child panels

### DIFF
--- a/src/lib/split-view/split-view/split-view-adapter.ts
+++ b/src/lib/split-view/split-view/split-view-adapter.ts
@@ -49,7 +49,9 @@ export class SplitViewAdapter extends BaseAdapter<ISplitViewComponent> implement
    */
   public getSlottedPanels(): ISplitViewPanelComponent[] {
     const nodeList = this._component.querySelectorAll<ISplitViewPanelComponent>(SPLIT_VIEW_CONSTANTS.selectors.PANEL);
-    return Array.from(nodeList);
+    const panelArray = Array.from(nodeList);
+    const immediateChildPanels = panelArray.filter(panel => panel.parentElement === this._component);
+    return immediateChildPanels;
   }
 
   public refitSlottedPanels(orientation: SplitViewOrientation): void {

--- a/src/test/spec/split-view/split-view/split-view.spec.ts
+++ b/src/test/spec/split-view/split-view/split-view.spec.ts
@@ -1,6 +1,6 @@
 import { removeElement } from '@tylertech/forge-core';
 import { tick } from '@tylertech/forge-testing';
-import { defineSplitViewComponent, ISplitViewComponent, ISplitViewPanelComponent, SplitViewAnimatingLayer, SPLIT_VIEW_CONSTANTS, SPLIT_VIEW_PANEL_CONSTANTS } from '@tylertech/forge/split-view';
+import { defineSplitViewComponent, ISplitViewComponent, ISplitViewPanelComponent, SplitViewAnimatingLayer, SPLIT_VIEW_CONSTANTS, SPLIT_VIEW_PANEL_CONSTANTS, ISplitViewAdapter } from '@tylertech/forge/split-view';
 
 interface ITestContext {
   context: ITestSplitViewContext;
@@ -178,6 +178,17 @@ describe('SplitViewComponent', function(this: ITestContext) {
       await tick();
       const size = this.context.panels![1].style.getPropertyValue(SPLIT_VIEW_PANEL_CONSTANTS.customCssProperties.SIZE);
       expect(size).not.toBe('0px');
+    });
+
+    it('should query only immediate child panels', function(this: ITestContext) {
+      const numberOfImmediateChildren = 2;
+      this.context = setupTestContext(true, numberOfImmediateChildren);
+      const div = document.createElement('div');
+      const panel = document.createElement('forge-split-view-panel');
+      div.appendChild(panel);
+      this.context.component.appendChild(div);
+      const queriedComponents = (this.context.component['_foundation']['_adapter'] as ISplitViewAdapter).getSlottedPanels();
+      expect(queriedComponents.length).toBe(2);
     });
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Fixes #327 

This changes the `getSlottedPanels()` method of the split view adapter to match the parent element of queried panels against the component instance. Before, the method would return all panels nested within the split view instead of just those that should be directly managed by it.

