### PR TITLE
fix(chip-field): don't wrap leading/trailing icons

### DIFF
--- a/src/lib/chip-field/_base.scss
+++ b/src/lib/chip-field/_base.scss
@@ -220,6 +220,7 @@
 @mixin leading-core {
   @include _grid-leading;
   align-self: flex-start;
+  display: flex;
 }
 
 // Trailing

--- a/src/lib/chip-field/_selector.scss
+++ b/src/lib/chip-field/_selector.scss
@@ -160,7 +160,7 @@
 
 @mixin leading {
   // Core
-  ::slotted([slot='leading']) {
+  &--leading .forge-field__leading-container {
     @include base.leading-core;
   }
   // Margin
@@ -171,7 +171,7 @@
 
 @mixin trailing {
   // Core
-  ::slotted([slot='trailing']) {
+  &--trailing .forge-field__trailing-container {
     @include base.trailing-core;
   }
   // Margin

--- a/src/lib/chip-field/chip-field.html
+++ b/src/lib/chip-field/chip-field.html
@@ -1,7 +1,9 @@
 <template>
   <div class="forge-chip-field__wrapper" part="root">
     <div class="forge-chip-field forge-field" part="container">
-      <slot name="leading"></slot>
+      <div class="forge-field__leading-container" part="leading-container">
+        <slot name="leading"></slot>
+      </div>
       <div class="forge-field__label-input-container" part="label-input-container">
         <slot name="label"></slot>
         <div class="forge-field__input-container" part="input-container">
@@ -9,7 +11,9 @@
           <slot></slot>
         </div>
       </div>
-      <slot name="trailing"></slot>
+      <div class="forge-field__trailing-container" part="trailing-container">
+        <slot name="trailing"></slot>
+      </div>
       <div class="forge-field__addon-end-container" part="addon-end-container">
         <slot name="addon-end"></slot>
       </div>

--- a/src/stories/src/components/chip-field/chip-field.mdx
+++ b/src/stories/src/components/chip-field/chip-field.mdx
@@ -145,6 +145,8 @@ Controls the floating state of the label. Call this to manually float the label.
 | `label-input-container`        | The container element around the label and input slot.
 | `input-container`              | The container element around the input slot only.
 | `addon-end-container`          | The container element for the `addon-end` slot.
+| `leading-container`            | The container element for the `leading` slot.
+| `trailing-container`           | The container element for the `trailing` slot.
 
 </PageSection>
 


### PR DESCRIPTION
Fixes #378

## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: n/a (layout)
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Because the CSS grid formatting creates new rows if multiple elements target the same named grid lines, creating a single container to handle multiple leading/trailing icons, and exposing as CSS parts.  An example use case for needing two trailing icons is a Chips Autocomplete, with a dropdown arrow and a button to clear all selected chips.

## Additional information
The `grid-template-columns` existed longer than it was being used, but took effect with #290 fixing the reference to it, which is why this wasn't an issue until v2.14.0.  
