### PR TITLE
fix(autocomplete): fixed a bug where the filter text was not getting removed when the clear button is clicked

### DIFF
--- a/src/dev/pages/autocomplete/autocomplete.ejs
+++ b/src/dev/pages/autocomplete/autocomplete.ejs
@@ -4,6 +4,11 @@
       <forge-text-field>
         <input type="text" id="autocomplete-input" aria-label="Choose state" />
         <label for="autocomplete-input">Choose state</label>
+        <forge-icon-button slot="trailing" dense density-level="2">
+          <button type="button" data-forge-autocomplete-clear>
+            <forge-icon name="close"></forge-icon>
+          </button>
+        </forge-icon-button>
         <forge-icon slot="trailing" name="arrow_drop_down" data-forge-dropdown-icon></forge-icon>
       </forge-text-field>
     </forge-autocomplete>

--- a/src/lib/autocomplete/autocomplete-foundation.ts
+++ b/src/lib/autocomplete/autocomplete-foundation.ts
@@ -178,6 +178,7 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
   }
 
   private _onClear(evt: MouseEvent): void {
+    this._filterText = '';
     this._clearValue();
     this._adapter.setSelectedText(this._getSelectedText());
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The filter text will now be cleared when using the built-in clear functionality, and this will be properly reflected in the highlighted text of the dropdown.

## Additional information
Fixes #389 
