### PR TITLE
fix(date-picker): fixed a bug where the `locale` of the calendar could not be set through the date picker element

### DIFF
--- a/src/dev/pages/date-picker/date-picker.html
+++ b/src/dev/pages/date-picker/date-picker.html
@@ -6,6 +6,19 @@ include('./src/partials/page.ejs', {
     options: [
       {
         type: 'select',
+        label: 'Locale',
+        id: 'opt-locale',
+        defaultValue: 'EN',
+        options: [
+          { label: 'Arabic', value: 'AR' },
+          { label: 'Chinese', value: 'ZH' },
+          { label: 'English', value: 'EN' },
+          { label: 'French', value: 'FR' },
+          { label: 'Spanish', value: 'ES' },
+        ]
+      },
+      {
+        type: 'select',
         label: 'Value mode',
         id: 'opt-value-mode',
         defaultValue: 'object',

--- a/src/dev/pages/date-picker/date-picker.ts
+++ b/src/dev/pages/date-picker/date-picker.ts
@@ -26,6 +26,11 @@ datePickerInput.addEventListener('input', () => {
   datePickerInputValueElement.textContent = datePickerInput.value ?? '""';
 });
 
+const localeSelect = document.getElementById('opt-locale') as ISelectComponent;
+localeSelect.addEventListener('change', () => {
+  datePicker.locale = localeSelect.value;
+});
+
 const valueModeSelect = document.getElementById('opt-value-mode') as ISelectComponent;
 valueModeSelect.addEventListener('change', () => {
   datePicker.valueMode = valueModeSelect.value;

--- a/src/lib/calendar/calendar-dropdown/calendar-dropdown.ts
+++ b/src/lib/calendar/calendar-dropdown/calendar-dropdown.ts
@@ -12,6 +12,7 @@ export interface ICalendarDropdown {
   id: string;
   targetElement: HTMLElement;
   popupClasses: string | string[] | null;
+  locale: string | undefined;
   isOpen: boolean;
   activeChangeCallback: ((id: string) => void) | undefined;
   closeCallback: (() => void) | undefined;
@@ -41,6 +42,15 @@ export class CalendarDropdown implements ICalendarDropdown {
   }
   public set popupClasses(value: string | string[] | null) {
     this._popupClasses = !!value ? isArray(value) ? [...value as string[]] : [value as string] : [];
+  }
+
+  public get locale(): string | undefined {
+    return this.calendar?.locale;
+  }
+  public set locale(value: string | undefined) {
+    if (this.calendar) {
+      this.calendar.locale = value;
+    }
   }
   
   constructor(targetElement: HTMLElement, id: string) {

--- a/src/lib/date-picker/base/base-date-picker-adapter.ts
+++ b/src/lib/date-picker/base/base-date-picker-adapter.ts
@@ -53,6 +53,7 @@ export interface IBaseDatePickerAdapter extends IBaseAdapter {
   setCalendarActiveDate(date: Date): void;
   getCalendarActiveDate(): Date | undefined;
   setCalendarYearRange(value: string): void;
+  setCalendarLocale(locale: string | undefined): void;
   propagateCalendarKey(evt: KeyboardEvent): void;
 }
 export abstract class BaseDatePickerAdapter<T extends BaseComponent> extends BaseAdapter<T> implements IBaseDatePickerAdapter {
@@ -200,6 +201,12 @@ export abstract class BaseDatePickerAdapter<T extends BaseComponent> extends Bas
   public setCalendarYearRange(value: string): void {
     if (this._calendarDropdown?.calendar?.yearRange) {
       this._calendarDropdown.calendar.yearRange = value;
+    }
+  }
+
+  public setCalendarLocale(locale: string | undefined): void {
+    if (this._calendarDropdown?.calendar) {
+      this._calendarDropdown.locale = locale;
     }
   }
 

--- a/src/lib/date-picker/base/base-date-picker-constants.ts
+++ b/src/lib/date-picker/base/base-date-picker-constants.ts
@@ -38,7 +38,8 @@ const observedAttributes = {
   SHOW_TODAY: 'show-today',
   SHOW_CLEAR: 'show-clear',
   DISABLED_DAYS_OF_WEEK: 'disabled-days-of-week',
-  YEAR_RANGE: 'year-range'
+  YEAR_RANGE: 'year-range',
+  LOCALE: 'locale'
 };
 
 const attributes = {

--- a/src/lib/date-picker/base/base-date-picker-foundation.ts
+++ b/src/lib/date-picker/base/base-date-picker-foundation.ts
@@ -27,6 +27,7 @@ export interface IBaseDatePickerFoundation<TValue> extends ICustomElementFoundat
   showToday: boolean;
   showClear: boolean;
   yearRange: string;
+  locale: string | undefined;
 }
 
 export abstract class BaseDatePickerFoundation<TAdapter extends IBaseDatePickerAdapter, TPublicValue, TPrivateValue = TPublicValue> implements IBaseDatePickerFoundation<TPublicValue> {
@@ -53,6 +54,7 @@ export abstract class BaseDatePickerFoundation<TAdapter extends IBaseDatePickerA
   protected _showClear = false;
   protected _disabledDaysOfWeek: DayOfWeek[];
   protected _yearRange = '-50:+50';
+  protected _locale: string | undefined;
   protected _isInitialized = false;
 
   // Listeners
@@ -203,7 +205,8 @@ export abstract class BaseDatePickerFoundation<TAdapter extends IBaseDatePickerA
       preventFocus: true,
       menuAnimation: 'fade',
       fixedHeight: true,
-      selectionFollowsMonth: true
+      selectionFollowsMonth: true,
+      locale: this._locale
     };
     const dropdownConfig: ICalendarDropdownPopupConfig = {
       popupClasses: this._popupClasses,
@@ -735,6 +738,19 @@ export abstract class BaseDatePickerFoundation<TAdapter extends IBaseDatePickerA
 
       if (this._isInitialized && this._open) {
         this._adapter.setCalendarYearRange(this._yearRange);
+      }
+    }
+  }
+
+  public get locale(): string | undefined {
+    return this._locale;
+  }
+  public set locale(value: string | undefined) {
+    if (this._locale !== value) {
+      this._locale = value;
+
+      if (this._isInitialized && this._open) {
+        this._adapter.setCalendarLocale(this._locale);
       }
     }
   }

--- a/src/lib/date-picker/base/base-date-picker.ts
+++ b/src/lib/date-picker/base/base-date-picker.ts
@@ -27,6 +27,7 @@ export interface IBaseDatePickerComponent<TValue> extends IBaseComponent {
   showClear: boolean;
   disabledDaysOfWeek: DayOfWeek[];
   yearRange: string;
+  locale: string | undefined;
 }
 
 export abstract class BaseDatePickerComponent<TPublicValue, TPrivateValue, TFoundation extends BaseDatePickerFoundation<IBaseDatePickerAdapter, TPublicValue, TPrivateValue>> extends BaseComponent implements IBaseDatePickerComponent<TPublicValue> {
@@ -92,6 +93,9 @@ export abstract class BaseDatePickerComponent<TPublicValue, TPrivateValue, TFoun
         break;
       case BASE_DATE_PICKER_CONSTANTS.observedAttributes.YEAR_RANGE:
         this.yearRange = newValue;
+        break;
+      case BASE_DATE_PICKER_CONSTANTS.observedAttributes.LOCALE:
+        this.locale = newValue;
         break;
     }
   }
@@ -179,4 +183,8 @@ export abstract class BaseDatePickerComponent<TPublicValue, TPrivateValue, TFoun
   /** Sets the year range. */
   @FoundationProperty()
   public declare yearRange: string;
+
+  /** Sets the locale to use. */
+  @FoundationProperty()
+  public declare locale: string | undefined;
 }

--- a/src/stories/src/components/calendar/calendar.mdx
+++ b/src/stories/src/components/calendar/calendar.mdx
@@ -185,7 +185,7 @@ Toggles whether selecting a month or year from the menu changes the selected dat
 
 </PropertyDef>
 
-<PropertyDef name="locale" type="string" defaultValue="undefined">
+<PropertyDef name="locale" type="string | undefined" defaultValue="undefined">
 
 A Unicode locale identifier string to use when rendering the calendar. This sets regional date display, text direction, the first day of the week, and weekend days. The browser's locale will be used if `undefined`.
 

--- a/src/stories/src/components/date-picker/date-picker-args.ts
+++ b/src/stories/src/components/date-picker/date-picker-args.ts
@@ -13,6 +13,7 @@ export interface IDatePickerProps {
   showClear: boolean;
   disabledDaysOfWeek: DayOfWeek[];
   yearRange: string;
+  locale: string | undefined;
 }
 
 export const argTypes = {
@@ -106,6 +107,13 @@ export const argTypes = {
     },
   },
   yearRange: {
+    control: 'text',
+    description: '',
+    table: {
+      category: 'Properties',
+    },
+  },
+  locale: {
     control: 'text',
     description: '',
     table: {

--- a/src/stories/src/components/date-picker/date-picker.mdx
+++ b/src/stories/src/components/date-picker/date-picker.mdx
@@ -176,6 +176,12 @@ Sets the range of years selectable in the dropdown's year menu. The value is two
 
 </PropertyDef>
 
+<PropertyDef name="locale" type="string | undefined" defaultValue="undefined">
+
+A Unicode locale identifier string to use when rendering the calendar. This sets regional date display, text direction, the first day of the week, and weekend days. The browser's locale will be used if `undefined`.
+
+</PropertyDef>
+
 </PageSection>
 
 <PageSection>

--- a/src/stories/src/components/date-picker/date-picker.stories.tsx
+++ b/src/stories/src/components/date-picker/date-picker.stories.tsx
@@ -28,7 +28,8 @@ export const Default: Story<IDatePickerProps> = ({
   showToday = false,
   showClear = false,
   disabledDaysOfWeek = [],
-  yearRange = '-50:+50'
+  yearRange = '-50:+50',
+  locale = undefined
 }) => {
   if (min) {
     min = new Date(min);
@@ -50,6 +51,7 @@ export const Default: Story<IDatePickerProps> = ({
       showClear={showClear}
       disabledDaysOfWeek={disabledDaysOfWeek}
       yearRange={yearRange}
+      locale={locale}
       style={{ maxWidth: '256px' }}>
       <ForgeTextField>
         <input type="text" id="input-date-picker" />
@@ -70,5 +72,6 @@ Default.args = {
   showToday: false,
   showClear: false,
   disabledDaysOfWeek: [],
-  yearRange: '-50:+50'
+  yearRange: '-50:+50',
+  locale: ''
 } as IDatePickerProps;

--- a/src/stories/src/components/date-range-picker/date-range-picker-args.ts
+++ b/src/stories/src/components/date-range-picker/date-range-picker-args.ts
@@ -12,6 +12,7 @@ export interface IDateRangePickerProps {
   showToday: boolean;
   showClear: boolean;
   disabledDaysOfWeek: DayOfWeek[];
+  locale: string | undefined;
 }
 
 export const argTypes = {
@@ -103,5 +104,12 @@ export const argTypes = {
     table: {
       category: 'Properties',
     },
-  }
+  },
+  locale: {
+    control: 'text',
+    description: '',
+    table: {
+      category: 'Properties',
+    },
+  },
 };

--- a/src/stories/src/components/date-range-picker/date-range-picker.mdx
+++ b/src/stories/src/components/date-range-picker/date-range-picker.mdx
@@ -173,6 +173,12 @@ Sets a callback that will be executed on every date in the calendar and input. R
 
 </PropertyDef>
 
+<PropertyDef name="locale" type="string | undefined" defaultValue="undefined">
+
+A Unicode locale identifier string to use when rendering the calendar. This sets regional date display, text direction, the first day of the week, and weekend days. The browser's locale will be used if `undefined`.
+
+</PropertyDef>
+
 </PageSection>
 
 <PageSection>

--- a/src/stories/src/components/date-range-picker/date-range-picker.stories.tsx
+++ b/src/stories/src/components/date-range-picker/date-range-picker.stories.tsx
@@ -27,7 +27,8 @@ export const Default: Story<IDateRangePickerProps> = ({
   allowInvalidDate = false,
   showToday = false,
   showClear = false,
-  disabledDaysOfWeek = []
+  disabledDaysOfWeek = [],
+  locale = undefined
 }) => {
   if (min) {
     min = new Date(min);
@@ -48,6 +49,7 @@ export const Default: Story<IDateRangePickerProps> = ({
       showToday={showToday}
       showClear={showClear}
       disabledDaysOfWeek={disabledDaysOfWeek}
+      locale={locale}
       style={{ width: '320px' }}>
       <ForgeTextField>
         <input type="text" id="input-date-range-picker-01" autoComplete="off" placeholder="mm/dd/yyyy" />
@@ -68,5 +70,6 @@ Default.args = {
   allowInvalidDate: false,
   showToday: false,
   showClear: false,
-  disabledDaysOfWeek: []
+  disabledDaysOfWeek: [],
+  locale: ''
 } as IDateRangePickerProps;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Added a new `locale` property/attribute to the `<forge-date-picker>` and `<forge-date-range-picker>` elements that will propagate to the underlying `<forge-calendar>` that is presented in the dropdown. This allows for setting the locale of the calendar through the date picker elements.

## Additional information
Fixes #343 
