### PR TITLE
fix(chips): fixed a bug where the text was not centered if the width was less than than the min-width of the chip

### DIFF
--- a/src/lib/chips/chip/_mixins.scss
+++ b/src/lib/chips/chip/_mixins.scss
@@ -33,6 +33,7 @@
 
     &__content {
       flex-grow: 1;
+      text-align: center;
 
       &:focus {
         outline: none;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The `<forge-chip>` now sets `text-align: center` on the internal text content container element. This ensures that the text is always centered horizontally regardless of the width of the content in relation to the chip width.

## Additional information
Fixes #336 
