### PR TITLE
feat(paginator): added new `rangeLabelCallback` property to allow for controlling range label text externally

### DIFF
--- a/src/dev/pages/paginator/paginator.html
+++ b/src/dev/pages/paginator/paginator.html
@@ -9,7 +9,8 @@ include('./src/partials/page.ejs', {
       { type: 'switch', label: 'Show first', id: 'opt-show-first' },
       { type: 'switch', label: 'Show first & last', id: 'opt-show-first-last' },
       { type: 'switch', label: 'Disabled', id: 'opt-disabled' },
-      { type: 'switch', label: 'Alternative', id: 'opt-alternative' }
+      { type: 'switch', label: 'Alternative', id: 'opt-alternative' },
+      { type: 'switch', label: 'Custom range label', id: 'opt-custom-range-label' }
     ]
   }
 })

--- a/src/dev/pages/paginator/paginator.ts
+++ b/src/dev/pages/paginator/paginator.ts
@@ -1,36 +1,46 @@
 import '$src/shared';
 import '@tylertech/forge/paginator';
-import { IPaginatorComponent, ISwitchComponent, PAGINATOR_CONSTANTS } from '@tylertech/forge';
+import { IPaginatorComponent, IPaginatorRangeState, ISwitchComponent, PAGINATOR_CONSTANTS } from '@tylertech/forge';
 
 const paginator = document.getElementById('forge-paginator-example') as IPaginatorComponent;
 
 const showPageSizeOptsToggle = document.getElementById('opt-show-page-size-opts') as ISwitchComponent;
-const showLabelToggle = document.getElementById('opt-show-label') as ISwitchComponent;
-const showFirstToggle = document.getElementById('opt-show-first') as ISwitchComponent;
-const showFirstLastToggle = document.getElementById('opt-show-first-last') as ISwitchComponent;
-const disabledToggle = document.getElementById('opt-disabled') as ISwitchComponent;
-const alternativeToggle = document.getElementById('opt-alternative') as ISwitchComponent;
-
 showPageSizeOptsToggle.addEventListener('forge-switch-select', ({ detail: selected }) => {
   paginator.pageSizeOptions = selected ? PAGINATOR_CONSTANTS.numbers.DEFAULT_PAGE_SIZE_OPTIONS : false;
 });
 
+const showLabelToggle = document.getElementById('opt-show-label') as ISwitchComponent;
 showLabelToggle.addEventListener('forge-switch-select', ({ detail: selected }) => {
   paginator.label = selected ? PAGINATOR_CONSTANTS.strings.DEFAULT_LABEL : null;
 });
 
+const showFirstToggle = document.getElementById('opt-show-first') as ISwitchComponent;
 showFirstToggle.addEventListener('forge-switch-select', ({ detail: selected }) => {
   paginator.first = selected;
 });
 
+const showFirstLastToggle = document.getElementById('opt-show-first-last') as ISwitchComponent;
 showFirstLastToggle.addEventListener('forge-switch-select', ({ detail: selected }) => {
   paginator.firstLast = selected;
 });
 
+const disabledToggle = document.getElementById('opt-disabled') as ISwitchComponent;
 disabledToggle.addEventListener('forge-switch-select', ({ detail: selected }) => {
   paginator.disabled = selected;
 });
 
+const alternativeToggle = document.getElementById('opt-alternative') as ISwitchComponent;
 alternativeToggle.addEventListener('forge-switch-select', ({ detail: selected }) => {
   paginator.alternative = selected;
+});
+
+const customRangeLabelToggle = document.getElementById('opt-custom-range-label') as ISwitchComponent;
+customRangeLabelToggle.addEventListener('forge-switch-select', ({ detail: selected }) => {
+  if (selected) {
+    paginator.rangeLabelCallback = (state: IPaginatorRangeState) => {
+      return `items ${state.pageStart} thru ${state.pageEnd} out of ${state.total} total`;
+    };
+  } else {
+    paginator.rangeLabelCallback = undefined;
+  }
 });

--- a/src/lib/paginator/paginator-constants.ts
+++ b/src/lib/paginator/paginator-constants.ts
@@ -84,3 +84,14 @@ export interface IPaginatorChangeEvent {
   pageIndex: number;
   offset: number;
 }
+
+export interface IPaginatorRangeState {
+  pageSize: number;
+  pageIndex: number;
+  offset: number;
+  pageStart: number;
+  pageEnd: number;
+  total: number;
+}
+
+export type PaginatorRangeLabelBuilder = ((state: IPaginatorRangeState) => string) | undefined | null;

--- a/src/lib/paginator/paginator.ts
+++ b/src/lib/paginator/paginator.ts
@@ -1,6 +1,6 @@
 import { CustomElement, attachShadowTemplate, FoundationProperty, coerceBoolean } from '@tylertech/forge-core';
 import { tylIconFirstPage, tylIconLastPage, tylIconKeyboardArrowRight, tylIconKeyboardArrowLeft } from '@tylertech/tyler-icons/standard';
-import { PaginatorAlternativeAlignment, PAGINATOR_CONSTANTS, IPaginatorChangeEvent } from './paginator-constants';
+import { PaginatorAlternativeAlignment, PAGINATOR_CONSTANTS, IPaginatorChangeEvent, PaginatorRangeLabelBuilder } from './paginator-constants';
 import { PaginatorFoundation } from './paginator-foundation';
 import { PaginatorAdapter } from './paginator-adapter';
 import { IconButtonComponent } from '../icon-button';
@@ -24,6 +24,7 @@ export interface IPaginatorComponent extends IBaseComponent {
   disabled: boolean;
   alternative: boolean;
   alignment: PaginatorAlternativeAlignment;
+  rangeLabelCallback: PaginatorRangeLabelBuilder;
 }
 
 declare global {
@@ -166,6 +167,9 @@ export class PaginatorComponent extends BaseComponent implements IPaginatorCompo
 
   @FoundationProperty()
   public declare alignment: PaginatorAlternativeAlignment;
+
+  @FoundationProperty()
+  public declare rangeLabelCallback: PaginatorRangeLabelBuilder;
 
   public override focus(options?: FocusOptions): void {
     this._foundation.focus(options);

--- a/src/stories/src/components/paginator/paginator.mdx
+++ b/src/stories/src/components/paginator/paginator.mdx
@@ -129,6 +129,19 @@ you will respond to the `change` event that gets emitted from this component to 
 
 </PropertyDef>
 
+<PropertyDef name="rangeLabelCallback" attr={false} type="PaginatorRangeLabelBuilder" defaultValue="undefined">
+
+Sets the callback that will execute when the range label is rendered. This allows you to customize the range label text.
+
+Example usage:
+```typescript
+const rangeLabelCallback: PaginatorRangeLabelBuilder = ({ pageStart, pageEnd, total }: IPaginatorRangeState) => {
+  return `items ${pageStart} thru ${pageEnd} out of ${total} total`;
+};
+```
+
+</PropertyDef>
+
 </PageSection>
 
 <PageSection>
@@ -221,6 +234,25 @@ interface ISelectOption {
 
 ```typescript
 type PaginatorAlternativeAlignment = 'start' | 'space-between' | 'end';
+```
+
+### IPaginatorRangeState
+
+```typescript
+interface IPaginatorRangeState {
+  pageSize: number;
+  pageIndex: number;
+  offset: number;
+  pageStart: number;
+  pageEnd: number;
+  total: number;
+}
+```
+
+### PaginatorRangeLabelBuilder
+
+```typescript
+type PaginatorRangeLabelBuilder = ((state: IPaginatorRangeState) => string) | undefined | null;
 ```
 
 </PageSection>

--- a/src/test/spec/paginator/paginator.spec.ts
+++ b/src/test/spec/paginator/paginator.spec.ts
@@ -1,4 +1,4 @@
-import { IPaginatorComponent, PAGINATOR_CONSTANTS, IPaginatorChangeEvent, definePaginatorComponent } from '@tylertech/forge/paginator';
+import { IPaginatorComponent, PAGINATOR_CONSTANTS, IPaginatorChangeEvent, definePaginatorComponent, IPaginatorRangeState } from '@tylertech/forge/paginator';
 import { BASE_SELECT_CONSTANTS, ISelectComponent } from '@tylertech/forge/select';
 import { IIconButtonComponent } from '@tylertech/forge/icon-button';
 import { IListItemComponent, LIST_ITEM_CONSTANTS } from '@tylertech/forge/list';
@@ -553,6 +553,24 @@ describe('PaginatorComponent', function(this: ITestContext) {
         pageSize: 25
       };
       expect(callback).toHaveBeenCalledWith(jasmine.objectContaining({ detail }));
+    });
+
+    it('should use range label callback', function(this: ITestContext) {
+      this.context = setupTestContext();
+      this.context.paginator.total = 100;
+      this.context.paginator.rangeLabelCallback = (state: IPaginatorRangeState) => {
+        return `items ${state.pageStart} thru ${state.pageEnd} out of ${state.total} total`;
+      };
+
+      expect(this.context.rangeLabel.innerText).toBe('items 1 thru 25 out of 100 total');
+
+      this.context.paginator.pageIndex = 2;
+
+      expect(this.context.rangeLabel.innerText).toBe('items 51 thru 75 out of 100 total');
+
+      this.context.paginator.rangeLabelCallback = undefined;
+
+      expect(this.context.rangeLabel.innerText).toBe('51-75 of 100');
     });
 
     describe('with first button', function(this: ITestContext)  {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Added a new `rangeLabelCallback` property that allows developers to fully customize the range label to their needs. It provides the current paginator state with pre-calculated convenience state values to allow for easy customization.

## Additional information
Closes #433 
