### PR TITLE
fix(select): fixed a bug where options that contain leading whitespace could not be selected via keyboard filtering

### DIFF
--- a/src/lib/select/core/base-select-foundation.ts
+++ b/src/lib/select/core/base-select-foundation.ts
@@ -524,7 +524,9 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
     }, 300);
     this._options = this._adapter.getOptions();
     // TODO: Enhance this to cycle through closest matches (see the native select)
-    const matchedOption = this._flatOptions.find(option => !option.disabled && option.label.toLowerCase().startsWith(this._filterString.toLowerCase()));
+    const matchedOption = this._flatOptions.find(({ disabled, label }) => {
+      return !disabled && label.trim().toLowerCase().startsWith(this._filterString.trim().toLowerCase());
+    });
     if (matchedOption) {
       const optionIndex = this._flatOptions.indexOf(matchedOption);
       if (this._open) {

--- a/src/test/spec/select/select.spec.ts
+++ b/src/test/spec/select/select.spec.ts
@@ -833,6 +833,21 @@ describe('SelectComponent', function(this: ITestContext) {
       _expectPopupVisibility(this.context.component.popupElement, true);
     });
 
+    it('should highlight first match when filtering while popup is open with leading whitespace', async function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      const firstOption = this.context.component.querySelector('forge-option:first-child') as IOptionComponent;
+      firstOption.textContent = '   With Whitespace   ';
+      await tick();
+      
+      await _triggerPopupOpen(this.context.component);
+      
+      _sendFilterKey(this.context.component, 'w', 87);
+      await timer();
+
+      _expectActiveOption(this.context.component.popupElement, 0);
+      _expectPopupVisibility(this.context.component.popupElement, true);
+    });
+
     it('should highlight first match when filtering with uppercase characters', async function(this: ITestContext) {
       this.context = setupTestContext(true);
       await tick();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Options that contain leading whitespace will now be properly included in the keyboard filtering functionality.

## Additional information
Fixes #413 
