### PR TITLE
feat(autocomplete): added new `forceFilter()` method to allow for dynamically updating the options of an autocomplete

### DIFF
--- a/src/lib/autocomplete/autocomplete-constants.ts
+++ b/src/lib/autocomplete/autocomplete-constants.ts
@@ -77,3 +77,7 @@ export interface IAutocompletePopupConfiguration {
 export interface IAutocompleteSelectEventData<T = any> {
   value: T;
 }
+
+export interface IAutocompleteForceFilterOptions {
+  preserveValue: boolean;
+}

--- a/src/lib/autocomplete/autocomplete-foundation.ts
+++ b/src/lib/autocomplete/autocomplete-foundation.ts
@@ -4,7 +4,7 @@ import { IListItemComponent } from '../list';
 import { IListDropdownConfig, IListDropdownOption, ListDropdownAsyncStyle, ListDropdownFooterBuilder, ListDropdownHeaderBuilder, ListDropdownOptionBuilder } from '../list-dropdown';
 import { IListDropdownAwareFoundation, ListDropdownAwareFoundation } from '../list-dropdown/list-dropdown-aware-foundation';
 import { IAutocompleteAdapter } from './autocomplete-adapter';
-import { AutocompleteFilterCallback, AutocompleteMode, AutocompleteOptionBuilder, AutocompleteSelectedTextBuilder, AUTOCOMPLETE_CONSTANTS, IAutocompleteOption, IAutocompleteOptionGroup, IAutocompleteSelectEventData } from './autocomplete-constants';
+import { AutocompleteFilterCallback, AutocompleteMode, AutocompleteOptionBuilder, AutocompleteSelectedTextBuilder, AUTOCOMPLETE_CONSTANTS, IAutocompleteForceFilterOptions, IAutocompleteOption, IAutocompleteOptionGroup, IAutocompleteSelectEventData } from './autocomplete-constants';
 import { getSelectedOption, isOptionType, optionEqualPredicate, OptionType } from './autocomplete-utils';
 
 export interface IAutocompleteFoundation extends IListDropdownAwareFoundation {
@@ -25,6 +25,7 @@ export interface IAutocompleteFoundation extends IListDropdownAwareFoundation {
   matchKey: string | null | undefined;
   appendOptions(options: IAutocompleteOption[] | IAutocompleteOptionGroup[]): void;
   beforeValueChange: (value: any) => boolean | Promise<boolean>;
+  forceFilter(opts: IAutocompleteForceFilterOptions): void;
 }
 
 /**
@@ -115,6 +116,23 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     if (this._isDropdownOpen) {
       this._closeDropdown();
     }
+  }
+
+  public async forceFilter({ preserveValue }: IAutocompleteForceFilterOptions): Promise<void> {
+    // Clear any existing options since they are expected to no longer be valid
+    this._options = [];
+
+    // Execute the filter callback to fetch new options if the consumer has provided any.
+    // This allows us to update the current value(s) with new label(s) if there are any matches
+    await this._executeFilter(true, true);
+
+    // Edge case, but if the consumer has a need to preserve the existing selection if it doesn't exist in the new options, this will support that
+    if (preserveValue) {
+      this._options.push(...this._selectedOptions as IAutocompleteOption<any>[] & IAutocompleteOptionGroup[]);
+    }
+
+    // This will update our current state, but it's expected that consumers will manage their own values so it's likely that this will be called again soon
+    this._applyValue(this._values);
   }
 
   private _attachListeners(): void {

--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -9,7 +9,7 @@ import { PopupComponent } from '../popup';
 import { SkeletonComponent } from '../skeleton';
 import { TextFieldComponent } from '../text-field';
 import { AutocompleteAdapter } from './autocomplete-adapter';
-import { AutocompleteFilterCallback, AutocompleteMode, AutocompleteOptionBuilder, AutocompleteSelectedTextBuilder, AUTOCOMPLETE_CONSTANTS, IAutocompleteOption, IAutocompleteOptionGroup, IAutocompleteSelectEventData } from './autocomplete-constants';
+import { AutocompleteFilterCallback, AutocompleteMode, AutocompleteOptionBuilder, AutocompleteSelectedTextBuilder, AUTOCOMPLETE_CONSTANTS, IAutocompleteForceFilterOptions, IAutocompleteOption, IAutocompleteOptionGroup, IAutocompleteSelectEventData } from './autocomplete-constants';
 import { AutocompleteFoundation } from './autocomplete-foundation';
 
 import template from './autocomplete.html';
@@ -36,6 +36,7 @@ export interface IAutocompleteComponent extends IListDropdownAware {
   appendOptions(options: IAutocompleteOption[] | IAutocompleteOptionGroup[]): void;
   openDropdown(): void;
   closeDropdown(): void;
+  forceFilter(opts?: IAutocompleteForceFilterOptions): void;
 }
 
 declare global {
@@ -231,5 +232,13 @@ export class AutocompleteComponent extends ListDropdownAware implements IAutocom
   /** Closes the dropdown. */
   public closeDropdown(): void {
     this.open = false;
+  }
+
+  /**
+   * Forces the filter callback to be executed to update the current selection state with new options.
+   * @param opts
+   */
+  public forceFilter(opts: IAutocompleteForceFilterOptions = { preserveValue: false }): void {
+    this._foundation.forceFilter(opts);
   }
 }

--- a/src/stories/src/components/autocomplete/autocomplete.mdx
+++ b/src/stories/src/components/autocomplete/autocomplete.mdx
@@ -173,6 +173,14 @@ Closes the dropdown.
 
 </MethodDef>
 
+<MethodDef name="forceFilter(opts: IAutocompleteForceFilterOptions): void;">
+
+Forces the filter callback to be executed to update the current selection state with new options.
+
+Call this when you need to update the options of an autocomplete dynamically by forcing the filter callback to execute and clear any existing options.
+
+</MethodDef>
+
 </PageSection>
 
 ---
@@ -325,6 +333,14 @@ interface IAutocompletePopupConfiguration {
   syncPopupWidth: boolean;
   listener: (value: string) => void;
   scrollEndListener: () => void;
+}
+```
+
+### IAutocompleteForceFilterOptions
+
+```ts
+interface IAutocompleteForceFilterOptions {
+  preserveValue: boolean;
 }
 ```
 

--- a/src/test/spec/autocomplete/autocomplete.spec.ts
+++ b/src/test/spec/autocomplete/autocomplete.spec.ts
@@ -1528,7 +1528,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
         expect(this.context.component.value).toBe(listItems[2].value);
       });
 
-       it('should pass in to-be new value in beforeValueChange', async function(this: ITestContext) {
+      it('should pass in to-be new value in beforeValueChange', async function(this: ITestContext) {
         this.context = setupTestContext(true);
         let newValue = '';
         this.context.component.filter = () => DEFAULT_FILTER_OPTIONS;
@@ -1545,6 +1545,79 @@ describe('AutocompleteComponent', function(this: ITestContext) {
         await tick();
 
         expect(newValue).toBe(listItems[2].value);
+      });
+
+      it('should force filter callback to execute and update selected value', async function(this: ITestContext) {
+        this.context = setupTestContext(true);
+        this.context.component.filter = () => DEFAULT_FILTER_OPTIONS;
+
+        _triggerDropdownClick(this.context.input);
+
+        await tick();
+        const listItems = _getListItems(this.context.component.popupElement);
+        _clickListItem(2, this.context.component.popupElement);
+        await tick();
+
+        expect(this.context.component.value).toBe(listItems[2].value);
+
+        this.context.component.filter = () => [
+          { label: `${DEFAULT_FILTER_OPTIONS[2].label} UPDATED`, value: DEFAULT_FILTER_OPTIONS[2].value},
+          { label: 'New', value: 'new' }
+        ];
+        this.context.component.forceFilter();
+
+        await tick();
+
+        expect(this.context.input.value).toBe(`${DEFAULT_FILTER_OPTIONS[2].label} UPDATED`);
+        expect(this.context.component.value).toBe(DEFAULT_FILTER_OPTIONS[2].value);
+      });
+
+      it('should force filter callback to execute and remove selected value', async function(this: ITestContext) {
+        this.context = setupTestContext(true);
+        this.context.component.filter = () => DEFAULT_FILTER_OPTIONS;
+
+        _triggerDropdownClick(this.context.input);
+
+        await tick();
+        const listItems = _getListItems(this.context.component.popupElement);
+        _clickListItem(2, this.context.component.popupElement);
+        await tick();
+
+        expect(this.context.component.value).toBe(listItems[2].value);
+
+        this.context.component.filter = () => [
+          { label: 'New', value: 'new' }
+        ];
+        this.context.component.forceFilter();
+
+        await tick();
+
+        expect(this.context.input.value).toBe('');
+        expect(this.context.component.value).toBe(DEFAULT_FILTER_OPTIONS[2].value);
+      });
+
+      it('should force filter callback to execute and preserve selected value if not present in new filtered options', async function(this: ITestContext) {
+        this.context = setupTestContext(true);
+        this.context.component.filter = () => DEFAULT_FILTER_OPTIONS;
+
+        _triggerDropdownClick(this.context.input);
+
+        await tick();
+        const listItems = _getListItems(this.context.component.popupElement);
+        _clickListItem(2, this.context.component.popupElement);
+        await tick();
+
+        expect(this.context.component.value).toBe(listItems[2].value);
+
+        this.context.component.filter = () => [
+          { label: 'New', value: 'new' }
+        ];
+        this.context.component.forceFilter({ preserveValue: true });
+
+        await tick();
+
+        expect(this.context.input.value).toBe(DEFAULT_FILTER_OPTIONS[2].label);
+        expect(this.context.component.value).toBe(DEFAULT_FILTER_OPTIONS[2].value);
       });
     });
   });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Added a new `forceFilter()` method to the element that will allow for a consumer to call it when their underlying options have changed. This will usually coincide with a `value` update as well, so calling `forceUpdate()` will force the component to throw any old options it has cached and synchronize its selected value with the new options (as long as the consumer has also provided the new options to their filter callback of course).

There is an edge case here where the value of the autocomplete does not have a matching option in the new options from the filter callback. The label text in the input will be lost by default, but developers can call `forceUpdate({ preserveValue: true });` to ensure that the existing selected option will not be lost.

## Additional information
Closes #381
