### PR TITLE
fix(paginator): fixed a bug where the paginator was not reflecting the current page size after selection in the page size select

### DIFF
--- a/src/lib/paginator/paginator-foundation.ts
+++ b/src/lib/paginator/paginator-foundation.ts
@@ -340,6 +340,7 @@ export class PaginatorFoundation {
     if (canPage) {
       this.pageIndex = 0;
       this.pageSize = pageSize;
+    } else {
       evt.preventDefault();
     }
   }

--- a/src/test/spec/paginator/paginator.spec.ts
+++ b/src/test/spec/paginator/paginator.spec.ts
@@ -1,8 +1,9 @@
 import { IPaginatorComponent, PAGINATOR_CONSTANTS, IPaginatorChangeEvent, definePaginatorComponent } from '@tylertech/forge/paginator';
 import { BASE_SELECT_CONSTANTS, ISelectComponent } from '@tylertech/forge/select';
 import { IIconButtonComponent } from '@tylertech/forge/icon-button';
+import { IListItemComponent, LIST_ITEM_CONSTANTS } from '@tylertech/forge/list';
 import { getShadowElement, removeElement, emitEvent } from '@tylertech/forge-core';
-import { timer } from '@tylertech/forge-testing';
+import { tick, timer } from '@tylertech/forge-testing';
 
 interface ITestContext {
   context: ITestPaginatorContext;
@@ -240,6 +241,38 @@ describe('PaginatorComponent', function(this: ITestContext) {
       const newOptions = [1, 2, 3, 4];
       this.context.paginator.pageSizeOptions = newOptions;
       expect(this.context.paginator.pageSize).toBe(1);
+    });
+
+    it('should reflect page size selection', async function(this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.pageSizeSelect.open = true;
+
+      const listItem = this.context.pageSizeSelect.popupElement?.querySelector(LIST_ITEM_CONSTANTS.elementName) as IListItemComponent;
+      const listItemRoot = getShadowElement(listItem, LIST_ITEM_CONSTANTS.selectors.LIST_ITEM);
+      listItemRoot.click();
+      await tick();
+
+      expect(listItem.value).toBe('5');
+      expect(this.context.paginator.pageSize).toBe(5);
+      expect(this.context.pageSizeSelect.value).toBe('5');
+    });
+
+    it('should not reflect page size selection if change event is cancelled', async function(this: ITestContext) {
+      this.context = setupTestContext();
+      
+      const originalPageSize = this.context.pageSizeSelect.value;
+
+      const changeSpy = jasmine.createSpy('changeSpy', evt => evt.preventDefault()).and.callThrough();
+      this.context.paginator.addEventListener('forge-paginator-change', changeSpy);
+
+      this.context.pageSizeSelect.open = true;
+      const listItem = this.context.pageSizeSelect.popupElement?.querySelector(LIST_ITEM_CONSTANTS.elementName) as IListItemComponent;
+      const listItemRoot = getShadowElement(listItem, LIST_ITEM_CONSTANTS.selectors.LIST_ITEM);
+      listItemRoot.click();
+      await tick();
+
+      expect(this.context.paginator.pageSize).toBe(Number(originalPageSize));
+      expect(this.context.pageSizeSelect.value).toBe(originalPageSize);
     });
 
     it('should use default page size if options doesn\'t contain current page size as an option and no options exist', function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The page size select will now properly reflect the current page size selection value when changed by the user.

## Additional information
Fixes #332 

This was a regression caused by a [recent change](https://github.com/tyler-technologies-oss/forge/pull/212) in the select component where some state synchronization was fixed, but this component was not updated. Unit tests have been added to detect this situation in the future.
