### PR TITLE
fix(chip-field): fix floating label state

### DIFF
--- a/src/lib/field/field-foundation.ts
+++ b/src/lib/field/field-foundation.ts
@@ -190,6 +190,9 @@ export class FieldFoundation {
 
   public floatLabel(value: boolean): void {
     if (this._floatingLabel?.isFloating === value || this._adapter.isLabelFloating() === value) {
+      if (value) {
+        this._adapter.setHostAttribute(FIELD_CONSTANTS.attributes.HOST_LABEL_FLOATING, '');
+      }
       return;
     }
 

--- a/src/lib/field/field-foundation.ts
+++ b/src/lib/field/field-foundation.ts
@@ -93,6 +93,9 @@ export class FieldFoundation {
     this._isInitialized = false;
     this._adapter.destroy();
 
+    this._adapter.removeHostAttribute(FIELD_CONSTANTS.attributes.HOST_LABEL_FLOATING);
+    this._adapter.removeRootClass(FIELD_CONSTANTS.classes.LABEL);
+
     if (this._floatingLabel) {
       this._floatingLabel.destroy();
       this._floatingLabel = undefined;

--- a/src/test/spec/chip-field/chip-field.spec.ts
+++ b/src/test/spec/chip-field/chip-field.spec.ts
@@ -921,6 +921,26 @@ describe('ChipFieldComponent', function(this: ITestContext) {
         expect(this.context.component.getAttribute(FIELD_CONSTANTS.attributes.FLOAT_LABEL_TYPE)).withContext('float-label-type attribute should be "always"').toBe('always');
       });
 
+      it('should float the label when floatLabelType property is set to "always" after being moved in the DOM', async function(this: ITestContext) {
+        this.context = setupTestContext(true, {}, { label: 'Test' });
+        this.context.component.floatLabelType = 'always';
+        await tick();
+        
+        expect(this.context.component.hasAttribute(FIELD_CONSTANTS.attributes.HOST_LABEL_FLOATING)).toBeTrue();
+
+        const parent = this.context.component.parentElement as HTMLElement;
+        this.context.destroy();
+        await tick();
+
+        expect(this.context.component.hasAttribute(FIELD_CONSTANTS.attributes.HOST_LABEL_FLOATING)).toBeFalse();
+
+        parent.appendChild(this.context.component);
+        await tick();
+
+        expect((this.context.foundation as any)._floatingLabel.isFloating).withContext('label should be floating').toBeTrue();
+        expect(this.context.component.hasAttribute(FIELD_CONSTANTS.attributes.HOST_LABEL_FLOATING)).toBeTrue();
+      });
+
       it('should not float the label when floatLabelType property is set from "always" to auto (while input has no value)', async function(this: ITestContext) {
         this.context = setupTestContext(true, {}, { label: 'Test' });
         this.context.component.floatLabelType = 'always';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The `<forge-chip-field>` will now properly float its label when re-rendered while the label was previously already floating.

## Additional information
The underlying field logic that manages the floating label state was not properly destroying its floating label state when the element was removed from the DOM. This meant that when the component was re-added to the DOM, the field logic assumed the label was already floating and didn't need to float it.

Ensuring the DOM state was updated when the element was disconnected is all that needed to occur to allow for the label to re-float properly.
