### PR TITLE
fix(paginator): fix focus management to properly account for state updates while the element is already focused

### DIFF
--- a/src/lib/paginator/paginator-adapter.ts
+++ b/src/lib/paginator/paginator-adapter.ts
@@ -41,7 +41,8 @@ export interface IPaginatorAdapter extends IBaseAdapter {
   enableLastPageButton(): void;
   setAlternative(alternative: boolean): void;
   setAlignment(alignment: PaginatorAlternativeAlignment): void;
-  handleFocusMove(from: PaginatorFieldIdentifier): void;
+  hasFocus(): boolean;
+  handleFocusMove(from?: PaginatorFieldIdentifier | null, options?: FocusOptions): void;
 }
 
 /**
@@ -260,8 +261,12 @@ export class PaginatorAdapter extends BaseAdapter<IPaginatorComponent> implement
     }
   }
 
-  public handleFocusMove(from: PaginatorFieldIdentifier): void {
-    if (!this._component.matches(':focus')) {
+  public hasFocus(): boolean {
+    return this._component.matches(':focus');
+  }
+
+  public handleFocusMove(from?: PaginatorFieldIdentifier, options?: FocusOptions): void {
+    if (from && !this.hasFocus()) {
       return; // We can only move focus elsewhere within the element if the element already contains focus
     }
 
@@ -272,7 +277,7 @@ export class PaginatorAdapter extends BaseAdapter<IPaginatorComponent> implement
           this._lastPageButton,
           this._previousPageButton,
           this._pageSizeSelect
-        ]);
+        ], options);
         break;
       case 'last':
         this._tryFocus([
@@ -280,7 +285,7 @@ export class PaginatorAdapter extends BaseAdapter<IPaginatorComponent> implement
           this._firstPageButton,
           this._nextPageButton,
           this._pageSizeSelect
-        ]);
+        ], options);
         break;
       case 'previous':
         this._tryFocus([
@@ -296,7 +301,7 @@ export class PaginatorAdapter extends BaseAdapter<IPaginatorComponent> implement
           this._firstPageButton,
           this._lastPageButton,
           this._pageSizeSelect
-        ]);
+        ], options);
         break;
       case 'page-size':
         this._tryFocus([
@@ -304,15 +309,25 @@ export class PaginatorAdapter extends BaseAdapter<IPaginatorComponent> implement
           this._lastPageButton,
           this._firstPageButton,
           this._previousPageButton
-        ]);
+        ], options);
+        break;
+      default:
+        this._tryFocus([
+          this._firstPageButton,
+          this._previousPageButton,
+          this._nextPageButton,
+          this._lastPageButton,
+          this._pageSizeSelect
+        ], options);
         break;
     }
   }
 
-  private _tryFocus(elements: Array<HTMLButtonElement | ISelectComponent>): void {
+  private _tryFocus(elements: Array<HTMLButtonElement | ISelectComponent>, options?: FocusOptions): void {
+    const preventScroll = typeof options?.preventScroll === 'boolean' ? options.preventScroll : true;
     for (const el of elements) {
       if (el && el.isConnected && !el.disabled) {
-        el.focus();
+        el.focus({ ...options, preventScroll });
         return;
       }
     }

--- a/src/lib/paginator/paginator-foundation.ts
+++ b/src/lib/paginator/paginator-foundation.ts
@@ -10,6 +10,7 @@ export interface IPaginatorFoundation extends ICustomElementFoundation {
   total: number;
   pageSizeOptions: number[] | boolean;
   pageSizeLabel: string;
+  focus(options?: FocusOptions): void;
 }
 
 export class PaginatorFoundation {
@@ -54,6 +55,10 @@ export class PaginatorFoundation {
     this._detachListeners();
   }
 
+  public focus(options?: FocusOptions): void {
+    this._adapter.handleFocusMove(null, options);
+  }
+
   private _attachListeners(): void {
     this._adapter.attachPageSizeChangeListener(this._pageSizeListener);
     this._adapter.attachFirstPageListener(this._firstPageListener);
@@ -80,7 +85,7 @@ export class PaginatorFoundation {
     const firstPage = 0;
     const canPage = this._emitChangeEvent(PAGINATOR_CONSTANTS.strings.FIRST_PAGE, { pageIndex: firstPage });
     if (canPage) {
-      this._applyPageIndex(firstPage, { fromField: 'first' });
+      this._applyPageIndex(firstPage);
     }
   }
 
@@ -94,7 +99,7 @@ export class PaginatorFoundation {
     const prevPage = this._pageIndex - 1;
     const canPage = this._emitChangeEvent(PAGINATOR_CONSTANTS.strings.PREVIOUS_PAGE, { pageIndex: prevPage });
     if (canPage) {
-      this._applyPageIndex(prevPage, { fromField: 'previous' });
+      this._applyPageIndex(prevPage);
     }
   }
 
@@ -108,7 +113,7 @@ export class PaginatorFoundation {
     const nextPage = this._pageIndex + 1;
     const canPage = this._emitChangeEvent(PAGINATOR_CONSTANTS.strings.NEXT_PAGE, { pageIndex: nextPage });
     if (canPage) {
-      this._applyPageIndex(nextPage, { fromField: 'next' });
+      this._applyPageIndex(nextPage);
     }
   }
 
@@ -122,7 +127,7 @@ export class PaginatorFoundation {
     const lastPage = this._getMaxPages();
     const canPage = this._emitChangeEvent(PAGINATOR_CONSTANTS.strings.LAST_PAGE, { pageIndex: lastPage });
     if (canPage) {
-      this._applyPageIndex(lastPage, { fromField: 'last' });
+      this._applyPageIndex(lastPage);
     }
   }
 
@@ -132,7 +137,7 @@ export class PaginatorFoundation {
     const pageSize = Number(evt.detail);
     const canPage = this._emitChangeEvent(PAGINATOR_CONSTANTS.strings.PAGE_SIZE, { pageIndex: 0, pageSize });
     if (canPage) {
-      this._applyPageIndex(0, { fromField: 'page-size' });
+      this._applyPageIndex(0);
       this._applyPageSize(pageSize);
     } else {
       evt.preventDefault();
@@ -162,36 +167,36 @@ export class PaginatorFoundation {
     this._adapter.setRangeLabel(this._rangeLabel);
   }
 
-  private _syncInteractionState(fromField: PaginatorFieldIdentifier | null = null): void {
+  private _syncInteractionState(): void {
     this._adapter.enableFirstPageButton();
     this._adapter.enablePreviousPageButton();
     this._adapter.enableNextPageButton();
     this._adapter.enableLastPageButton();
 
     if (!this._hasFirstPage()) {
-      if (fromField) {
-        this._adapter.handleFocusMove(fromField);
+      if (this._adapter.hasFocus()) {
+        this._adapter.handleFocusMove('first');
       }
       this._adapter.disableFirstPageButton();
     }
 
     if (!this._hasPreviousPage()) {
-      if (fromField) {
-        this._adapter.handleFocusMove(fromField);
+      if (this._adapter.hasFocus()) {
+        this._adapter.handleFocusMove('previous');
       }
       this._adapter.disablePreviousPageButton();
     }
 
     if (!this._hasNextPage()) {
-      if (fromField) {
-        this._adapter.handleFocusMove(fromField);
+      if (this._adapter.hasFocus()) {
+        this._adapter.handleFocusMove('next');
       }
       this._adapter.disableNextPageButton();
     }
 
     if (!this._hasLastPage()) {
-      if (fromField) {
-        this._adapter.handleFocusMove(fromField);
+      if (this._adapter.hasFocus()) {
+        this._adapter.handleFocusMove('last');
       }
       this._adapter.disableLastPageButton();
     }
@@ -258,11 +263,11 @@ export class PaginatorFoundation {
     }
   }
 
-  private _applyPageIndex(value: number, { fromField = null }: { fromField?: PaginatorFieldIdentifier | null } = {}): void {
+  private _applyPageIndex(value: number): void {
     this._pageIndex = value;
     this._computeOffset();
     this._updateRangeLabel();
-    this._syncInteractionState(fromField);
+    this._syncInteractionState();
     this._adapter.toggleHostAttribute(PAGINATOR_CONSTANTS.attributes.PAGE_INDEX, this._pageIndex != null, this._pageIndex.toString());
   }
 

--- a/src/lib/paginator/paginator.ts
+++ b/src/lib/paginator/paginator.ts
@@ -166,4 +166,8 @@ export class PaginatorComponent extends BaseComponent implements IPaginatorCompo
 
   @FoundationProperty()
   public declare alignment: PaginatorAlternativeAlignment;
+
+  public override focus(options?: FocusOptions): void {
+    this._foundation.focus(options);
+  }
 }

--- a/src/test/spec/paginator/paginator.spec.ts
+++ b/src/test/spec/paginator/paginator.spec.ts
@@ -158,6 +158,67 @@ describe('PaginatorComponent', function(this: ITestContext) {
       expect(this.context.previousPageButton.matches(':focus')).toBe(true);
     });
 
+    it('should move focus to appropriate action if element contains focus but state is set programmatically in response to change event', async function(this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.paginator.total = 100;
+      this.context.paginator.pageSize = 50;
+      this.context.paginator.offset = 0;
+      this.context.paginator.addEventListener(PAGINATOR_CONSTANTS.events.CHANGE, ({ detail }: CustomEvent<IPaginatorChangeEvent>) => {
+        this.context.paginator.offset = detail.offset;
+      });
+      
+      await tick();
+      this.context.nextPageButton.focus();
+      this.context.nextPageButton.click();
+      await tick();
+
+      expect(this.context.previousPageButton.matches(':focus')).toBeTrue();
+    });
+
+    it('should move focus to appropriate action if element contains focus but state is set programmatically', async function(this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.paginator.total = 100;
+      this.context.paginator.pageSize = 50;
+      this.context.paginator.offset = 0;
+      
+      await tick();
+      this.context.nextPageButton.focus();
+      this.context.nextPageButton.click();
+      await tick();
+
+      expect(this.context.paginator.offset).toBe(50);
+      expect(this.context.previousPageButton.matches(':focus')).toBeTrue();
+
+      this.context.paginator.offset = 0;
+      await tick();
+
+      expect(this.context.nextPageButton.matches(':focus')).toBeTrue();
+    });
+
+    it('should keep focus if state is updated programmatically', async function(this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.paginator.total = 100;
+      this.context.paginator.pageSize = 25;
+      this.context.paginator.offset = 0;
+
+      await tick();
+
+      this.context.paginator.focus();
+      expect(this.context.paginator.matches(':focus')).toBeTrue();
+
+      this.context.paginator.offset = 25;
+      await tick();
+      expect(this.context.paginator.matches(':focus')).toBeTrue();
+
+      this.context.paginator.pageIndex = 0;
+      await tick();
+      expect(this.context.paginator.matches(':focus')).toBeTrue();
+
+      this.context.paginator.total = 200;
+      await tick();
+      expect(this.context.paginator.matches(':focus')).toBeTrue();
+    });
+
     it('should emit change event when clicking next page button', function(this: ITestContext) {
       this.context = setupTestContext();
       this.context.paginator.total = 100;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The paginator will now manage its internal focus state in the following scenarios:
1. When state is updated that causes a button to get disabled, but only while the element is focused
2. In response to user interaction with one of the buttons that causes the button to be disabled upon clicking (again only while the field already has focus)
3. In response to a user interaction, but the state is changed from the change event listener. This is the same as the first scenario, but the order of operations is different (and this is a common use case that we now test for)

The goal is to now ensure that we only move focus from the component if it already has focus at that time. This ensures that we allow for both user actions and programmatic state changes to move focus the same way, but it's more clear _when_ this can happen now.

Additionally, a new `focus()` override method was provided that allows for programmatically focusing the paginator element because this was missing functionality before, and is standard for interactive HTML elements.

## Additional information
<!-- Add any other context about the change here. -->
