### PR TITLE
docs(button-area): add header slot to expansion panel example

### DIFF
--- a/src/stories/src/components/button-area/code/button-area-default.ts
+++ b/src/stories/src/components/button-area/code/button-area-default.ts
@@ -47,7 +47,7 @@ export const ButtonAreaInExpansionPanelCodeHtml = () => {
   return `
 <forge-card>
   <forge-expansion-panel id="expansion-panel">
-    <forge-button-area>
+    <forge-button-area slot="header">
       <button slot="button" type="button" id="button" aria-controls="expandable-content" aria-expanded="false">Toggle panel</button>
       <div class="header-content">
         <div>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N/A
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N/A

## Describe the new behavior?
Fixed the expansion panel example to use correct slots