### PR TITLE
fix(list-item): fixed a bug where setting `dense` wasn't applying the correct height

### DIFF
--- a/src/lib/list/list-item/_mixins.scss
+++ b/src/lib/list/list-item/_mixins.scss
@@ -72,10 +72,17 @@
       ::slotted(.forge-list-item__title) {
         @include mdc-typography.typography(body2);
       }
+
+      &.forge-list-item--two-line {
+        @include theme.css-custom-property(min-height, --forge-list-item-min-height, variables.$dense-two-line-height);
+      }
+
+      &.forge-list-item--three-line {
+        @include theme.css-custom-property(min-height, --forge-list-item-min-height, variables.$dense-three-line-height);
+      }
     }
   
     &--wrap {
-      @include theme.css-custom-property(min-height, --forge-list-item-min-height, variables.$single-line-height);
       @include theme.css-custom-property(height, --forge-list-item-height, auto);
 
       ::slotted([slot=title]),
@@ -343,14 +350,17 @@
 }
 
 @mixin two-line() {
+  @include theme.css-custom-property(min-height, --forge-list-item-min-height, variables.$two-line-height);
   @include theme.css-custom-property(height, --forge-list-item-height, variables.$two-line-height);
 }
 
 @mixin three-line() {
+  @include theme.css-custom-property(min-height, --forge-list-item-min-height, variables.$three-line-height);
   @include theme.css-custom-property(height, --forge-list-item-height, variables.$three-line-height);
 }
 
 @mixin dense() {
+  @include theme.css-custom-property(min-height, --forge-list-item-min-height, variables.$dense-single-line-height);
   @include theme.css-custom-property(height, --forge-list-item-height, variables.$dense-height);
 }
 

--- a/src/lib/list/list-item/_variables.scss
+++ b/src/lib/list/list-item/_variables.scss
@@ -7,6 +7,15 @@ $drawer-inline-padding: #{math.div($inline-padding, 2)};
 /// The default height for a single line list item.
 $single-line-height: #{48px - $block-padding * 2} !default;
 
+/// The default height for a single line list item.
+$dense-single-line-height: #{32px - $block-padding * 2} !default;
+
+/// The default height for a two line list item.
+$dense-two-line-height: #{56px - $block-padding * 2} !default;
+
+/// The default height for a three line list item.
+$dense-three-line-height: #{72px - $block-padding * 2} !default;
+
 /// The default min-height for a single line list item in a drawer context.
 $drawer-single-line-height: 40px !default;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The list item component will now properly apply the dense height styles.

## Additional information
Fixes #357 