### PR TITLE
feat(keyboard-shortcut): add activate callback

### DIFF
--- a/src/lib/keyboard-shortcut/keyboard-shortcut-constants.ts
+++ b/src/lib/keyboard-shortcut/keyboard-shortcut-constants.ts
@@ -44,6 +44,8 @@ export const textInputTypes = [
   'week'
 ];
 
+export type KeyboardShortcutActivationCallback = (event: KeyboardEvent) => void;
+
 export interface IKeyCombination {
   key: string;
   modifier?: string;

--- a/src/lib/keyboard-shortcut/keyboard-shortcut-constants.ts
+++ b/src/lib/keyboard-shortcut/keyboard-shortcut-constants.ts
@@ -44,7 +44,7 @@ export const textInputTypes = [
   'week'
 ];
 
-export type KeyboardShortcutActivationCallback = (event: KeyboardEvent) => void;
+export type KeyboardShortcutActivateCallback = (event: KeyboardEvent) => void;
 
 export interface IKeyCombination {
   key: string;

--- a/src/lib/keyboard-shortcut/keyboard-shortcut-foundation.ts
+++ b/src/lib/keyboard-shortcut/keyboard-shortcut-foundation.ts
@@ -84,7 +84,7 @@ export class KeyboardShortcutFoundation implements IKeyboardShortcutFoundation {
         evt.preventDefault();
       }
       this._adapter.emitHostEvent(KEYBOARD_SHORTCUT_CONSTANTS.events.ACTIVATE, evt);
-      this._activateCallback?.(evt);
+      this._activateCallback?.call(null, evt);
     }
   }
 
@@ -203,8 +203,6 @@ export class KeyboardShortcutFoundation implements IKeyboardShortcutFoundation {
     return this._activateCallback;
   }
   public set activateCallback(value: KeyboardShortcutActivateCallback | null | undefined) {
-    if (this._activateCallback !== value) {
-      this._activateCallback = value;
-    }
+    this._activateCallback = value;
   }
 }

--- a/src/lib/keyboard-shortcut/keyboard-shortcut-foundation.ts
+++ b/src/lib/keyboard-shortcut/keyboard-shortcut-foundation.ts
@@ -1,7 +1,7 @@
 import { ICustomElementFoundation } from '@tylertech/forge-core';
 
 import { IKeyboardShortcutAdapter } from './keyboard-shortcut-adapter';
-import { IKeyCombination, KEYBOARD_SHORTCUT_CONSTANTS, KeyboardShortcutActivationCallback } from './keyboard-shortcut-constants';
+import { IKeyCombination, KEYBOARD_SHORTCUT_CONSTANTS, KeyboardShortcutActivateCallback } from './keyboard-shortcut-constants';
 import { elementAcceptsTextInput, matchKeyCombination, parseKeyCombinations } from './keyboard-shortcut-utils';
 
 export interface IKeyboardShortcutFoundation extends ICustomElementFoundation {
@@ -13,7 +13,7 @@ export interface IKeyboardShortcutFoundation extends ICustomElementFoundation {
   capture: boolean;
   useCode: boolean;
   disabled: boolean;
-  activationCallback: KeyboardShortcutActivationCallback | null | undefined;
+  activateCallback: KeyboardShortcutActivateCallback | null | undefined;
 }
 
 export class KeyboardShortcutFoundation implements IKeyboardShortcutFoundation {
@@ -25,7 +25,7 @@ export class KeyboardShortcutFoundation implements IKeyboardShortcutFoundation {
   private _capture = false;
   private _useCode = false;
   private _disabled = false;
-  private _activationCallback: KeyboardShortcutActivationCallback | null | undefined;
+  private _activateCallback: KeyboardShortcutActivateCallback | null | undefined;
   private _keyCombinations: IKeyCombination[];
   private _keyDownListener: (evt: KeyboardEvent) => void;
   
@@ -84,7 +84,7 @@ export class KeyboardShortcutFoundation implements IKeyboardShortcutFoundation {
         evt.preventDefault();
       }
       this._adapter.emitHostEvent(KEYBOARD_SHORTCUT_CONSTANTS.events.ACTIVATE, evt);
-      this._activationCallback?.(evt);
+      this._activateCallback?.(evt);
     }
   }
 
@@ -199,12 +199,12 @@ export class KeyboardShortcutFoundation implements IKeyboardShortcutFoundation {
   }
 
   /** Gets/sets the activation callback. */
-  public get activationCallback(): KeyboardShortcutActivationCallback | null | undefined {
-    return this._activationCallback;
+  public get activateCallback(): KeyboardShortcutActivateCallback | null | undefined {
+    return this._activateCallback;
   }
-  public set activationCallback(value: KeyboardShortcutActivationCallback | null | undefined) {
-    if (this._activationCallback !== value) {
-      this._activationCallback = value;
+  public set activateCallback(value: KeyboardShortcutActivateCallback | null | undefined) {
+    if (this._activateCallback !== value) {
+      this._activateCallback = value;
     }
   }
 }

--- a/src/lib/keyboard-shortcut/keyboard-shortcut-foundation.ts
+++ b/src/lib/keyboard-shortcut/keyboard-shortcut-foundation.ts
@@ -1,7 +1,7 @@
 import { ICustomElementFoundation } from '@tylertech/forge-core';
 
 import { IKeyboardShortcutAdapter } from './keyboard-shortcut-adapter';
-import { IKeyCombination, KEYBOARD_SHORTCUT_CONSTANTS } from './keyboard-shortcut-constants';
+import { IKeyCombination, KEYBOARD_SHORTCUT_CONSTANTS, KeyboardShortcutActivationCallback } from './keyboard-shortcut-constants';
 import { elementAcceptsTextInput, matchKeyCombination, parseKeyCombinations } from './keyboard-shortcut-utils';
 
 export interface IKeyboardShortcutFoundation extends ICustomElementFoundation {
@@ -13,6 +13,7 @@ export interface IKeyboardShortcutFoundation extends ICustomElementFoundation {
   capture: boolean;
   useCode: boolean;
   disabled: boolean;
+  activationCallback: KeyboardShortcutActivationCallback | null | undefined;
 }
 
 export class KeyboardShortcutFoundation implements IKeyboardShortcutFoundation {
@@ -24,6 +25,7 @@ export class KeyboardShortcutFoundation implements IKeyboardShortcutFoundation {
   private _capture = false;
   private _useCode = false;
   private _disabled = false;
+  private _activationCallback: KeyboardShortcutActivationCallback | null | undefined;
   private _keyCombinations: IKeyCombination[];
   private _keyDownListener: (evt: KeyboardEvent) => void;
   
@@ -82,6 +84,7 @@ export class KeyboardShortcutFoundation implements IKeyboardShortcutFoundation {
         evt.preventDefault();
       }
       this._adapter.emitHostEvent(KEYBOARD_SHORTCUT_CONSTANTS.events.ACTIVATE, evt);
+      this._activationCallback?.(evt);
     }
   }
 
@@ -192,6 +195,16 @@ export class KeyboardShortcutFoundation implements IKeyboardShortcutFoundation {
       } else {
         this._connectTargetElement();
       }
+    }
+  }
+
+  /** Gets/sets the activation callback. */
+  public get activationCallback(): KeyboardShortcutActivationCallback | null | undefined {
+    return this._activationCallback;
+  }
+  public set activationCallback(value: KeyboardShortcutActivationCallback | null | undefined) {
+    if (this._activationCallback !== value) {
+      this._activationCallback = value;
     }
   }
 }

--- a/src/lib/keyboard-shortcut/keyboard-shortcut.ts
+++ b/src/lib/keyboard-shortcut/keyboard-shortcut.ts
@@ -2,7 +2,7 @@ import { coerceBoolean, CustomElement, FoundationProperty } from '@tylertech/for
 
 import { KeyboardShortcutAdapter } from './keyboard-shortcut-adapter';
 import { KeyboardShortcutFoundation } from './keyboard-shortcut-foundation';
-import { KEYBOARD_SHORTCUT_CONSTANTS } from './keyboard-shortcut-constants';
+import { KEYBOARD_SHORTCUT_CONSTANTS, KeyboardShortcutActivationCallback } from './keyboard-shortcut-constants';
 import { BaseComponent, IBaseComponent } from '../core/base/base-component';
 
 export interface IKeyboardShortcutComponent extends IBaseComponent {
@@ -15,6 +15,7 @@ export interface IKeyboardShortcutComponent extends IBaseComponent {
   capture: boolean;
   useCode: boolean;
   disabled: boolean;
+  activationCallback: KeyboardShortcutActivationCallback | null | undefined;
 }
 
 declare global {
@@ -133,4 +134,8 @@ export class KeyboardShortcutComponent extends BaseComponent implements IKeyboar
   /** Gets/sets whether the callback will be called. */
   @FoundationProperty()
   public declare disabled: boolean;
+
+  /** Gets/sets whether the activation callback. */
+  @FoundationProperty()
+  public declare activationCallback: KeyboardShortcutActivationCallback | null | undefined;
 }

--- a/src/lib/keyboard-shortcut/keyboard-shortcut.ts
+++ b/src/lib/keyboard-shortcut/keyboard-shortcut.ts
@@ -2,7 +2,7 @@ import { coerceBoolean, CustomElement, FoundationProperty } from '@tylertech/for
 
 import { KeyboardShortcutAdapter } from './keyboard-shortcut-adapter';
 import { KeyboardShortcutFoundation } from './keyboard-shortcut-foundation';
-import { KEYBOARD_SHORTCUT_CONSTANTS, KeyboardShortcutActivationCallback } from './keyboard-shortcut-constants';
+import { KEYBOARD_SHORTCUT_CONSTANTS, KeyboardShortcutActivateCallback } from './keyboard-shortcut-constants';
 import { BaseComponent, IBaseComponent } from '../core/base/base-component';
 
 export interface IKeyboardShortcutComponent extends IBaseComponent {
@@ -15,7 +15,7 @@ export interface IKeyboardShortcutComponent extends IBaseComponent {
   capture: boolean;
   useCode: boolean;
   disabled: boolean;
-  activationCallback: KeyboardShortcutActivationCallback | null | undefined;
+  activateCallback: KeyboardShortcutActivateCallback | null | undefined;
 }
 
 declare global {
@@ -137,5 +137,5 @@ export class KeyboardShortcutComponent extends BaseComponent implements IKeyboar
 
   /** Gets/sets whether the activation callback. */
   @FoundationProperty()
-  public declare activationCallback: KeyboardShortcutActivationCallback | null | undefined;
+  public declare activateCallback: KeyboardShortcutActivateCallback | null | undefined;
 }

--- a/src/stories/src/components/keyboard-shortcut/keyboard-shortcut.mdx
+++ b/src/stories/src/components/keyboard-shortcut/keyboard-shortcut.mdx
@@ -127,6 +127,13 @@ target element.
 
 </PropertyDef>
 
+<PropertyDef name="activationCallback" type="KeyboardShortcutActivationCallback" attr={false} defaultValue="undefined">
+
+Sets a function to call when the keyboard shortcut is activated. This provides an alternative to
+binding to the `forge-keyboard-shortcut-activate` event in scenerios where that may be cumbersome.
+
+</PropertyDef>
+
 </PageSection>
 
 ---
@@ -160,5 +167,17 @@ pressed if it includes a submit button.
 
 > Even though the keyboard shortcut component exists in the DOM, the element itself doesn't affect
 > accessibility or layout due to having its `display` style property set to `none`.
+
+</PageSection>
+
+<PageSection>
+
+## Types
+
+### KeyboardShortcutActivationCallback
+
+```ts
+type KeyboardShortcutActivationCallback = (event: KeyboardEvent) => void;
+```
 
 </PageSection>

--- a/src/stories/src/components/keyboard-shortcut/keyboard-shortcut.mdx
+++ b/src/stories/src/components/keyboard-shortcut/keyboard-shortcut.mdx
@@ -127,7 +127,7 @@ target element.
 
 </PropertyDef>
 
-<PropertyDef name="activationCallback" type="KeyboardShortcutActivationCallback" attr={false} defaultValue="undefined">
+<PropertyDef name="activateCallback" type="KeyboardShortcutActivateCallback" attr={false} defaultValue="undefined">
 
 Sets a function to call when the keyboard shortcut is activated. This provides an alternative to
 binding to the `forge-keyboard-shortcut-activate` event in scenerios where that may be cumbersome.
@@ -174,10 +174,10 @@ pressed if it includes a submit button.
 
 ## Types
 
-### KeyboardShortcutActivationCallback
+### KeyboardShortcutActivateCallback
 
 ```ts
-type KeyboardShortcutActivationCallback = (event: KeyboardEvent) => void;
+type KeyboardShortcutActivateCallback = (event: KeyboardEvent) => void;
 ```
 
 </PageSection>

--- a/src/test/spec/keyboard-shortcut/keyboard-shortcut.spec.ts
+++ b/src/test/spec/keyboard-shortcut/keyboard-shortcut.spec.ts
@@ -1,6 +1,6 @@
 import { removeElement } from '@tylertech/forge-core';
 import { tick } from '@tylertech/forge-testing';
-import { IKeyboardShortcutComponent, KEYBOARD_SHORTCUT_CONSTANTS, KeyboardShortcutActivationCallback, defineKeyboardShortcutComponent } from '@tylertech/forge/keyboard-shortcut';
+import { IKeyboardShortcutComponent, KEYBOARD_SHORTCUT_CONSTANTS, KeyboardShortcutActivateCallback, defineKeyboardShortcutComponent } from '@tylertech/forge/keyboard-shortcut';
 
 interface ITestContext {
   context: IKeyboardShortcutTestContext
@@ -45,7 +45,7 @@ describe('KeyboardShortcutComponent', function(this: ITestContext) {
     const callback = jasmine.createSpy();
     this.context = setupTestContext();
     this.context.component.key = key;
-    this.context.component.activationCallback = callback;
+    this.context.component.activateCallback = callback;
 
     this.context.attach();
 
@@ -544,7 +544,7 @@ describe('KeyboardShortcutComponent', function(this: ITestContext) {
       const callback = jasmine.createSpy();
       this.context = setupTestContext();
       this.context.component.key = key;
-      this.context.component.activationCallback = callback;
+      this.context.component.activateCallback = callback;
       this.context.component.disabled = true;
 
       this.context.attach();

--- a/src/test/spec/keyboard-shortcut/keyboard-shortcut.spec.ts
+++ b/src/test/spec/keyboard-shortcut/keyboard-shortcut.spec.ts
@@ -1,6 +1,6 @@
 import { removeElement } from '@tylertech/forge-core';
 import { tick } from '@tylertech/forge-testing';
-import { IKeyboardShortcutComponent, KEYBOARD_SHORTCUT_CONSTANTS, defineKeyboardShortcutComponent } from '@tylertech/forge/keyboard-shortcut';
+import { IKeyboardShortcutComponent, KEYBOARD_SHORTCUT_CONSTANTS, KeyboardShortcutActivationCallback, defineKeyboardShortcutComponent } from '@tylertech/forge/keyboard-shortcut';
 
 interface ITestContext {
   context: IKeyboardShortcutTestContext
@@ -38,6 +38,19 @@ describe('KeyboardShortcutComponent', function(this: ITestContext) {
     const spy = this.context.spyOnActivateEvent();
     this.context.dispatchKeydownEvent({key});
     expect(spy).toHaveBeenCalled();
+  });
+
+  it('should invoke the callback function on a matching target keydown event', function(this: ITestContext) {
+    const key = 'a';
+    const callback = jasmine.createSpy();
+    this.context = setupTestContext();
+    this.context.component.key = key;
+    this.context.component.activationCallback = callback;
+
+    this.context.attach();
+
+    this.context.dispatchKeydownEvent({key});
+    expect(callback).toHaveBeenCalled();
   });
 
   describe('attributes', function(this: ITestContext) {
@@ -524,6 +537,20 @@ describe('KeyboardShortcutComponent', function(this: ITestContext) {
       const spy = this.context.spyOnActivateEvent();
       this.context.dispatchKeydownEvent({key});
       expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should not invoke the callback when disabled is set to true', function(this: ITestContext) {
+      const key = 'a';
+      const callback = jasmine.createSpy();
+      this.context = setupTestContext();
+      this.context.component.key = key;
+      this.context.component.activationCallback = callback;
+      this.context.component.disabled = true;
+
+      this.context.attach();
+
+      this.context.dispatchKeydownEvent({key});
+      expect(callback).not.toHaveBeenCalled();
     });
 
     it('should connect target element when disabled is set to false', function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N/A

## Describe the new behavior?
This adds a new `activateCallback` property as an alternative to requiring binding to the `keyboard-shortcut-activate` event to use the component. There are some situations where this method could be more concise than adding an event listener.
