### PR TITLE
fix: fixed a bug where detecting the active element after being adopted into a new document could incorrectly reflect the wrong element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@material/top-app-bar": "^14.0.0",
         "@material/touch-target": "^14.0.0",
         "@material/typography": "^14.0.0",
-        "@tylertech/forge-core": "^2.1.0",
+        "@tylertech/forge-core": "^2.3.0",
         "@tylertech/tyler-icons": "^1.12.0",
         "imask": "^6.6.1",
         "tslib": "^2.3.1"
@@ -3136,9 +3136,9 @@
       }
     },
     "node_modules/@tylertech/forge-core": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@tylertech/forge-core/-/forge-core-2.2.2.tgz",
-      "integrity": "sha512-VnMebSPWyn8p9/HQWybIBXYUAoKaaLDKhm2BCHoIeE0t6WUlyullS4kBR4t4//0qkJn3o5Gh6bX6lgH+esLxHA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@tylertech/forge-core/-/forge-core-2.3.0.tgz",
+      "integrity": "sha512-qxR1ZCW9HnBdTyZJYyHBzmwHNv4FNCZOVmD4Ss3AJBum6BTkLye0n9odaEZe87b9aXH18FjPr9wtotrH/aILKA==",
       "dependencies": {
         "@floating-ui/dom": "^0.5.0",
         "tslib": "^2.3.1"
@@ -21382,9 +21382,9 @@
       }
     },
     "@tylertech/forge-core": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@tylertech/forge-core/-/forge-core-2.2.2.tgz",
-      "integrity": "sha512-VnMebSPWyn8p9/HQWybIBXYUAoKaaLDKhm2BCHoIeE0t6WUlyullS4kBR4t4//0qkJn3o5Gh6bX6lgH+esLxHA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@tylertech/forge-core/-/forge-core-2.3.0.tgz",
+      "integrity": "sha512-qxR1ZCW9HnBdTyZJYyHBzmwHNv4FNCZOVmD4Ss3AJBum6BTkLye0n9odaEZe87b9aXH18FjPr9wtotrH/aILKA==",
       "requires": {
         "@floating-ui/dom": "^0.5.0",
         "tslib": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@material/top-app-bar": "^14.0.0",
     "@material/touch-target": "^14.0.0",
     "@material/typography": "^14.0.0",
-    "@tylertech/forge-core": "^2.1.0",
+    "@tylertech/forge-core": "^2.3.0",
     "@tylertech/tyler-icons": "^1.12.0",
     "imask": "^6.6.1",
     "tslib": "^2.3.1"

--- a/src/lib/app-bar/profile-button/app-bar-profile-button-adapter.ts
+++ b/src/lib/app-bar/profile-button/app-bar-profile-button-adapter.ts
@@ -75,7 +75,7 @@ export class AppBarProfileButtonAdapter extends BaseAdapter<IAppBarProfileButton
       if (!this._popupElement) {
         return;
       }
-      if (!this._component.contains(getActiveElement())) {
+      if (!this._component.contains(getActiveElement(this._component.ownerDocument))) {
         dismissListener();
       }
     }, true);

--- a/src/lib/autocomplete/autocomplete-adapter.ts
+++ b/src/lib/autocomplete/autocomplete-adapter.ts
@@ -170,7 +170,7 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
   }
 
   public hasFocus(): boolean {
-    const activeElement = getActiveElement() as HTMLElement;
+    const activeElement = getActiveElement(this._component.ownerDocument) as HTMLElement;
     return activeElement === this._inputElement || this.isFocusWithinPopup(activeElement);
   }
 

--- a/src/lib/busy-indicator/busy-indicator-adapter.ts
+++ b/src/lib/busy-indicator/busy-indicator-adapter.ts
@@ -266,7 +266,7 @@ export class BusyIndicatorAdapter extends BaseAdapter<IBusyIndicatorComponent> i
   }
 
   public getFocusedElement(): HTMLElement {
-    return getActiveElement() as HTMLElement;
+    return getActiveElement(this._component.ownerDocument) as HTMLElement;
   }
 
   public hasFocus(): boolean {

--- a/src/lib/chip-field/chip-field-foundation.ts
+++ b/src/lib/chip-field/chip-field-foundation.ts
@@ -131,7 +131,7 @@ export class ChipFieldFoundation extends FieldFoundation implements IChipFieldFo
   }
 
   private _memberIsActive(ele: HTMLElement): boolean {
-    return getActiveElement() === ele || ele.hasAttribute('focused');
+    return getActiveElement(ele.ownerDocument) === ele || ele.hasAttribute('focused');
   }
 
   private _getActiveMember(): HTMLElement | null {

--- a/src/lib/chips/chip/chip-adapter.ts
+++ b/src/lib/chips/chip/chip-adapter.ts
@@ -221,7 +221,7 @@ export class ChipAdapter extends BaseAdapter<IChipComponent> implements IChipAda
   }
 
   public tryMoveFocusNext(): void {
-    const activeElement = getActiveElement();
+    const activeElement = getActiveElement(this._component.ownerDocument);
     if (activeElement === this._buttonElement) {
       if (this._deleteButton) {
         this._deleteButton.focus();
@@ -234,7 +234,7 @@ export class ChipAdapter extends BaseAdapter<IChipComponent> implements IChipAda
   }
 
   public tryMoveFocusPrevious(): void {
-    const activeElement = getActiveElement();
+    const activeElement = getActiveElement(this._component.ownerDocument);
     if (activeElement === this._deleteButton) {
       this._buttonElement.focus();
     } else if (activeElement === this._buttonElement) {

--- a/src/lib/date-picker/date-picker-adapter.ts
+++ b/src/lib/date-picker/date-picker-adapter.ts
@@ -108,7 +108,7 @@ export class DatePickerAdapter extends BaseDatePickerAdapter<IDatePickerComponen
   }
 
   public isInputFocused(): boolean {
-    return getActiveElement() === this._inputElement;
+    return getActiveElement(this._component.ownerDocument) === this._inputElement;
   }
 
   public getInputValue(): string {

--- a/src/lib/date-range-picker/date-range-picker-adapter.ts
+++ b/src/lib/date-range-picker/date-range-picker-adapter.ts
@@ -185,7 +185,7 @@ export class DateRangePickerAdapter extends BaseDatePickerAdapter<IDateRangePick
     if (target && this._toInputElement === target || this._fromInputElement === target) {
       return true;
     }
-    const activeEl = getActiveElement();
+    const activeEl = getActiveElement(this._component.ownerDocument);
     return this._toInputElement === activeEl || this._fromInputElement === activeEl;
   }
 

--- a/src/lib/dialog/dialog-adapter.ts
+++ b/src/lib/dialog/dialog-adapter.ts
@@ -191,7 +191,7 @@ export class DialogAdapter extends BaseAdapter<IDialogComponent> implements IDia
   }
 
   public captureActiveElement(): void {
-    this._activeElement = getActiveElement() as HTMLElement;
+    this._activeElement = getActiveElement(this._component.ownerDocument) as HTMLElement;
     if (this._activeElement) {
       this._activeElement.blur();
     }

--- a/src/lib/field/field-adapter.ts
+++ b/src/lib/field/field-adapter.ts
@@ -191,7 +191,7 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
   }
 
   public inputHasFocus(target?: EventTarget | null): boolean {
-    return this._inputElement === target || this._inputElement === getActiveElement();
+    return this._inputElement === target || this._inputElement === getActiveElement(this._component.ownerDocument);
   }
 
   public setLabelClass(name: string): void {

--- a/src/lib/list/list/list-adapter.ts
+++ b/src/lib/list/list/list-adapter.ts
@@ -63,7 +63,7 @@ export class ListAdapter extends BaseAdapter<IListComponent> implements IListAda
     const listItems = deepQuerySelectorAll(this._component, LIST_CONSTANTS.selectors.FOCUSABLE_LIST_ITEMS, false) as HTMLElement[];
 
     if (listItems && listItems.length > 0) {
-      const focusedListItemIndex = listItems.indexOf(getActiveElement() as HTMLElement);
+      const focusedListItemIndex = listItems.indexOf(getActiveElement(this._component.ownerDocument) as HTMLElement);
       const nextIndex = focusedListItemIndex < listItems.length - 1 ? focusedListItemIndex + 1 : 0;
 
       if (nextIndex <= listItems.length - 1) {
@@ -79,7 +79,7 @@ export class ListAdapter extends BaseAdapter<IListComponent> implements IListAda
     const listItems = deepQuerySelectorAll(this._component, LIST_CONSTANTS.selectors.FOCUSABLE_LIST_ITEMS, false) as HTMLElement[];
 
     if (listItems && listItems.length > 0) {
-      const focusedListItemIndex = listItems.indexOf(getActiveElement() as HTMLElement);
+      const focusedListItemIndex = listItems.indexOf(getActiveElement(this._component.ownerDocument) as HTMLElement);
       const nextIndex = focusedListItemIndex > 0 ? focusedListItemIndex - 1 : listItems.length - 1;
 
       if (nextIndex >= 0) {

--- a/src/lib/popup/popup-adapter.ts
+++ b/src/lib/popup/popup-adapter.ts
@@ -86,7 +86,7 @@ export class PopupAdapter extends BaseAdapter<IPopupComponent> implements IPopup
     this.positionPopup();
 
     if (manageFocus) {
-      this._previouslyFocusedElement = getActiveElement() as HTMLElement;
+      this._previouslyFocusedElement = getActiveElement(this._component.ownerDocument) as HTMLElement;
       this._component.focus();
     }
   }
@@ -97,7 +97,7 @@ export class PopupAdapter extends BaseAdapter<IPopupComponent> implements IPopup
     if (manageFocus) {
       window.requestAnimationFrame(() => {
         if (this._previouslyFocusedElement) {
-          const activeElement = getActiveElement();
+          const activeElement = getActiveElement(this._component.ownerDocument);
           if (!activeElement || activeElement === document.body) {
             this._previouslyFocusedElement.focus();
           }

--- a/src/lib/radio/radio-adapter.ts
+++ b/src/lib/radio/radio-adapter.ts
@@ -110,7 +110,8 @@ export class RadioAdapter implements IRadioAdapter, ForgeRippleCapableSurface {
   }
 
   public syncFocusedStateWithInput(): void {
-    if (getActiveElement() === this._inputElement) {
+    const activeElement = getActiveElement(this._component.ownerDocument);
+    if (activeElement === this._inputElement) {
       this.addRootClass(RADIO_CONSTANTS.classes.FOCUSED);
     } else {
       this.removeRootClass(RADIO_CONSTANTS.classes.FOCUSED);

--- a/src/lib/stepper/stepper/stepper-adapter.ts
+++ b/src/lib/stepper/stepper/stepper-adapter.ts
@@ -141,7 +141,7 @@ export class StepperAdapter extends BaseAdapter<IStepperComponent> implements IS
 
   public tryGetFocusedStep(): IStepComponent | undefined {
     let focusedStep: IStepComponent = undefined as any;
-    const activeElement = getActiveElement();
+    const activeElement = getActiveElement(this._component.ownerDocument);
     this._applyToSteps(step => {
       if (activeElement === getShadowElement(step, STEP_CONSTANTS.selectors.STEP)) {
         focusedStep = step;

--- a/src/lib/tabs/tab-bar/tab-bar-adapter.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-adapter.ts
@@ -213,7 +213,7 @@ export class TabBarAdapter extends BaseAdapter<ITabBarComponent> implements ITab
   }
 
   public getFocusedTabIndex(): number {
-    const activeElement = getActiveElement() as ITabComponent;
+    const activeElement = getActiveElement(this._component.ownerDocument) as ITabComponent;
     return this._tabs.findIndex(tab => {
       if (tab === activeElement) {
         return true;

--- a/src/lib/text-field/text-field-adapter.ts
+++ b/src/lib/text-field/text-field-adapter.ts
@@ -76,7 +76,8 @@ export class TextFieldAdapter extends FieldAdapter implements ITextFieldAdapter 
   }
 
   public override inputHasFocus(target?: EventTarget | null): boolean {
-    return this._inputsSome(input => input === target || input === getActiveElement());
+    const activeElement = getActiveElement(this._component.ownerDocument);
+    return this._inputsSome(input => input === target || input === activeElement);
   }
 
   public override setInputClass(className: string): void {

--- a/src/lib/time-picker/time-picker-adapter.ts
+++ b/src/lib/time-picker/time-picker-adapter.ts
@@ -162,7 +162,8 @@ export class TimePickerAdapter extends BaseAdapter<ITimePickerComponent> impleme
   }
 
   public isInputFocused(): boolean {
-    return getActiveElement() === this._inputElement;
+    const activeElement = getActiveElement(this._component.ownerDocument);
+    return activeElement === this._inputElement;
   }
 
   public setInputValue(value: string, emitEvents: boolean): void {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
An issue was presented where an element was adopted from its origin document into a new document (via a new window). The issue stemmed from the fact that there were checks in various components (specifically the autocomplete) where `document.activeElement` (from within the `getActiveElement()` utility function) was evaluating incorrectly in these scenarios due to the wrong `document` being used.

This change updates the calls to `getActiveElement()` to always use the `ownerDocument` of the component. This ensures that it is evaluating the focus from the correct context.

## Additional information
Depends on the changes made in `@tylertech/forge-core` here:
https://github.com/tyler-technologies-oss/forge-core/pull/9
