### PR TITLE
fix(expansion-panel): fixed a bug where calling `setOpenImmediate()` while an expand/collapse animation is already running would not cancel the active animation

### DIFF
--- a/src/lib/expansion-panel/expansion-panel-adapter.ts
+++ b/src/lib/expansion-panel/expansion-panel-adapter.ts
@@ -20,6 +20,7 @@ export class ExpansionPanelAdapter extends BaseAdapter<IExpansionPanelComponent>
   private _headerElement: HTMLElement;
   private _contentElement: HTMLElement;
   private _headerSlotElement: HTMLSlotElement;
+  private _activeAnimationFrame: number | undefined;
 
   constructor(component: IExpansionPanelComponent) {
     super(component);
@@ -114,8 +115,9 @@ export class ExpansionPanelAdapter extends BaseAdapter<IExpansionPanelComponent>
         this._contentElement.style.transition = EXPANSION_PANEL_CONSTANTS.strings.EXPANSION_VERTICAL_TRANSITION;
       }
 
-      window.requestAnimationFrame(() => {
-        window.requestAnimationFrame(() => {
+      this._activeAnimationFrame = window.requestAnimationFrame(() => {
+        this._activeAnimationFrame = window.requestAnimationFrame(() => {
+          this._activeAnimationFrame = undefined;
           if (opening) {
             if (orientation === EXPANSION_PANEL_CONSTANTS.strings.ORIENTATION_HORIZONTAL) {
               this._contentElement.style.width = `${this._contentElement.scrollWidth}px`;
@@ -142,6 +144,11 @@ export class ExpansionPanelAdapter extends BaseAdapter<IExpansionPanelComponent>
         });
       });
     } else {
+      if (this._activeAnimationFrame) {
+        window.cancelAnimationFrame(this._activeAnimationFrame);
+        this._activeAnimationFrame = undefined;
+      }
+
       this._contentElement.style.removeProperty('transition');
       if (opening) {
         if (orientation === EXPANSION_PANEL_CONSTANTS.strings.ORIENTATION_HORIZONTAL) {

--- a/src/test/spec/expansion-panel/expansion-panel.spec.ts
+++ b/src/test/spec/expansion-panel/expansion-panel.spec.ts
@@ -373,6 +373,22 @@ describe('ExpansionPanelComponent', function(this: ITestContext) {
       expect(getInternalPanelContent(this.context.component).clientHeight).toBe(0);
     });
 
+    it('should close immediately if set while active animation is running', async function(this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.append();
+
+      await tick();
+
+      this.context.component.open = true;
+      this.context.component.setOpenImmediate(true);
+
+      await tick();
+      await tick();
+
+      expect(this.context.component.open).toBeTrue();
+      expect(getInternalPanelContent(this.context.component).style.height).toBe('');
+    });
+
     it('should close immediately horizontal', async function(this: ITestContext) {
       this.context = setupTestContext();
       this.context.component.useAnimations = false;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The expansion panel will now cancel any active expand/collapse animations if the open state is changed while the previous animation was executing asynchronously.

## Additional information
This was found when an application was setting the open state to `true` shortly after initialization, then calling `setOpenImmediate(true)` to force the open state without animation, but due to the async nature of `requestAnimationFrame()` the result of the first open animation was running after the open state was forced open causing the internal content element to receive a static `height` style incorrectly.
