### PR TITLE
fix(stepper): fixed a bug where the `vertical` state was not being applied if the `steps` property was changed dynamically

### DIFF
--- a/src/lib/stepper/core/stepper-utils.ts
+++ b/src/lib/stepper/core/stepper-utils.ts
@@ -19,7 +19,7 @@ export class StepperUtils {
     stepElement.alternative = stepperConfig.alternative;
     stepElement.error = step.error || false;
     stepElement.disabled = step.disabled || false;
-    stepElement.vertical = step.vertical || false;
+    stepElement.vertical = step.vertical ?? stepperConfig.vertical ?? false;
     stepElement.ignoreUserExpansion = step.ignoreUserExpansion || false;
     stepElement.expanded = step.expanded || false;
 

--- a/src/lib/stepper/stepper/stepper-foundation.ts
+++ b/src/lib/stepper/stepper/stepper-foundation.ts
@@ -223,6 +223,7 @@ export class StepperFoundation implements IStepperFoundation {
   private _renderConfiguration(): void {
     const steps = StepperUtils.createSteps({
       steps: this._steps,
+      vertical: this._vertical,
       selectedIndex: this._selectedIndex,
       alternative: this._alternative,
       layoutAlign: this._layoutAlign,

--- a/src/test/spec/stepper/stepper.spec.ts
+++ b/src/test/spec/stepper/stepper.spec.ts
@@ -499,6 +499,17 @@ describe('StepperComponent', function (this: ITestContext) {
 
       expect(icon.name).toBe('mode_edit', 'Should have a edit when selected and editable');
     });
+
+    it('should set steps to vertical', async function (this: ITestContext) {
+      this.context = setupTestContext(true, DEFAULT_STEPS.length);
+      this.context.component.vertical = true;
+      this.context.component.steps = DEFAULT_STEPS;
+      await tick();
+
+      this.context.component.steps = [...DEFAULT_STEPS];
+
+      expect(this.context.getSteps().every(step => step.vertical)).toBeTrue();
+    });
   });
 
   describe('vertical stepper', function (this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? Y
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Settings the `steps` property will now properly inherit the `vertical` state from the `<forge-stepper>` when creating the `<forge-step>` elements.

## Additional information
Fixes #339 
