### PR TITLE
feat(calendar): fixed a bug where an exception was being thrown if min/max was set and caused the current month to have no selectable dates. The calendar will now automatically move to the closest month with a selectable date

### DIFF
--- a/src/lib/calendar/calendar-foundation.ts
+++ b/src/lib/calendar/calendar-foundation.ts
@@ -1605,6 +1605,10 @@ export class CalendarFoundation implements ICalendarFoundation {
   private _applyMin(): void {
     this._adapter.toggleHostAttribute(CALENDAR_CONSTANTS.attributes.MIN, !!this._minAttribute, this._minAttribute as string);
 
+    if (this._min && this._min.getMonth() > this._month) {
+      this._month = this._min.getMonth();
+    }
+
     if (this._isInitialized) {
       this._applyDisabledDates();
 
@@ -1619,6 +1623,10 @@ export class CalendarFoundation implements ICalendarFoundation {
 
   private _applyMax(): void {
     this._adapter.toggleHostAttribute(CALENDAR_CONSTANTS.attributes.MAX, !!this._maxAttribute, this._maxAttribute as string);
+
+    if (this._max && this._max.getMonth() < this._month) {
+      this._month = this._max.getMonth();
+    }
 
     if (this._isInitialized) {
       this._applyDisabledDates();

--- a/src/test/spec/date-picker/date-picker.spec.ts
+++ b/src/test/spec/date-picker/date-picker.spec.ts
@@ -77,6 +77,30 @@ describe('DatePickerComponent', function(this: ITestContext) {
       expect((<Date>calendar.value).toDateString()).toEqual(date.toDateString());
     });
 
+    it('should open calendar in month of min date if min is after current month', function(this: ITestContext) {
+      this.context = setupTestContext(false);
+      const date = new Date();
+      this.context.component.min = new Date(date.getFullYear(), date.getMonth() + 1, 1);
+      this.context.append();
+
+      openPopup(this.context.component);
+      const calendar = getCalendar(this.context.component);
+
+      expect(calendar.month).toEqual(date.getMonth() + 1);
+    });
+
+    it('should open calendar in month of max date if max is before current month', function(this: ITestContext) {
+      this.context = setupTestContext(false);
+      const date = new Date();
+      this.context.component.max = new Date(date.getFullYear(), date.getMonth() - 1, 1);
+      this.context.append();
+
+      openPopup(this.context.component);
+      const calendar = getCalendar(this.context.component);
+
+      expect(calendar.month).toEqual(date.getMonth() - 1);
+    });
+
     it('should automatically render a toggle button with a Forge text-field component', function(this: ITestContext) {
       this.context = setupTestContext(false, true, false);
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The calendar will now default to a month with selectable dates if min/max is set that doesn't allow dates within the current month to be selected.

## Additional information
Fixes #387 
