### PR TITLE
fix(paginator): fixed a bug where focus was lost when disabling the page buttons dynamically

### DIFF
--- a/src/lib/paginator/paginator-adapter.ts
+++ b/src/lib/paginator/paginator-adapter.ts
@@ -185,6 +185,7 @@ export class PaginatorAdapter extends BaseAdapter<IPaginatorComponent> implement
   }
 
   public disableFirstPageButton(): void {
+    this._handleFocusMove('first');
     this._firstPageButton.setAttribute('disabled', 'disabled');
   }
 
@@ -193,6 +194,7 @@ export class PaginatorAdapter extends BaseAdapter<IPaginatorComponent> implement
   }
 
   public disablePreviousPageButton(): void {
+    this._handleFocusMove('previous');
     this._previousPageButton.setAttribute('disabled', 'disabled');
   }
 
@@ -201,6 +203,7 @@ export class PaginatorAdapter extends BaseAdapter<IPaginatorComponent> implement
   }
 
   public disableNextPageButton(): void {
+    this._handleFocusMove('next');
     this._nextPageButton.setAttribute('disabled', 'disabled');
   }
 
@@ -209,6 +212,7 @@ export class PaginatorAdapter extends BaseAdapter<IPaginatorComponent> implement
   }
 
   public disablePageSizeSelect(): void {
+    this._handleFocusMove('page-size');
     this._pageSizeSelect.setAttribute('disabled', 'disabled');
   }
 
@@ -225,6 +229,7 @@ export class PaginatorAdapter extends BaseAdapter<IPaginatorComponent> implement
   }
 
   public disableLastPageButton(): void {
+    this._handleFocusMove('last');
     this._lastPageButton.setAttribute('disabled', 'disabled');
   }
 
@@ -254,6 +259,60 @@ export class PaginatorAdapter extends BaseAdapter<IPaginatorComponent> implement
       default:
         addClass(PAGINATOR_CONSTANTS.classes.ALIGNMENT_SPACE_BETWEEN, this._root);
         break;
+    }
+  }
+
+  private _handleFocusMove(from: 'first' | 'last' | 'previous' | 'next' | 'page-size'): void {
+    switch (from) {
+      case 'first':
+        this._tryFocus([
+          this._nextPageButton,
+          this._lastPageButton,
+          this._previousPageButton,
+          this._pageSizeSelect
+        ]);
+        break;
+      case 'last':
+        this._tryFocus([
+          this._previousPageButton,
+          this._firstPageButton,
+          this._nextPageButton,
+          this._pageSizeSelect
+        ]);
+        break;
+      case 'previous':
+        this._tryFocus([
+          this._nextPageButton,
+          this._lastPageButton,
+          this._firstPageButton,
+          this._pageSizeSelect
+        ]);
+        break;
+      case 'next':
+        this._tryFocus([
+          this._previousPageButton,
+          this._firstPageButton,
+          this._lastPageButton,
+          this._pageSizeSelect
+        ]);
+        break;
+      case 'page-size':
+        this._tryFocus([
+          this._nextPageButton,
+          this._lastPageButton,
+          this._firstPageButton,
+          this._previousPageButton
+        ]);
+        break;
+    }
+  }
+
+  private _tryFocus(elements: Array<HTMLButtonElement | ISelectComponent>): void {
+    for (const el of elements) {
+      if (el && el.isConnected && !el.disabled) {
+        el.focus();
+        return;
+      }
     }
   }
 }

--- a/src/test/spec/paginator/paginator.spec.ts
+++ b/src/test/spec/paginator/paginator.spec.ts
@@ -114,6 +114,46 @@ describe('PaginatorComponent', function(this: ITestContext) {
       expect(this.context.nextPageButton.hasAttribute('disabled')).toBe(true);
     });
 
+    it('should move focus to previous page button when next page button is disabled', function(this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.paginator.total = 100;
+      this.context.paginator.pageIndex = 2;
+      this.context.nextPageButton.click();
+
+      expect(this.context.nextPageButton.hasAttribute('disabled')).toBe(true);
+      expect(this.context.previousPageButton.matches(':focus')).toBe(true);
+    });
+
+    it('should move focus to next page button when previous page button is disabled', function(this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.paginator.total = 100;
+      this.context.paginator.pageIndex = 1;
+      this.context.previousPageButton.click();
+
+      expect(this.context.previousPageButton.hasAttribute('disabled')).toBe(true);
+      expect(this.context.nextPageButton.matches(':focus')).toBe(true);
+    });
+
+    it('should move focus to next page button when first page button is disabled', function(this: ITestContext) {
+      this.context = setupTestContext(true, true);
+      this.context.paginator.total = 100;
+      this.context.paginator.pageIndex = 1;
+      this.context.firstPageButton.click();
+
+      expect(this.context.firstPageButton.hasAttribute('disabled')).toBe(true);
+      expect(this.context.nextPageButton.matches(':focus')).toBe(true);
+    });
+
+    it('should move focus to previous page button when last page button is disabled', function(this: ITestContext) {
+      this.context = setupTestContext(true, true);
+      this.context.paginator.total = 100;
+      this.context.paginator.pageIndex = 2;
+      this.context.lastPageButton.click();
+
+      expect(this.context.lastPageButton.hasAttribute('disabled')).toBe(true);
+      expect(this.context.previousPageButton.matches(':focus')).toBe(true);
+    });
+
     it('should emit change event when clicking next page button', function(this: ITestContext) {
       this.context = setupTestContext();
       this.context.paginator.total = 100;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The paginator will now attempt to keep focus within itself (if it can) by explicitly moving focus to the next available focusable element when disabling the action that the user just took. For example, if clicking the "next page" button to reach the end of the data set, the focus will attempt to move to the "previous page" button. There are fall backs for each action in case the expected next action is not enabled as well to account for the various states that this component can be in.

## Additional information
Closes #397 
