### PR TITLE
fix(chip-field): don't propagate click if disabled

### DIFF
--- a/src/lib/chip-field/chip-field-adapter.ts
+++ b/src/lib/chip-field/chip-field-adapter.ts
@@ -74,7 +74,7 @@ export class ChipFieldAdapter extends FieldAdapter implements IChipFieldAdapter 
   
   public tryPropagateClick(target: EventTarget | null): void {
     // We only propagate the click to the input if it originated from our internal input container
-    if (target instanceof HTMLElement && target.matches(CHIP_FIELD_CONSTANTS.selectors.INPUT_CONTAINER)) {
+    if (!this._inputElement.disabled && target instanceof HTMLElement && target.matches(CHIP_FIELD_CONSTANTS.selectors.INPUT_CONTAINER)) {
       this._inputElement?.dispatchEvent(new MouseEvent('click'));
     }
   }

--- a/src/test/spec/chip-field/chip-field.spec.ts
+++ b/src/test/spec/chip-field/chip-field.spec.ts
@@ -1121,6 +1121,37 @@ describe('ChipFieldComponent', function(this: ITestContext) {
 
     });
 
+   describe('Click events', function (this: ITestContext) {
+      it('should emit a click event from the input if the container is clicked', function(this: ITestContext) {
+        this.context = setupTestContext();
+        const clickSpy = jasmine.createSpy('inputClick');
+        const inputEl =  getNativeInput(this.context.component);
+        inputEl.addEventListener('click', clickSpy);
+        
+        const containerEl = getInputContainerElement(this.context.component);
+        containerEl.dispatchEvent(new MouseEvent('mousedown'));
+        
+        expect(clickSpy).toHaveBeenCalledTimes(1);
+        
+        inputEl.removeEventListener('click', clickSpy);
+      });
+
+      it('should not emit a click event from a disabled input if the container is clicked', function(this: ITestContext) {
+        this.context = setupTestContext();
+        const clickSpy = jasmine.createSpy('inputClick');
+        const inputEl =  getNativeInput(this.context.component);
+        inputEl.addEventListener('click', clickSpy);
+        inputEl.disabled = true;
+        
+        const containerEl = getInputContainerElement(this.context.component);
+        containerEl.dispatchEvent(new MouseEvent('mousedown'));
+        
+        expect(clickSpy).not.toHaveBeenCalled();
+        
+        inputEl.removeEventListener('click', clickSpy);
+      });
+    });
+
     describe('Member navigation', function(this: ITestContext) {
       it('should focus the last element when the left arrow key is pressed while the input is focused', function(this: ITestContext) {
         this.context = setupTestContext();
@@ -1216,6 +1247,10 @@ describe('ChipFieldComponent', function(this: ITestContext) {
 
   function getHelperTextElement(component: IChipFieldComponent) {
     return component.querySelector(CHIP_FIELD_CONSTANTS.selectors.HELPER_TEXT) as HTMLElement;
+  }
+
+  function getInputContainerElement(component: IChipFieldComponent) {
+    return getShadowElement(component, CHIP_FIELD_CONSTANTS.selectors.INPUT_CONTAINER) as HTMLDivElement;
   }
 
   function dispatchKeydownEvent(ele: HTMLElement, key: string) {


### PR DESCRIPTION
Fixes #380 

## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? [Y/N]

## Describe the new behavior?
Don't propagate click events on the input container from the input if the input is disabled.

## Additional information
May want to reverify #289

Also going to look into fixing a two other issues, potentially could skip-release here to batch them in a single patch. 
