### PR TITLE
fix(text-field): fixed a bug where the label was not being initialized properly when toggling density dynamically

### DIFF
--- a/src/lib/field/field-foundation.ts
+++ b/src/lib/field/field-foundation.ts
@@ -121,8 +121,9 @@ export class FieldFoundation {
       if (this._isInitialized) {
         this._applyDensity();
 
-        // We only need to initialize the label if we are changing from dense to non-dense or vice versa
-        if (this._density === 'dense' || prevDensity === 'dense') {
+        if (this._density === 'dense') {
+          this._destroyFloatingLabel({ cancelFloat: true });
+        } else if (prevDensity === 'dense') {
           this._initializeLabel();
         }
       }
@@ -241,20 +242,24 @@ export class FieldFoundation {
   }
 
   protected _initializeLabel(): void {
-    if (this._floatingLabel) {
-      this._floatingLabel.destroy();
-    }
+    this._floatingLabel?.destroy();
     this._adapter.detectLabel();
+    
     if (this._adapter.hasLabel() && this._density !== 'dense') {
       this._floatingLabel = this._adapter.initializeFloatingLabel();
       this._adapter.ensureLabelOrder();
       this.floatLabel(this._floatLabelType === 'always' || this._adapter.fieldHasValue() || this._adapter.hasPlaceholder());
       this._adapter.setRootClass(FIELD_CONSTANTS.classes.LABEL);
     } else {
-      this._adapter.removeHostAttribute(FIELD_CONSTANTS.attributes.HOST_LABEL_FLOATING);
-      this._adapter.removeRootClass(FIELD_CONSTANTS.classes.LABEL);
-      this._floatingLabel = undefined;
+      this._destroyFloatingLabel();
     }
+  }
+
+  private _destroyFloatingLabel({ cancelFloat = false } = {}): void {
+    this._adapter.removeHostAttribute(FIELD_CONSTANTS.attributes.HOST_LABEL_FLOATING);
+    this._adapter.removeRootClass(FIELD_CONSTANTS.classes.LABEL);
+    this._floatingLabel?.destroy({ cancelFloat });
+    this._floatingLabel = undefined;
   }
 
   protected _detectLeadingContent(): void {

--- a/src/lib/field/field-foundation.ts
+++ b/src/lib/field/field-foundation.ts
@@ -115,11 +115,16 @@ export class FieldFoundation {
   }
   public set density(value: FieldDensityType) {
     if (this._density !== value) {
+      const prevDensity = this._density;
       this._density = value;
 
       if (this._isInitialized) {
         this._applyDensity();
-        this._initializeLabel();
+
+        // We only need to initialize the label if we are changing from dense to non-dense or vice versa
+        if (this._density === 'dense' || prevDensity === 'dense') {
+          this._initializeLabel();
+        }
       }
 
       this._adapter.setHostAttribute(FIELD_CONSTANTS.attributes.DENSITY, this._density.toString());

--- a/src/lib/floating-label/floating-label.ts
+++ b/src/lib/floating-label/floating-label.ts
@@ -5,7 +5,7 @@ export interface IFloatingLabel {
   isFloating: boolean;
   float(float: boolean, alwaysFloat?: boolean): void;
   getWidth(): number;
-  destroy(): void;
+  destroy(opts?: { cancelFloat?: boolean }): void;
 }
 
 export class FloatingLabel implements IFloatingLabel {
@@ -21,8 +21,8 @@ export class FloatingLabel implements IFloatingLabel {
     return this._foundation.isFloating;
   }
 
-  public destroy(): void {
-    this._foundation.disconnect();
+  public destroy({ cancelFloat = false } = {}): void {
+    this._foundation.disconnect({ cancelFloat });
     this._labelElement = undefined as any;
   }
 

--- a/src/test/spec/text-field/text-field.spec.ts
+++ b/src/test/spec/text-field/text-field.spec.ts
@@ -184,6 +184,34 @@ describe('TextFieldComponent', function(this: ITestContext) {
       expectFloatingLabelState(this.context, true);
     });
 
+    it('should float label when value is set after changing from dense to roomy', async function(this: ITestContext) {
+      this.context = setupTestContext(true, { density: 'dense' });
+
+      await tick();
+      this.context.input.value = 'test';
+      await floatTick();
+      
+      this.context.component.density = 'roomy';
+      await floatTick();
+
+      expect(this.context.component.hasAttribute(FIELD_CONSTANTS.attributes.HOST_LABEL_FLOATING)).toBeTrue();
+      expectFloatingLabelState(this.context, true);
+    });
+
+    it('should float label when value is set after changing from dense to default', async function(this: ITestContext) {
+      this.context = setupTestContext(true, { density: 'dense' });
+
+      await tick();
+      this.context.input.value = 'test';
+      await floatTick();
+      
+      this.context.component.density = 'default';
+      await floatTick();
+
+      expect(this.context.component.hasAttribute(FIELD_CONSTANTS.attributes.HOST_LABEL_FLOATING)).toBeTrue();
+      expectFloatingLabelState(this.context, true);
+    });
+
     it('should float label when invoked programmatically', async function(this: ITestContext) {
       this.context = setupTestContext();
       await tick();

--- a/src/test/utils/floating-label-utils.ts
+++ b/src/test/utils/floating-label-utils.ts
@@ -6,14 +6,14 @@ export interface IFloatingLabelContext {
 }
 
 export function expectFloatingLabelState(
-  instance: IFloatingLabelContext, 
+  instance: IFloatingLabelContext,
   isFloating: boolean
 ): void {
   testFloatingLabelState(instance.label, isFloating);
 }
 
 export function testFloatingLabelState(
-  labelElement: HTMLLabelElement, 
+  labelElement: HTMLLabelElement,
   isFloating: boolean
 ): void {
   expect(labelElement.classList.contains(FLOATING_LABEL_CONSTANTS.classes.FLOAT_ABOVE)).toBe(isFloating);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The floating label was being reinitialized when it didn't need to be when switching between densities. This was causing the animation of the floating label to not execute. This change ensures that the floating label only reinitializes when switching between dense and non-dense densities.

A minor bug was also discovered during testing when switching to the "dense" `density` where the `<label>` element was incorrectly receiving floating label CSS classes after the `FloatingLabel` instance was destroyed (due to the `requestAnimationFrame()` queue). Another fix was added to ensure that when the rAF calls were cancelled when the `FloatingLabel` instance is destroyed upon switching to "dense" state.

## Additional information
Fixes #401 
