### PR TITLE
fix(autocomplete): fixed a bug where selecting appended options in multiple mode would incorrectly select the wrong options in the UI dropdown

### DIFF
--- a/src/lib/autocomplete/autocomplete-adapter.ts
+++ b/src/lib/autocomplete/autocomplete-adapter.ts
@@ -24,7 +24,6 @@ export interface IAutocompleteAdapter extends IBaseAdapter {
   setInputValue(value: string): void;
   selectInputValue(): void;
   setDismissListener(listener: () => void): void;
-  toggleOptionMultiple(index: number, selected: boolean): void;
   isFocusWithinPopup(target: HTMLElement): boolean;
   hasFocus(): boolean;
   hasInputElement(): boolean;
@@ -123,10 +122,6 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
 
   public setBusyVisibility(isVisible: boolean): void {
     this._listDropdown?.setBusyVisibility(isVisible);
-  }
-
-  public toggleOptionMultiple(index: number, selected: boolean): void {
-    this._listDropdown?.toggleOptionMultiple(index, selected);
   }
 
   public setDismissListener(listener: () => void): void {

--- a/src/lib/autocomplete/autocomplete-foundation.ts
+++ b/src/lib/autocomplete/autocomplete-foundation.ts
@@ -534,11 +534,6 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
       const label = option ? option.label : '';
 
       if (this._multiple) {
-        const optionIndex = flatOptions.findIndex(o => optionEqualPredicate(o, selectedValue, this._matchKey));
-        if (optionIndex >= 0) {
-          const selected = this._selectedOptions.some(o => optionEqualPredicate(o, selectedValue, this._matchKey));
-          this._adapter.toggleOptionMultiple(optionIndex, selected);
-        }
         const selectedOption = getSelectedOption(this._selectedOptions, value);
         if (selectedOption) {
           const index = this._selectedOptions.indexOf(selectedOption);
@@ -570,13 +565,6 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
       // Select the text in the input to allow for the next filter
       if (!Platform.isMobile && keepFocus) {
         this._adapter.selectInputValue();
-      }
-
-      if (this._multiple) {
-        // If we're in multiselect mode, we need to toggle the selected option
-        const index = flatOptions.findIndex(o => optionEqualPredicate(o, selectedValue, this._matchKey));
-        const isSelected = this._values.includes(selectedValue);
-        this._adapter.toggleOptionMultiple(index, isSelected);
       }
 
       this._emitChangeEvent();

--- a/src/lib/list-dropdown/list-dropdown-adapter.ts
+++ b/src/lib/list-dropdown/list-dropdown-adapter.ts
@@ -273,7 +273,7 @@ export class ListDropdownAdapter implements IListDropdownAdapter {
     if (!this._dropdownElement || !this._listElement) {
       return;
     }
-    createListItems(config, this._listElement, options);
+    createListItems(config, this._listElement, options, this._listElement.childElementCount, false);
   }
 
   public setBusyVisibility(isVisible: boolean): void {

--- a/src/lib/list-dropdown/list-dropdown-utils.ts
+++ b/src/lib/list-dropdown/list-dropdown-utils.ts
@@ -98,14 +98,14 @@ export function createList(config: IListDropdownOpenConfig): IListComponent {
  * Creates the list to place inside of the dropdown.
  * @param config 
  */
-export function createListItems(config: IListDropdownOpenConfig, listElement: IListComponent, options?: Array<IListDropdownOption | IListDropdownOptionGroup>): void {
+export function createListItems(config: IListDropdownOpenConfig, listElement: IListComponent, options?: Array<IListDropdownOption | IListDropdownOptionGroup>, startIndex = 0, renderSelected = true): void {
   // Ensure the options are provided in the form a group (if no groups provided, then we have one anonymous group of options)
   const groups = getOptionsByGroup(options || config.options);
   const flatOptions = getFlattenedOptions(groups);
 
   const limitOptions = config.optionLimit ? true : false;
   let optionLimit = config.optionLimit || 0;
-  let optionIndex = 0;
+  let optionIdIndex = startIndex;
 
   // Iterate over our groups and render the optional headers and options for that group
   for (const group of groups) {
@@ -160,14 +160,18 @@ export function createListItems(config: IListDropdownOpenConfig, listElement: IL
       if (limitOptions && --optionLimit < 0) {
         break;
       }
-
-      optionIndex++;
       
       // Create and configure the list element
       const isSelected = config.selectedValues ? config.selectedValues.some(v => isDeepEqual(v, option.value)) : false;
+
+      // We don't render selected options that are appended dynamically since those are always displayed at the top of the list
+      if (!renderSelected && isSelected) {
+        continue;
+      }
+
       let listItemElement = document.createElement('forge-list-item');
       listItemElement.value = option.value;
-      listItemElement.id = `list-dropdown-option-${config.id}-${optionIndex}`;
+      listItemElement.id = `list-dropdown-option-${config.id}-${optionIdIndex++}`;
       listItemElement.style.cursor = 'pointer';
 
       if (config.wrapOptionText) {

--- a/src/test/spec/list-dropdown/list-dropdown.spec.ts
+++ b/src/test/spec/list-dropdown/list-dropdown.spec.ts
@@ -87,7 +87,7 @@ describe('ListDropdown', function(this: ITestContext) {
     expect(activeChangeCallback).not.toHaveBeenCalled();
 
     this.context.listDropdown.handleKey('ArrowDown');
-    expect(activeChangeCallback).toHaveBeenCalledWith('list-dropdown-option-list-dropdown-1');
+    expect(activeChangeCallback).toHaveBeenCalledWith('list-dropdown-option-list-dropdown-0');
   });
 
   it('should close', async function(this: ITestContext) {

--- a/src/test/spec/select/select-dropdown.spec.ts
+++ b/src/test/spec/select/select-dropdown.spec.ts
@@ -246,10 +246,10 @@ describe('SelectDropdownComponent', function(this: ITestContext) {
     this.context.targetElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
 
     expect(this.context.targetElement.hasAttribute('aria-activedescendant')).toBeTrue();
-    expect(this.context.targetElement.getAttribute('aria-activedescendant')).toBe(`list-dropdown-option-${this.context.foundation['_identifier']}-1`);
+    expect(this.context.targetElement.getAttribute('aria-activedescendant')).toBe(`list-dropdown-option-${this.context.foundation['_identifier']}-0`);
   });
 
-  it('should update active descenadant when using keyboard navigation',  async function(this: ITestContext) {
+  it('should update active descendant when using keyboard navigation',  async function(this: ITestContext) {
     this.context = setupTestContext();
 
     this.context.component.open = true;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The autocomplete will now only toggle the specific option that was clicked when selecting a dynamically added option in an infinite scroll scenario.

This change relies on the standard selection functionality of the underlying list item instead of manually calculating the option index and toggling the selected state.

Along with this change, the underlying option `id` of each dynamically appended option will now be unique.

## Additional information
Previously the component was manually toggling the selected list items when they were clicked, which caused the indexes to become out of sync when selected options were rendered at the top of the list.
