### PR TITLE
feat: created a new `<forge-focus-indicator>` component (for `:focus-visible` support)

### DIFF
--- a/src/dev/pages/focus-indicator/focus-indicator.ejs
+++ b/src/dev/pages/focus-indicator/focus-indicator.ejs
@@ -1,0 +1,66 @@
+<div class="vert">
+  <!-- Default example with :focus-visible -->
+  <div>
+    <button type="button" class="example-target">
+      Button :focus-visible
+      <forge-focus-indicator></forge-focus-indicator>
+    </button>
+  </div>
+
+  <!-- Default example with :focus-visible -->
+  <div>
+    <button type="button" class="example-target custom-target">
+      Custom :focus-visible
+      <forge-focus-indicator></forge-focus-indicator>
+    </button>
+  </div>
+
+  <!-- Default example with :focus-visible and target -->
+  <div>
+    <div class="example-target">
+      <button id="target-btn" type="button" class="example-target">
+        Button :focus-visible w/target
+      </button>
+      <forge-focus-indicator target="target-btn"></forge-focus-indicator>
+    </div>
+  </div>
+
+  <!-- Example with :focus -->
+  <div>
+    <button type="button" class="example-target">
+      Button :focus
+      <forge-focus-indicator allow-focus></forge-focus-indicator>
+    </button>
+  </div>
+
+  <!-- Circular example-->
+  <div>
+    <div tabindex="0" role="button" class="example-target icon">
+      <forge-icon name="forge_logo"></forge-icon>
+      <forge-focus-indicator circular allow-focus></forge-focus-indicator>
+    </div>
+  </div>
+
+  <!-- Typical card example -->
+  <div tabindex="0" role="button" class="example-target">
+    <forge-card role="presentation" style="border-radius: 4px;">
+      <p style="margin: 0;">
+        Lorem ipsum dolor, sit amet consectetur adipisicing elit. Voluptate, nihil et sequi similique ad,
+        voluptas quod quisquam iure deleniti voluptatibus pariatur laborum maiores iste omnis ut sapiente!
+        Repellendus, autem delectus.
+      </p>
+      <forge-ripple></forge-ripple>
+    </forge-card>
+    <forge-focus-indicator style="--forge-focus-indicator-inward-offset: 1px; --forge-focus-indicator-shape: 4px;"></forge-focus-indicator>
+  </div>
+
+  <!-- Inward example -->
+  <div>
+    <div class="example-target inward-example" tabindex="0" role="button">
+      <span class="forge-typography--body1">Inward example</span>
+      <forge-focus-indicator allow-focus inward></forge-focus-indicator>
+    </div>
+  </div>
+</div>
+
+<script type="module" src="focus-indicator.ts"></script>

--- a/src/dev/pages/focus-indicator/focus-indicator.html
+++ b/src/dev/pages/focus-indicator/focus-indicator.html
@@ -1,0 +1,8 @@
+<%-
+include('./src/partials/page.ejs', {
+  page: {
+    title: 'Focus indicator',
+    includePath: './pages/focus-indicator/focus-indicator.ejs'
+  }
+})
+%>

--- a/src/dev/pages/focus-indicator/focus-indicator.scss
+++ b/src/dev/pages/focus-indicator/focus-indicator.scss
@@ -1,0 +1,38 @@
+.example-target {
+  position: relative;
+  outline: none;
+
+  &:not(button) {
+    cursor: pointer;
+  }
+}
+
+.icon {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.inward-example {
+  width: 200px;
+  height: 100px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  border: 1px solid var(--forge-theme-border-color);
+
+  --forge-focus-indicator-shape: 10px;
+  --forge-focus-indicator-inward-offset: 4px;
+}
+
+.custom-target {
+  --forge-focus-indicator-color: red;
+  --forge-focus-indicator-active-width: 14px;
+  --forge-focus-indicator-width: 6px;
+  --forge-focus-indicator-duration: 2s;
+  --forge-focus-indicator-outward-offset: 0px; /* stylelint-disable-line */
+  --forge-focus-indicator-easing: ease-in;
+  --forge-focus-indicator-shape-start-start: 0;
+  --forge-focus-indicator-shape-end-end: 0;
+}

--- a/src/dev/pages/focus-indicator/focus-indicator.ts
+++ b/src/dev/pages/focus-indicator/focus-indicator.ts
@@ -1,0 +1,3 @@
+import '$src/shared';
+import '@tylertech/forge/focus-indicator';
+import './focus-indicator.scss';

--- a/src/dev/src/components.json
+++ b/src/dev/src/components.json
@@ -24,6 +24,7 @@
   { "label": "Expansion panel", "path": "/pages/expansion-panel/expansion-panel.html" },
   { "label": "File picker", "path": "/pages/file-picker/file-picker.html", "tags": ["form"] },
   { "label": "Floating action button", "path": "/pages/fab/fab.html" },
+  { "label": "Focus indicator", "path": "/pages/focus-indicator/focus-indicator.html" },
   { "label": "Icon", "path": "/pages/icon/icon.html" },
   { "label": "Icon button", "path": "/pages/icon-button/icon-button.html" },
   { "label": "Inline message", "path": "/pages/inline-message/inline-message.html" },

--- a/src/lib/focus-indicator/_mixins.scss
+++ b/src/lib/focus-indicator/_mixins.scss
@@ -1,0 +1,142 @@
+@use 'sass:list';
+@use '../theme/theme-values';
+@use './variables';
+
+@mixin provide-theme($theme) {
+  @each $key, $value in $theme {
+    @if list.index(variables.$supported-theme-properties, $key) == null {
+      @error 'Invalid theme property: #{$key}';
+    }
+    @if $value {
+      --forge-focus-indicator-#{$key}: #{$value};
+    }
+  }
+}
+
+@mixin configuration {
+  --_active-width: var(--forge-focus-indicator-active-width, 6px);
+  --_color: var(--forge-focus-indicator-color, var(--mdc-theme-primary, #{theme-values.$primary}));
+  --_duration: var(--forge-focus-indicator-duration, 600ms);
+  --_outward-offset: var(--forge-focus-indicator-outward-offset, 4px);
+  --_inward-offset: var(--forge-focus-indicator-inward-offset, 0px); // stylelint-disable-line length-zero-no-unit
+  --_shape: var(--forge-focus-indicator-shape, 1px);
+  --_width: var(--forge-focus-indicator-width, 3px);
+  --_easing: var(--forge-focus-indicator-easing, cubic-bezier(0.2, 0, 0, 1));
+  --_shape-start-start: var(--forge-focus-indicator-shape-start-start, var(--_shape));
+  --_shape-start-end: var(--forge-focus-indicator-shape-start-end, var(--_shape));
+  --_shape-end-start: var(--forge-focus-indicator-shape-end-start, var(--_shape));
+  --_shape-end-end: var(--forge-focus-indicator-shape-end-end, var(--_shape));
+  --_margin-block: var(--forge-focus-indicator-offset-block, 0);
+  --_margin-inline: var(--forge-focus-indicator-offset-inline, 0);
+}
+
+@mixin core-styles {
+  .forge-focus-indicator {
+    @include configuration;
+    @include base;
+  }
+
+  @include reduced-motion-styles;
+  @include keyframes;
+}
+
+@mixin outward-styles {
+  .forge-focus-indicator {
+    @include outward;
+  }
+}
+
+@mixin inward-styles {
+  .forge-focus-indicator {
+    @include inward;
+  }
+}
+
+@mixin active-styles {
+  .forge-focus-indicator {
+    @include active;
+  }
+}
+
+@mixin circular-styles {
+  .forge-focus-indicator {
+    --_shape: 50%;
+  }
+}
+
+@mixin reduced-motion-styles {
+  @media (prefers-reduced-motion) {
+    .forge-focus-indicator {
+      animation: none;
+    }
+  }
+}
+
+@mixin base {
+  animation-delay: 0s, calc(var(--_duration) * 0.25);
+  animation-duration: calc(var(--_duration) * 0.25), calc(var(--_duration) * 0.75);
+  animation-timing-function: var(--_easing);
+  box-sizing: border-box;
+  color: var(--_color);
+  display: none;
+  pointer-events: none;
+  position: absolute;
+  margin-block: var(--_margin-block);
+  margin-inline: var(--_margin-inline);
+}
+
+@mixin active {
+  display: flex;
+}
+
+@mixin outward {
+  animation-name: outward-grow, outward-shrink;
+  border-end-end-radius: calc(var(--_shape-end-end) + var(--_outward-offset));
+  border-end-start-radius: calc(var(--_shape-end-start) + var(--_outward-offset));
+  border-start-end-radius: calc(var(--_shape-start-end) + var(--_outward-offset));
+  border-start-start-radius: calc(var(--_shape-start-start) + var(--_outward-offset));
+  inset: calc(-1 * var(--_outward-offset));
+  outline: var(--_width) solid currentColor;
+}
+
+@mixin inward {
+  animation-name: inward-grow, inward-shrink;
+  border-end-end-radius: calc(var(--_shape-end-end) - var(--_inward-offset));
+  border-end-start-radius: calc(var(--_shape-end-start) - var(--_inward-offset));
+  border-start-end-radius: calc(var(--_shape-start-end) - var(--_inward-offset));
+  border-start-start-radius: calc(var(--_shape-start-start) - var(--_inward-offset));
+  border: var(--_width) solid currentColor;
+  inset: var(--_inward-offset);
+}
+
+@mixin keyframes {
+  @keyframes outward-grow {
+    from {
+      outline-width: 0;
+    }
+    to {
+      outline-width: var(--_active-width);
+    }
+  }
+
+  @keyframes outward-shrink {
+    from {
+      outline-width: var(--_active-width);
+    }
+  }
+
+  @keyframes inward-grow {
+    from {
+      border-width: 0;
+    }
+    to {
+      border-width: var(--_active-width);
+    }
+  }
+
+  @keyframes inward-shrink {
+    from {
+      border-width: var(--_active-width);
+    }
+  }
+}

--- a/src/lib/focus-indicator/_variables.scss
+++ b/src/lib/focus-indicator/_variables.scss
@@ -1,0 +1,15 @@
+$supported-theme-properties: (
+  'active-width',
+  'color',
+  'duration',
+  'outward-offset',
+  'inward-offset',
+  'shape',
+  'width',
+  'shape-start-start',
+  'shape-start-end',
+  'shape-end-end',
+  'shape-end-start',
+  'offset-block',
+  'offset-inline'
+);

--- a/src/lib/focus-indicator/build.json
+++ b/src/lib/focus-indicator/build.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../../node_modules/@tylertech/forge-cli/build-schema.json",
+  "extends": "../build.json"
+}

--- a/src/lib/focus-indicator/focus-indicator-adapter.ts
+++ b/src/lib/focus-indicator/focus-indicator-adapter.ts
@@ -1,0 +1,76 @@
+import { BaseAdapter, IBaseAdapter } from '../core';
+import { IFocusIndicatorComponent } from './focus-indicator';
+
+export interface IFocusIndicatorAdapter extends IBaseAdapter {
+  destroy(): void;
+  hasTargetElement(): boolean;
+  addTargetListener(type: string, listener: EventListener): void;
+  removeTargetListener(type: string, listener: EventListener): void;
+  getTargetElement(): HTMLElement | null;
+  setTargetElement(el: HTMLElement | null): void;
+  trySetTarget(value: string | null): void;
+  isActive(selector: string): boolean;
+}
+
+export class FocusIndicatorAdapter extends BaseAdapter<IFocusIndicatorComponent> implements IFocusIndicatorAdapter {
+  private _targetElement: HTMLElement | null = null;
+
+  constructor(component: IFocusIndicatorComponent) {
+    super(component);
+  }
+
+  public destroy(): void {
+    this._targetElement = null;
+  }
+  
+  public hasTargetElement(): boolean {
+    return !!this._targetElement;
+  }
+
+  public addTargetListener(type: string, listener: EventListener): void {
+    this._targetElement?.addEventListener(type, listener);
+  }
+
+  public removeTargetListener(type: string, listener: EventListener): void {
+    this._targetElement?.removeEventListener(type, listener);
+  }
+
+  public getTargetElement(): HTMLElement | null {
+    return this._targetElement;
+  }
+
+  public setTargetElement(el: HTMLElement | null): void {
+    this._targetElement = el;
+  }
+
+  /**
+   * We use the following heuristic for locating the target element:
+   *  - If the `target` attribute is set, we use that value to query the DOM for the target element
+   *  - If the `target` attribute is set to `:host`, we use the host element from within a shadow tree (only if the root node is a ShadowRoot instance)
+   *  - If the `target` attribute is set but the querySelector returns null, we use the parent element as the target element
+   *  - If the `target` attribute is not set, we use the parent element as the target element
+   * @param value {string | null} - A selector string to query the DOM for the target element
+   */
+  public trySetTarget(value: string | null): void {
+    if (value) {
+      const rootNode = this._component.getRootNode() as Document | ShadowRoot;
+
+      // Special case handling for a `:host` selector to easily target a host element
+      // from within a shadow tree, given that this is a very common scenario
+      if (value === ':host' && rootNode instanceof ShadowRoot) {
+        this._targetElement = rootNode.host as HTMLElement;
+        return;
+      }
+
+      this._targetElement = rootNode.querySelector(`#${value}`);
+    }
+
+    if (!this._targetElement) {
+      this.setTargetElement(this._component.parentElement);
+    }
+  }
+
+  public isActive(selector: string): boolean {
+    return !!this._targetElement?.matches(selector);
+  }
+}

--- a/src/lib/focus-indicator/focus-indicator-constants.ts
+++ b/src/lib/focus-indicator/focus-indicator-constants.ts
@@ -1,0 +1,20 @@
+import { COMPONENT_NAME_PREFIX } from '../constants';
+
+const elementName: keyof HTMLElementTagNameMap = `${COMPONENT_NAME_PREFIX}focus-indicator`;
+
+const observedAttributes = {
+  TARGET: 'target',
+  ACTIVE: 'active',
+  INWARD: 'inward',
+  CIRCULAR: 'circular',
+  ALLOW_FOCUS: 'allow-focus'
+};
+
+const attributes = {
+  ...observedAttributes
+};
+
+export const FOCUS_INDICATOR_CONSTANTS = {
+  elementName,
+  attributes
+};

--- a/src/lib/focus-indicator/focus-indicator-foundation.ts
+++ b/src/lib/focus-indicator/focus-indicator-foundation.ts
@@ -1,0 +1,130 @@
+import { IFocusIndicatorAdapter } from './focus-indicator-adapter';
+import { FOCUS_INDICATOR_CONSTANTS } from './focus-indicator-constants';
+
+export interface IFocusIndicatorFoundation {
+  targetElement: HTMLElement | null;
+  target: string | null;
+  active: boolean;
+  inward: boolean;
+  circular: boolean;
+  allowFocus: boolean;
+  initialize(): void;
+  destroy(): void;
+}
+
+export class FocusIndicatorFoundation implements IFocusIndicatorFoundation {
+  private _target: string | null = null;
+  private _active = false;
+  private _inward = false;
+  private _circular = false;
+  private _allowFocus = false;
+  private _interactionListener: EventListener;
+
+  constructor(private _adapter: IFocusIndicatorAdapter) {
+    this._interactionListener = evt => this._onInteraction(evt);
+  }
+
+  public initialize(): void {
+    if (!this._adapter.hasTargetElement()) {
+      this._adapter.trySetTarget(this._target);
+    }
+    this._addListeners();
+  }
+
+  public destroy(): void {
+    this._adapter.destroy();
+    this._removeListeners();
+  }
+
+  private _addListeners(): void {
+    this._adapter.addTargetListener('focusin', this._interactionListener);
+    this._adapter.addTargetListener('focusout', this._interactionListener);
+    this._adapter.addTargetListener('pointerdown', this._interactionListener);
+  }
+
+  private _removeListeners(): void {
+    this._adapter.removeTargetListener('focusin', this._interactionListener);
+    this._adapter.removeTargetListener('focusout', this._interactionListener);
+    this._adapter.removeTargetListener('pointerdown', this._interactionListener);
+  }
+
+  private _onInteraction(evt: Event): void {
+    switch (evt.type) {
+      case 'focusin':
+        this.active = this._adapter.isActive(this._allowFocus ? ':focus' : ':focus-visible');
+        break;
+      case 'focusout':
+        this.active = false;
+        break;
+      case 'pointerdown':
+        this.active = this._allowFocus ? this._adapter.isActive(':focus') : false;
+        break;
+    }
+  }
+
+  public get targetElement(): HTMLElement | null {
+    return this._adapter.getTargetElement();
+  }
+  public set targetElement(value: HTMLElement | null) {
+    this._removeListeners();
+    this._adapter.setTargetElement(value);
+    this._addListeners();
+  }
+
+  public get target(): string | null {
+    return this._adapter.getHostAttribute(FOCUS_INDICATOR_CONSTANTS.attributes.TARGET);
+  }
+  public set target(value: string | null) {
+    if (this._target !== value) {
+      this._target = value;
+      if (this._adapter.isConnected) {
+        this._adapter.trySetTarget(value);
+      }
+      this._adapter.toggleHostAttribute(FOCUS_INDICATOR_CONSTANTS.attributes.TARGET, Boolean(this._target), this._target as string);
+    }
+  }
+
+  public get active(): boolean {
+    return this._active;
+  }
+  public set active(value: boolean) {
+    value = Boolean(value);
+    if (this._active !== value) {
+      this._active = value;
+      this._adapter.toggleHostAttribute(FOCUS_INDICATOR_CONSTANTS.attributes.ACTIVE, this._active);
+    }
+  }
+
+  public get inward(): boolean {
+    return this._inward;
+  }
+  public set inward(value: boolean) {
+    value = Boolean(value);
+    if (this._inward !== value) {
+      this._inward = value;
+      this._adapter.toggleHostAttribute(FOCUS_INDICATOR_CONSTANTS.attributes.INWARD, this._inward);
+    }
+  }
+
+  public get circular(): boolean {
+    return this._circular;
+  }
+  public set circular(value: boolean) {
+    value = Boolean(value);
+    if (this._circular !== value) {
+      this._circular = value;
+      this._adapter.toggleHostAttribute(FOCUS_INDICATOR_CONSTANTS.attributes.CIRCULAR, this._circular);
+    }
+  }
+
+  public get allowFocus(): boolean {
+    return this._allowFocus;
+  }
+  public set allowFocus(value: boolean) {
+    value = Boolean(value);
+    if (this._allowFocus !== value) {
+      this._allowFocus = value;
+      this._adapter.toggleHostAttribute(FOCUS_INDICATOR_CONSTANTS.attributes.ALLOW_FOCUS, this._allowFocus);
+    }
+  }
+}

--- a/src/lib/focus-indicator/focus-indicator.html
+++ b/src/lib/focus-indicator/focus-indicator.html
@@ -1,0 +1,3 @@
+<template>
+  <div class="forge-focus-indicator" part="indicator"></div>
+</template>

--- a/src/lib/focus-indicator/focus-indicator.scss
+++ b/src/lib/focus-indicator/focus-indicator.scss
@@ -1,0 +1,27 @@
+@use './mixins';
+
+@include mixins.core-styles;
+
+:host {
+  display: contents;
+}
+
+:host([hidden]) {
+  display: none;
+}
+
+:host([active]) {
+  @include mixins.active-styles;
+}
+
+:host(:not([inward])) {
+  @include mixins.outward-styles;
+}
+
+:host([inward]) {
+  @include mixins.inward-styles;
+}
+
+:host([circular]) {
+  @include mixins.circular-styles;
+}

--- a/src/lib/focus-indicator/focus-indicator.test.ts
+++ b/src/lib/focus-indicator/focus-indicator.test.ts
@@ -1,0 +1,200 @@
+import { expect } from '@esm-bundle/chai';
+import { fixture, html } from '@open-wc/testing';
+import { getShadowElement, tryDefine } from '@tylertech/forge-core';
+import { sendKeys, sendMouse } from '@web/test-runner-commands';
+import type { IFocusIndicatorComponent } from './focus-indicator';
+
+import './focus-indicator';
+
+describe('FocusIndicator', () => {
+  it('should contain shadow root', async () => {
+    const { focusIndicator } = await createFixture();
+    expect(focusIndicator.shadowRoot).not.to.be.null;
+  });
+
+  it('should be active on keyboard focus', async () => {
+    const { detachedButton, button, focusIndicator } = await createFixture();
+
+    expect(button.matches(':focus')).to.be.false;
+
+    await focusKeyboard(detachedButton);
+
+    expect(button.matches(':focus-visible')).to.be.true;
+    expect(focusIndicator.active).to.be.true;
+  });
+
+  it('should not be active on pointer focus', async () => {
+    const { button, focusIndicator } = await createFixture();
+
+    expect(button.matches(':focus')).to.be.false;
+
+    await focusPointer(button);
+
+    expect(button.matches(':focus-visible')).to.be.false;
+    expect(button.matches(':focus')).to.be.true;
+    expect(focusIndicator.active).to.be.false;
+  });
+
+  it('should be active on pointer focus when allowFocus is true', async () => {
+    const { button, focusIndicator } = await createFixture({ allowFocus: true });
+
+    expect(button.matches(':focus')).to.be.false;
+
+    await focusPointer(button);
+
+    expect(button.matches(':focus-visible')).to.be.false;
+    expect(button.matches(':focus')).to.be.true;
+    expect(focusIndicator.active).to.be.true;
+  });
+
+  it('should attach to specific target via id', async () => {
+    const { button, detachedButton, focusIndicator } = await createFixture({ target: 'detached' });
+    
+    expect(focusIndicator.targetElement).to.equal(detachedButton);
+
+    button.focus();
+    await sendKeys({ down: 'Shift' });
+    await sendKeys({ press: 'Tab' });
+    await sendKeys({ up: 'Shift' });
+
+    expect(detachedButton.matches(':focus-visible')).to.be.true;
+    expect(focusIndicator.active).to.be.true;
+  });
+
+  it('should set target element manually', async () => {
+    const { button, detachedButton, focusIndicator } = await createFixture();
+    
+    expect(focusIndicator.targetElement).to.equal(button);
+
+    focusIndicator.targetElement = detachedButton;
+
+    expect(focusIndicator.targetElement).to.equal(detachedButton);
+
+    button.focus();
+    await sendKeys({ down: 'Shift' });
+    await sendKeys({ press: 'Tab' });
+    await sendKeys({ up: 'Shift' });
+
+    expect(detachedButton.matches(':focus-visible')).to.be.true;
+    expect(focusIndicator.active).to.be.true;
+  });
+
+  it('should set inward', async () => {
+    const { focusIndicator } = await createFixture({ inward: true });
+    expect(focusIndicator.inward).to.be.true;
+  });
+
+  it('should animate inward when active', async () => {
+    const { button, detachedButton, focusIndicator } = await createFixture({ inward: true });
+
+    await focusKeyboard(detachedButton);
+
+    const surface = getShadowElement(focusIndicator, 'div[part=indicator]') as HTMLElement;
+    const style = getComputedStyle(surface);
+
+    expect(style.animationName).to.equal('inward-grow, inward-shrink');
+    expect(button.matches(':focus-visible')).to.be.true;
+    expect(focusIndicator.active).to.be.true;
+  });
+
+  it('should set circular', async () => {
+    const { focusIndicator } = await createFixture({ circular: true });
+
+    const surface = getShadowElement(focusIndicator, 'div[part=indicator]') as HTMLElement;
+    const style = getComputedStyle(surface);
+
+    expect(style.getPropertyValue('--_shape')).to.equal('50%');
+    expect(focusIndicator.circular).to.be.true;
+  });
+
+  it('should reattach listeners when moved in DOM', async () => {
+    const { button, detachedButton, focusIndicator } = await createFixture();
+
+    expect(focusIndicator.targetElement).to.equal(button);
+
+    detachedButton.appendChild(focusIndicator);
+
+    expect(focusIndicator.targetElement).to.equal(detachedButton);
+
+    button.focus();
+    await sendKeys({ down: 'Shift' });
+    await sendKeys({ press: 'Tab' });
+    await sendKeys({ up: 'Shift' });
+
+    expect(button.matches(':focus')).to.be.false;
+    expect(detachedButton.matches(':focus-visible')).to.be.true;
+    expect(focusIndicator.active).to.be.true;
+  });
+
+  it('should release reference to target element when disconnected', async () => {
+    const { button, focusIndicator } = await createFixture();
+
+    expect(focusIndicator.targetElement).to.equal(button);
+
+    button.remove();
+
+    expect(focusIndicator.targetElement).to.be.null;
+  });
+
+  it('should locate target element when target is :host', async () => {
+    class TestFocusIndicator extends HTMLElement {
+      constructor() {
+        super();
+        this.attachShadow({ mode: 'open'});
+        this.shadowRoot!.innerHTML = '<forge-focus-indicator target=":host"></forge-focus-indicator>';
+      }
+    }
+    window.customElements.define('test-focus-indicator-host', TestFocusIndicator);
+
+    const el = await fixture<TestFocusIndicator>(html`<test-focus-indicator-host></test-focus-indicator-host>`);
+    const focusIndicator = getShadowElement(el, 'forge-focus-indicator') as IFocusIndicatorComponent;
+
+    expect(focusIndicator.targetElement).to.equal(el);
+  });
+});
+
+interface FocusIndicatorFixtureConfig {
+  target?: string;
+  inward?: boolean;
+  circular?: boolean;
+  allowFocus?: boolean;
+}
+
+interface FocusIndicatorFixtureResult {
+  detachedButton: HTMLButtonElement;
+  button: HTMLButtonElement;
+  focusIndicator: IFocusIndicatorComponent
+}
+
+async function createFixture({ target, inward, circular, allowFocus }: FocusIndicatorFixtureConfig = {}): Promise<FocusIndicatorFixtureResult> {
+  const result = await fixture<HTMLElement>(html`
+    <div>
+      <button id="detached" type="button">Simple button</button>
+      <button id="attached" type="button">
+        Button
+        <forge-focus-indicator
+          target=${target}
+          ?inward=${inward}
+          ?circular=${circular}
+          ?allow-focus=${allowFocus}>
+        </forge-focus-indicator>
+      </button>
+    </div>
+  `);
+  const detachedButton = result.querySelector('button#detached') as HTMLButtonElement;
+  const button = result.querySelector('button#attached') as HTMLButtonElement;
+  const focusIndicator = result.querySelector('forge-focus-indicator') as IFocusIndicatorComponent;
+  return { detachedButton, button, focusIndicator };
+}
+
+async function focusKeyboard(startFocusEl: HTMLElement): Promise<void> {
+  startFocusEl.focus();
+  await sendKeys({ press: 'Tab' });
+}
+
+async function focusPointer(targetEl: HTMLElement): Promise<void> {
+  const { x, y, height, width } = targetEl.getBoundingClientRect();
+  const mouseX = Math.round(x + width / 2);
+  const mouseY = Math.round(y + height / 2);
+  await sendMouse({ type: 'click', position: [mouseX, mouseY], button: 'left' });
+}

--- a/src/lib/focus-indicator/focus-indicator.ts
+++ b/src/lib/focus-indicator/focus-indicator.ts
@@ -1,0 +1,126 @@
+import { attachShadowTemplate, coerceBoolean, CustomElement, FoundationProperty } from '@tylertech/forge-core';
+import { BaseComponent, IBaseComponent } from '../core/base/base-component';
+import { FocusIndicatorAdapter } from './focus-indicator-adapter';
+import { FOCUS_INDICATOR_CONSTANTS } from './focus-indicator-constants';
+import { FocusIndicatorFoundation } from './focus-indicator-foundation';
+
+import template from './focus-indicator.html';
+import styles from './focus-indicator.scss';
+
+export interface IFocusIndicatorComponent extends IBaseComponent {
+  targetElement: HTMLElement;
+  target: string | null;
+  active: boolean;
+  inward: boolean;
+  circular: boolean;
+  allowFocus: boolean;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'forge-focus-indicator': IFocusIndicatorComponent;
+  }
+}
+
+/**
+ * @tag forge-focus-indicator
+ * 
+ * @summary Renders a focus indicator when an attached element matches `:focus-visible`.
+ * 
+ * @property {HTMLElement} targetElement - The element to attach the focus indicator to.
+ * @property {string} target - The id of the element to attach the focus indicator to.
+ * @property {boolean} active - Controls whether the indicator is active.
+ * @property {boolean} inward - Controls whether the indicator renders inward.
+ * @property {boolean} circular - Controls whether the indicator renders circular.
+ * @property {boolean} allowFocus - Controls whether the indicator renders when the target element matches `:focus` instead of `:focus-visible`.
+ * 
+ * @attribute {string} target - The id of the element to attach the focus indicator to.
+ * @attribute {boolean} active - Controls whether the indicator is active.
+ * @attribute {boolean} inward - Controls whether the indicator renders inward.
+ * @attribute {boolean} circular - Controls whether the indicator renders circular.
+ * @attribute {boolean} allow-focus - Controls whether the indicator renders when the target element matches `:focus` instead of `:focus-visible`.
+ * 
+ * @cssproperty --forge-focus-indicator-active-width - The width of the focus indicator when active. When animating this is the max extent.
+ * @cssproperty --forge-focus-indicator-color - The color of the focus indicator.
+ * @cssproperty --forge-focus-indicator-duration - The animation duration.
+ * @cssproperty --forge-focus-indicator-outward-offset - The offset of the focus indicator when outward.
+ * @cssproperty --forge-focus-indicator-inward-offset - The offset of the focus indicator when inward.
+ * @cssproperty --forge-focus-indicator-shape - The shape of the focus indicator.
+ * @cssproperty --forge-focus-indicator-width - The width of the focus indicator when resting.
+ * @cssproperty --forge-focus-indicator-shape-start-start - The start start shape.
+ * @cssproperty --forge-focus-indicator-shape-start-end - The start end shape.
+ * @cssproperty --forge-focus-indicator-shape-end-start - The end start shape.
+ * @cssproperty --forge-focus-indicator-shape-end-end - The end end shape.
+ * @cssproperty --forge-focus-indicator-offset-block - The block offset.
+ * @cssproperty --forge-focus-indicator-offset-inline - The inline offset.
+ * 
+ * @csspart indicator - The focus indicator element.
+ */
+@CustomElement({
+  name: FOCUS_INDICATOR_CONSTANTS.elementName
+})
+export class FocusIndicatorComponent extends BaseComponent implements IFocusIndicatorComponent {
+  public static get observedAttributes(): string[] {
+    return [
+      FOCUS_INDICATOR_CONSTANTS.attributes.TARGET,
+      FOCUS_INDICATOR_CONSTANTS.attributes.ACTIVE,
+      FOCUS_INDICATOR_CONSTANTS.attributes.INWARD,
+      FOCUS_INDICATOR_CONSTANTS.attributes.CIRCULAR,
+      FOCUS_INDICATOR_CONSTANTS.attributes.ALLOW_FOCUS
+    ];
+  }
+
+  private _foundation: FocusIndicatorFoundation;
+
+  constructor() {
+    super();
+    attachShadowTemplate(this, template, styles);
+    this._foundation = new FocusIndicatorFoundation(new FocusIndicatorAdapter(this));
+  }
+
+  public connectedCallback(): void {
+    this._foundation.initialize();
+  }
+
+  public disconnectedCallback(): void {
+    this._foundation.destroy();
+  }
+
+  public attributeChangedCallback(name: string, oldValue: string, newValue: string): void {
+    switch (name) {
+      case FOCUS_INDICATOR_CONSTANTS.attributes.TARGET:
+        this.target = newValue;
+        break;
+      case FOCUS_INDICATOR_CONSTANTS.attributes.ACTIVE:
+        this.active = coerceBoolean(newValue);
+        break;
+      case FOCUS_INDICATOR_CONSTANTS.attributes.INWARD:
+        this.inward = coerceBoolean(newValue);
+        break;
+      case FOCUS_INDICATOR_CONSTANTS.attributes.CIRCULAR:
+        this.circular = coerceBoolean(newValue);
+        break;
+      case FOCUS_INDICATOR_CONSTANTS.attributes.ALLOW_FOCUS:
+        this.allowFocus = coerceBoolean(newValue);
+        break;
+    }
+  }
+
+  @FoundationProperty()
+  public declare targetElement: HTMLElement;
+
+  @FoundationProperty()
+  public declare target: string | null;
+
+  @FoundationProperty()
+  public declare active: boolean;
+
+  @FoundationProperty()
+  public declare inward: boolean;
+
+  @FoundationProperty()
+  public declare circular: boolean;
+
+  @FoundationProperty()
+  public declare allowFocus: boolean;
+}

--- a/src/lib/focus-indicator/index.ts
+++ b/src/lib/focus-indicator/index.ts
@@ -1,0 +1,11 @@
+import { defineCustomElement } from '@tylertech/forge-core';
+import { FocusIndicatorComponent } from './focus-indicator';
+
+export * from './focus-indicator-adapter';
+export * from './focus-indicator-constants';
+export * from './focus-indicator-foundation';
+export * from './focus-indicator';
+
+export function defineFocusIndicatorComponent(): void {
+  defineCustomElement(FocusIndicatorComponent);
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -32,6 +32,7 @@ import { DrawerComponent, MiniDrawerComponent, ModalDrawerComponent } from './dr
 import { ExpansionPanelComponent } from './expansion-panel';
 import { FilePickerComponent } from './file-picker';
 import { FloatingActionButton } from './floating-action-button';
+import { FocusIndicatorComponent } from './focus-indicator';
 import { IconButtonComponent } from './icon-button';
 import { InlineMessageComponent } from './inline-message';
 import { KeyboardShortcutComponent } from './keyboard-shortcut';
@@ -105,6 +106,7 @@ export * from './expansion-panel';
 export * from './file-picker';
 export * from './floating-action-button';
 export * from './floating-label';
+export * from './focus-indicator';
 export * from './icon-button';
 export * from './inline-message';
 export * from './keyboard-shortcut';
@@ -169,6 +171,7 @@ const CUSTOM_ELEMENTS = [
   ExpansionPanelComponent,
   FilePickerComponent,
   FloatingActionButton,
+  FocusIndicatorComponent,
   ProductIconComponent,
   IconComponent,
   IconButtonComponent,

--- a/src/lib/slider/_mixins.scss
+++ b/src/lib/slider/_mixins.scss
@@ -1,5 +1,6 @@
 @use 'sass:list';
 @use '../core/style-layer/slider';
+@use '../focus-indicator/mixins' as focus-indicator;
 @use './variables';
 
 @mixin provide-theme($theme) {
@@ -19,4 +20,12 @@
 
 @mixin core-styles {
   @include slider.styles;
+
+  forge-focus-indicator {
+    /* stylelint-disable length-zero-no-unit */
+    @include focus-indicator.provide-theme((
+      shape: 50%,
+      outward-offset: 0px
+    ));
+  }
 }

--- a/src/lib/slider/slider-utils.ts
+++ b/src/lib/slider/slider-utils.ts
@@ -24,6 +24,10 @@ export function createStartHandleElement(thumbLabel: string): HTMLElement {
   const startHandle = document.createElement('div');
   startHandle.classList.add(SLIDER_CONSTANTS.classes.HANDLE, SLIDER_CONSTANTS.classes.HANDLE_START);
   startHandle.setAttribute('part', 'handle-start');
+
+  const startHandleFocusIndicator = document.createElement('forge-focus-indicator');
+  startHandleFocusIndicator.target = 'start';
+  startHandle.appendChild(startHandleFocusIndicator);
   
   const startHandleThumb = document.createElement('div');
   startHandleThumb.classList.add(SLIDER_CONSTANTS.classes.HANDLE_THUMB);

--- a/src/lib/slider/slider.html
+++ b/src/lib/slider/slider.html
@@ -6,6 +6,7 @@
       <div class="handle-container-block">
         <div class="handle-container">
           <div class="handle end" part="handle-end">
+            <forge-focus-indicator target="end"></forge-focus-indicator>
             <div class="handle-thumb" part="handle-end-thumb"></div>
             <span class="handle-ripple"></span>
             <div class="handle-label" part="handle-end-label">

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -1,5 +1,6 @@
 import { attachShadowTemplate, coerceBoolean, coerceNumber, CustomElement, FoundationProperty, toggleAttribute } from '@tylertech/forge-core';
 import { BaseComponent, IBaseComponent } from '../core/base/base-component';
+import { FocusIndicatorComponent } from '../focus-indicator/focus-indicator';
 import { SliderAdapter } from './slider-adapter';
 import { SLIDER_CONSTANTS, SliderLabelBuilder, ISliderRangeEventData } from './slider-constants';
 import { SliderFoundation } from './slider-foundation';
@@ -132,10 +133,12 @@ declare global {
  * @csspart handle-start-thumb - Styles the start handle thumb element.
  * @csspart handle-start-label - Styles the start handle label element.
  * @csspart handle-start-label-content - Styles the start handle label content element.
- * 
  */
 @CustomElement({
-  name: SLIDER_CONSTANTS.elementName
+  name: SLIDER_CONSTANTS.elementName,
+  dependencies: [
+    FocusIndicatorComponent
+  ]
 })
 export class SliderComponent extends BaseComponent implements ISliderComponent {
   public static get observedAttributes(): string[] {

--- a/src/lib/tabs/tab/_mixins.scss
+++ b/src/lib/tabs/tab/_mixins.scss
@@ -1,4 +1,5 @@
 @use '../../core/style-layer/tabs/tab';
+@use '../../focus-indicator/mixins' as focus-indicator;
 @use './variables';
 
 @mixin provide-theme($theme) {
@@ -14,6 +15,10 @@
 
 @mixin core-styles {
   @include tab.styles;
+
+  forge-focus-indicator {
+    @include focus-indicator.provide-theme(( shape: 8px ));
+  }
 }
 
 @mixin focus-styles {
@@ -39,6 +44,12 @@
 @mixin selected-styles {
   @include tab.selected-styles;
   @include tab.forced-colors-styles;
+
+  forge-focus-indicator {
+    @include focus-indicator.provide-theme((
+      'offset-block': 0 calc(var(--_active-indicator-height) + 1px)
+    ));
+  }
 }
 
 @mixin stacked-styles {

--- a/src/lib/tabs/tab/tab-adapter.ts
+++ b/src/lib/tabs/tab/tab-adapter.ts
@@ -1,10 +1,10 @@
 import { getShadowElement, requireParent, toggleAttribute } from '@tylertech/forge-core';
 import { BaseAdapter, IBaseAdapter } from '../../core/base/base-adapter';
-import { ITabComponent } from './tab';
-import { TAB_CONSTANTS } from './tab-constants';
-import { TabRipple } from './tab-ripple';
 import { userInteractionListener } from '../../core/utils';
 import { TAB_BAR_CONSTANTS } from '../tab-bar/tab-bar-constants';
+import type { ITabComponent } from './tab';
+import { TAB_CONSTANTS } from './tab-constants';
+import { TabRipple } from './tab-ripple';
 
 export interface ITabAdapter extends IBaseAdapter {
   initialize(): void;
@@ -28,9 +28,9 @@ export class TabAdapter extends BaseAdapter<ITabComponent> implements ITabAdapte
 
   public initialize(): void {
     this._deferRippleInitialization();
-    this._component.tabIndex = -1;
+    this._component.tabIndex = this._component.selected ? 0 : -1;
     this._component.setAttribute('role', 'tab');
-    this._component.setAttribute('aria-selected', 'false');
+    this._component.setAttribute('aria-selected', this._component.selected ? 'true' : 'false');
   }
 
   public destroy(): void {

--- a/src/lib/tabs/tab/tab-constants.ts
+++ b/src/lib/tabs/tab/tab-constants.ts
@@ -13,8 +13,7 @@ const attributes = {
 
 const selectors = {
   RIPPLE: '.ripple-surface',
-  INDICATOR: '.indicator',
-  FOCUS_INDICATOR: '.focus-indicator'
+  INDICATOR: '.indicator'
 };
 
 const classes = {

--- a/src/lib/tabs/tab/tab-constants.ts
+++ b/src/lib/tabs/tab/tab-constants.ts
@@ -13,7 +13,8 @@ const attributes = {
 
 const selectors = {
   RIPPLE: '.ripple-surface',
-  INDICATOR: '.indicator'
+  INDICATOR: '.indicator',
+  FOCUS_INDICATOR: '.focus-indicator'
 };
 
 const classes = {

--- a/src/lib/tabs/tab/tab.html
+++ b/src/lib/tabs/tab/tab.html
@@ -9,5 +9,6 @@
       <span class="indicator" part="indicator"></span>
     </span>
     <span class="ripple-surface"></span>
+    <forge-focus-indicator target=":host" inward></forge-focus-indicator>
   </div>
 </template>

--- a/src/lib/tabs/tab/tab.ts
+++ b/src/lib/tabs/tab/tab.ts
@@ -4,6 +4,7 @@ import { TabAdapter } from './tab-adapter';
 import { TabFoundation } from './tab-foundation';
 import { TAB_CONSTANTS } from './tab-constants';
 import { BaseComponent, IBaseComponent } from '../../core/base/base-component';
+import { FocusIndicatorComponent } from '../../focus-indicator/focus-indicator';
 
 import template from './tab.html';
 import styles from './tab.scss';
@@ -76,7 +77,10 @@ declare global {
  * @csspart indicator - The tab active indicator.
  */
 @CustomElement({
-  name: TAB_CONSTANTS.elementName
+  name: TAB_CONSTANTS.elementName,
+  dependencies: [
+    FocusIndicatorComponent
+  ]
 })
 export class TabComponent extends BaseComponent implements ITabComponent {
   public static get observedAttributes(): string[] {

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -33,8 +33,8 @@ export default {
     report: true,
     reportDir: '.coverage',
     exclude: [
-      'src/lib/core/base/**',
-      'src/lib/**/index.ts',
+      'src/lib/*',
+      'src/lib/core/**',
       'src/lib/**/*.{html,scss,json}',
       '**/node_modules/**',
     ],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
With `:focus-visible` being well-supported in browsers now, we needed to provide a way to show keyboard focus only, instead of relying on the states styles from the ripple implementation.

Going forward the ripple will no longer be used on any components to convey focus. Elements will either provide their own focus states, or utilize the `<forge-focus-indicator>` to provide a "focus ring" to elements via `:focus-visible`. The ripple will be refactored in the near future to no longer provide a resting focused state, and instead provide just hover, active, and interaction animation styles. It is intended that the focus indicator and ripple will be used alongside each other where necessary.

One other note is that the `<forge-focus-indicator>` can be configured to utilize `:focus` instead of `:focus-visible` with the `allow-focus` attribute to allow for elements to display the indicator when they are focused regardless of how the element received focus.

## Additional information
This PR includes updates to the `<forge-slider>` and `<forge-tab>` elements to utilize the focus indicator.
