### PR TITLE
feat(popup): add popup ref to close event, emit from host

### DIFF
--- a/src/lib/popup/popup-adapter.ts
+++ b/src/lib/popup/popup-adapter.ts
@@ -1,6 +1,6 @@
 import { addClass, closestElement, emitEvent, getShadowElement, IPositionElementConfig, notChildEventListener, positionElementAsync, removeClass, removeElement, deepQuerySelectorAll, getActiveElement } from '@tylertech/forge-core';
 import { BaseAdapter, IBaseAdapter } from '../core/base/base-adapter';
-import { IPopupComponent } from './popup';
+import { IPopupComponent, IPopupCloseEventData } from './popup';
 import { IPopupPositionEventData, POPUP_CONSTANTS, PopupPlacement } from './popup-constants';
 
 export interface IPopupAdapter extends IBaseAdapter {
@@ -17,6 +17,7 @@ export interface IPopupAdapter extends IBaseAdapter {
   removeEventListener(type: string, listener: (evt: Event) => void): void;
   setBlurListener(listener: () => void): () => void;
   trySetInitialFocus(): void;
+  getCloseEventData(): IPopupCloseEventData;
 }
 
 export class PopupAdapter extends BaseAdapter<IPopupComponent> implements IPopupAdapter {
@@ -128,6 +129,10 @@ export class PopupAdapter extends BaseAdapter<IPopupComponent> implements IPopup
       return !emitEvent(this._component.targetElement, type, data, bubbles, cancelable);
     }
     return false;
+  }
+
+  public getCloseEventData(): IPopupCloseEventData {
+    return { popup: this._component };
   }
 
   public addClass(classes: string | string[]): void {

--- a/src/lib/popup/popup-foundation.ts
+++ b/src/lib/popup/popup-foundation.ts
@@ -1,6 +1,6 @@
 import { ICustomElementFoundation, isElement } from '@tylertech/forge-core';
 import { IPopupAdapter } from './popup-adapter';
-import { IPopupPosition, PopupAnimationType, PopupPlacement, PopupStateCallback, POPUP_CONSTANTS as constants, POPUP_CONSTANTS } from './popup-constants';
+import { IPopupPosition, PopupAnimationType, PopupPlacement, PopupStateCallback, POPUP_CONSTANTS } from './popup-constants';
 
 export interface IPopupFoundation extends ICustomElementFoundation {
   targetElement: HTMLElement;
@@ -66,7 +66,7 @@ export class PopupFoundation implements IPopupFoundation {
     }
 
     this._adapter.manageWindowEvents(true);
-    this._adapter.dispatchEvent(constants.events.OPEN);
+    this._adapter.dispatchEvent(POPUP_CONSTANTS.events.OPEN);
   }
 
   private _closePopup(): void {
@@ -85,7 +85,9 @@ export class PopupFoundation implements IPopupFoundation {
   private _destroyPopup(): void {
     this._adapter.manageWindowEvents(false);
     this._adapter.removePopup(this._manageFocus);
-    this._adapter.dispatchEvent(constants.events.CLOSE);
+    const eventData = this._adapter.getCloseEventData();
+    this._adapter.dispatchEvent(POPUP_CONSTANTS.events.CLOSE, eventData);
+    this._adapter.emitHostEvent(POPUP_CONSTANTS.events.CLOSE, eventData);
     this._adapter.removeAttribute(POPUP_CONSTANTS.attributes.OPEN);
   }
 

--- a/src/lib/popup/popup.ts
+++ b/src/lib/popup/popup.ts
@@ -23,6 +23,10 @@ export interface IPopupComponent extends IBaseComponent {
   closeCallback: PopupStateCallback;
 }
 
+export interface IPopupCloseEventData {
+  popup: IPopupComponent;
+}
+
 declare global {
   interface HTMLElementTagNameMap {
     'forge-popup': IPopupComponent;
@@ -30,7 +34,7 @@ declare global {
 
   interface HTMLElementEventMap {
     'forge-popup-open': CustomEvent<void>;
-    'forge-popup-close': CustomEvent<void>;
+    'forge-popup-close': CustomEvent<IPopupCloseEventData>;
     'forge-popup-position': CustomEvent<IPopupPositionEventData>;
     'forge-popup-blur': CustomEvent<void>;
   }

--- a/src/stories/src/components/popup/popup.mdx
+++ b/src/stories/src/components/popup/popup.mdx
@@ -185,14 +185,15 @@ Manually tells the popup to execute its positioning logic.
 | Name                    | Description
 | :-----------------------| :-----------------
 | `forge-popup-position`    | Emits when the popup is re-positioned.
+| `forge-popup-close`       | Emits from both the host and target elements when the popup is closed.
 
 The following events are emitted from the targetElement, **NOT** the `<forge-popup>` element.
 
 | Name                    | Description
 | :-----------------------| :-----------------
 | `forge-popup-open`        | Emits when the popup is opened.
-| `forge-popup-close`       | Emits when the popup is closed.
-| `forge-popup-blur`        | Emits when the popup is closed.
+| `forge-popup-close`       | Emits from both the host and target elements when the popup is closed.
+| `forge-popup-blur`        | Emits when the popup is blurred.
 
 </PageSection>
 

--- a/src/test/spec/popup/popup.spec.ts
+++ b/src/test/spec/popup/popup.spec.ts
@@ -128,6 +128,18 @@ describe('Popup component', function(this: ITestContext) {
     targetElement.removeEventListener(POPUP_CONSTANTS.events.CLOSE, callback);
   });
 
+  it('should also emit close event from the host element', function(this: ITestContext) {
+    this.context = setupTestContext();
+    const { component, targetElement } = this.context;
+    component.targetElement = targetElement;
+    const callback = jasmine.createSpy('callback');
+    component.addEventListener(POPUP_CONSTANTS.events.CLOSE, callback);
+    component.open = true;
+    component.open = false;
+    expect(callback).toHaveBeenCalledTimes(1);
+    component.removeEventListener(POPUP_CONSTANTS.events.CLOSE, callback);
+  });
+
   it('should accept and return focus on open and close', async function(this: ITestContext) {
     this.context = setupTestContext();
     const { component, targetElement } = this.context;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?
The `forge-popup-close` event now contains a reference to the `forge-popup` element in the event `detail`, so that it's possible to distinguish which popup is responsible for the event in the case where there are multiple (e.g. when clicking a menu item shows a popup).  Also emitting the close event from the host element, in addition to the target element, which also ensures a one-to-one relationship between the event and popup given you have a reference to it.  The latter might be more useful in JavaScript, while the former method disambiguates the events in the declarative use case.

## Additional information
Would it be better to create a new event to raise instead of re-using the same event as the target?  If so, what should it be called?  `forge-popup-host-closed`?
