### PR TITLE
fix(color-picker): fixed a bug where manually entering a hex value would not accept characters until a valid hex string value and length was reached

### DIFF
--- a/src/lib/color-picker/color-picker-foundation.ts
+++ b/src/lib/color-picker/color-picker-foundation.ts
@@ -175,14 +175,10 @@ export class ColorPickerFoundation implements IColorPickerFoundation {
   private _render(): void {
     this._setGradientColor();
     this._adapter.setPreviewColor(formatRgba(this._rgba));
-    this._adapter.setHexInputValue(this._getFormattedHex());
+    this._adapter.setHexInputValue(`#${this._hex}`);
     this._adapter.setRgbaInputValue(this._rgba);
     this._adapter.setHsvaInputValue(this._hsva);
     this._adapter.updateA11y(this._hsva.h, Math.round(this._hsva.a * 100));
-  }
-
-  private _getFormattedHex(): string {
-    return formatHex(this._hex, false);
   }
 
   private _emitChangeEvent(type: ColorPickerChangeEventType, source: ColorPickerChangeEventSource): void {
@@ -200,7 +196,7 @@ export class ColorPickerFoundation implements IColorPickerFoundation {
   }
 
   public get value(): string | null | undefined {
-    return this._getFormattedHex();
+    return formatHex(this._hex, false);
   }
   public set value(value: string | null | undefined) {
     if (this._value !== value) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The `<forge-color-picker>` will now accept manually entering a hex color value that is invalid. This means an invalid hex color value can technically be entered now, but the underlying color will not change until a valid hex value is received.

This change allows for incrementally entering a hex color value that will _eventually_ create a valid hex code.

## Additional information
Fixes #338 
