### PR TITLE
feat(button): add full width property/attribute

### DIFF
--- a/src/dev/pages/button/button.ejs
+++ b/src/dev/pages/button/button.ejs
@@ -83,7 +83,7 @@
   <section>
     <h3 class="forge-typography--heading2">Form example</h3>
     <form class="test-form" id="test-btn-form" action="javascript: alert('<form> submit action');">
-      <forge-text-field>
+      <forge-text-field style="width: 516px;">
         <input type="text" placeholder="Text input" aria-label="Test form input" autocomplete="off" />
       </forge-text-field>
       <div>

--- a/src/dev/pages/button/button.html
+++ b/src/dev/pages/button/button.html
@@ -8,6 +8,7 @@ include('./src/partials/page.ejs', {
       { type: 'switch', label: 'Dense', id: 'opt-dense' },
       { type: 'switch', label: 'Pill', id: 'opt-pill' },
       { type: 'switch', label: 'Anchor', id: 'opt-anchor' },
+      { type: 'switch', label: 'Full width', id: 'opt-full-width' },
       { type: 'switch', label: 'Popover icon', id: 'opt-popover-icon' },
       { type: 'switch', label: 'Form prevent default', id: 'opt-form-prevent' },
       { type: 'switch', label: 'Anchor prevent default', id: 'opt-href-prevent' },

--- a/src/dev/pages/button/button.scss
+++ b/src/dev/pages/button/button.scss
@@ -6,11 +6,10 @@
 .button-demo {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
   gap: 16px;
 }
 
-forge-button {
+forge-button:not([full-width]) {
   width: 256px;
 }
 

--- a/src/dev/pages/button/button.ts
+++ b/src/dev/pages/button/button.ts
@@ -78,6 +78,11 @@ anchorToggle.addEventListener('forge-switch-change', ({ detail: selected }) => {
   allButtons.filter(b => !b.href).forEach(btn => btn.anchor = selected);
 });
 
+const fullWidthToggle = document.querySelector('#opt-full-width') as ISwitchComponent;
+fullWidthToggle.addEventListener('forge-switch-change', ({ detail: selected }) => {
+  allButtons.forEach(btn => btn.fullWidth = selected);
+});
+
 const popoverIconToggle = document.querySelector('#opt-popover-icon') as ISwitchComponent;
 popoverIconToggle.addEventListener('forge-switch-change', ({ detail: selected }) => {
   allButtons.filter(btn => btn.id !== 'popover-button').forEach(btn => btn.popoverIcon = selected);

--- a/src/lib/button/base/base-button-foundation.ts
+++ b/src/lib/button/base/base-button-foundation.ts
@@ -179,21 +179,20 @@ export abstract class BaseButtonFoundation<T extends IBaseButtonAdapter> impleme
     return this._disabled;
   }
   public set disabled(value: boolean) {
-    // If we're in anchor mode, we need to ensure that the anchor is always enabled
+    value = Boolean(value);
+
+    if (this._disabled === value) {
+      return;
+    }
+
+    // When we're in anchor mode we need to ensure that the anchor is always enabled
     if (this._anchor) {
-      if (this._disabled) {
-        this._adapter.syncDisabled(false);
-      }
       value = false;
     }
 
-    value = Boolean(value);
-
-    if (this._disabled !== value) {
-      this._disabled = value;
-      this._adapter.setDisabled(this._disabled);
-      this._adapter.toggleHostAttribute(BASE_BUTTON_CONSTANTS.attributes.DISABLED, value);
-    }
+    this._disabled = value;
+    this._adapter.setDisabled(this._disabled);
+    this._adapter.toggleHostAttribute(BASE_BUTTON_CONSTANTS.attributes.DISABLED, value);
   }
 
   public get popoverIcon(): boolean {

--- a/src/lib/button/base/base-button.test.ts
+++ b/src/lib/button/base/base-button.test.ts
@@ -244,7 +244,7 @@ describe('BaseButton', () => {
   });
 
   it('should not disable when href is specified', async () => {
-    const el = await fixture<IButtonComponent>(html`<forge-test-base-button disable href="javascript: void(0);">Button</forge-test-base-button>`);
+    const el = await fixture<IButtonComponent>(html`<forge-test-base-button disabled href="javascript: void(0);">Button</forge-test-base-button>`);
 
     const stateLayer = getStateLayer(el);
     const focusIndicator = getFocusIndicator(el);

--- a/src/lib/button/base/base-button.ts
+++ b/src/lib/button/base/base-button.ts
@@ -1,15 +1,15 @@
 import { coerceBoolean, FoundationProperty } from '@tylertech/forge-core';
 import { tylIconArrowDropDown } from '@tylertech/tyler-icons/standard';
 import { IconRegistry } from '../../icon/icon-registry';
-import { BaseFocusableComponent } from '../../core/base/base-focusable-component';
+import { WithFocusable, IBaseFocusableComponent } from '../../core/base/base-focusable-component';
+import { BaseComponent } from '../../core/base/base-component';
 import { ExperimentalFocusOptions, internals } from '../../constants';
-import { IBaseComponent } from '../../core/base/base-component';
 import { IBaseButtonAdapter } from './base-button-adapter';
 import { BASE_BUTTON_CONSTANTS, ButtonType } from './base-button-constants';
 import { BaseButtonFoundation } from './base-button-foundation';
 import { ILabelAware } from '../../label/label-aware';
 
-export interface IBaseButton extends IBaseComponent {
+export interface IBaseButton extends IBaseFocusableComponent {
   type: ButtonType;
   disabled: boolean;
   popoverIcon: boolean;
@@ -25,7 +25,7 @@ export interface IBaseButton extends IBaseComponent {
   focus(options?: ExperimentalFocusOptions): void;
 }
 
-export abstract class BaseButton<T extends BaseButtonFoundation<IBaseButtonAdapter>> extends BaseFocusableComponent implements IBaseButton, ILabelAware {
+export abstract class BaseButton<T extends BaseButtonFoundation<IBaseButtonAdapter>> extends WithFocusable(BaseComponent) implements IBaseButton, ILabelAware {
   public static readonly formAssociated = true;
 
   public [internals]: ElementInternals;

--- a/src/lib/button/button-constants.ts
+++ b/src/lib/button/button-constants.ts
@@ -5,7 +5,8 @@ const elementName: keyof HTMLElementTagNameMap = `${COMPONENT_NAME_PREFIX}button
 const observedAttributes = {
   VARIANT: 'variant',
   PILL: 'pill',
-  THEME: 'theme'
+  THEME: 'theme',
+  FULL_WIDTH: 'full-width'
 };
 
 const attributes = {

--- a/src/lib/button/button-foundation.ts
+++ b/src/lib/button/button-foundation.ts
@@ -6,12 +6,14 @@ export interface IButtonFoundation extends IBaseButtonFoundation {
   variant: ButtonVariant;
   pill: boolean;
   theme: ButtonTheme;
+  fullWidth: boolean;
 }
 
 export class ButtonFoundation extends BaseButtonFoundation<IButtonAdapter> implements IButtonFoundation {
   private _variant: ButtonVariant = 'text';
   private _pill = false;
   private _theme: ButtonTheme = 'primary';
+  private _fullWidth = false;
 
   constructor(adapter: IButtonAdapter) {
     super(adapter);
@@ -52,6 +54,16 @@ export class ButtonFoundation extends BaseButtonFoundation<IButtonAdapter> imple
     if (this._theme !== value) {
       this._theme = value;
       this._adapter.setHostAttribute(BUTTON_CONSTANTS.attributes.THEME, this._theme);
+    }
+  }
+
+  public get fullWidth(): boolean {
+    return this._fullWidth;
+  }
+  public set fullWidth(value: boolean) {
+    if (this._fullWidth !== value) {
+      this._fullWidth = value;
+      this._adapter.toggleHostAttribute(BUTTON_CONSTANTS.attributes.FULL_WIDTH, this._fullWidth);
     }
   }
 }

--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -128,6 +128,15 @@ forge-focus-indicator {
 }
 
 //
+// Full width
+//
+
+:host([full-width]) {
+  width: 100%;
+}
+
+
+//
 // Dense
 //
 

--- a/src/lib/button/button.test.ts
+++ b/src/lib/button/button.test.ts
@@ -3,6 +3,7 @@ import { spy } from 'sinon';
 import { fixture, html } from '@open-wc/testing';
 import { sendMouse } from '@web/test-runner-commands';
 import { BASE_BUTTON_CONSTANTS } from './base/base-button-constants';
+import { BUTTON_CONSTANTS } from './button-constants';
 import { ButtonComponent, IButtonComponent } from './button';
 import type { IStateLayerComponent } from '../state-layer';
 import type { IFocusIndicatorComponent } from '../focus-indicator';
@@ -94,6 +95,18 @@ describe('Button', () => {
     expect(el.theme).to.equal('success');
     expect(el.getAttribute('theme')).to.equal('success');
     await expect(el).to.be.accessible();
+  });
+
+  it('should set full width', async () => {
+    const el = await fixture<IButtonComponent>(html`<forge-button full-width>Button</forge-button>`);
+
+    expect(el.fullWidth).to.be.true;
+    expect(el.hasAttribute(BUTTON_CONSTANTS.attributes.FULL_WIDTH)).to.be.true;
+
+    el.fullWidth = false;
+
+    expect(el.fullWidth).to.be.false;
+    expect(el.hasAttribute(BUTTON_CONSTANTS.attributes.FULL_WIDTH)).to.be.false;
   });
 
   describe('ButtonComponentDelegate', () => {

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -15,6 +15,7 @@ export interface IButtonComponent extends IBaseButton {
   variant: ButtonVariant;
   pill: boolean;
   theme: ButtonTheme;
+  fullWidth: boolean;
 }
 
 declare global {
@@ -35,6 +36,7 @@ declare global {
  * 
  * @property {string} type - The type of button. Defaults to `button`. Valid values are `button`, `submit`, and `reset`.
  * @property {ButtonVariant} variant - The variant of the button. Defaults to `text`.
+ * @property {boolean} fullWidth - Whether or not the button is full-width.
  * @property {boolean} disabled - Whether or not the button is disabled.
  * @property {boolean} popoverIcon - Whether or not the button shows a built-in popover icon.
  * @property {string} name - The name of the button.
@@ -51,6 +53,7 @@ declare global {
  * 
  * @attribute {string} type - The type of button. Defaults to `button`. Valid values are `button`, `submit`, and `reset`.
  * @attribute {ButtonVariant} variant - The variant of the button. Defaults to `text`.
+ * @attribute {boolean} full-width - Whether or not the button is full-width.
  * @attribute {boolean} disabled - Whether or not the button is disabled.
  * @attribute {boolean} popover-icon - Whether or not the button shows a built-in popover icon.
  * @attribute {string} name - The name of the button.
@@ -175,6 +178,9 @@ export class ButtonComponent extends BaseButton<ButtonFoundation> implements IBu
       case BUTTON_CONSTANTS.observedAttributes.THEME:
         this.theme = newValue as ButtonTheme;
         return;
+      case BUTTON_CONSTANTS.observedAttributes.FULL_WIDTH:
+        this.fullWidth = coerceBoolean(newValue);
+        return;
     }
     super.attributeChangedCallback(name, oldValue, newValue);
   }
@@ -187,4 +193,7 @@ export class ButtonComponent extends BaseButton<ButtonFoundation> implements IBu
 
   @FoundationProperty()
   public declare theme: ButtonTheme;
+
+  @FoundationProperty()
+  public declare fullWidth: boolean;
 }

--- a/src/lib/core/base/base-focusable-component.ts
+++ b/src/lib/core/base/base-focusable-component.ts
@@ -30,7 +30,15 @@ const _isUpdatingTabIndex = Symbol('isUpdatingTabIndex');
 const _updateTabIndex = Symbol('updateTabIndex');
 
 /**
- * Mixes in focusable functionality into a base component.
+ * Provides focusable functionality for an element.
+ *
+ * Elements can enable and disable their focusability with the `isFocusable`
+ * symbol property. **Use this instead of changing `tabIndex` directly.**
+ *
+ * This will preserve externally-set tabindices. If an element sets `tabindex="-1"`,
+ * but a user sets `tabindex="0"`, it will still be focusable.
+ *
+ * To remove user overrides and restore focus control to the element, remove the `tabindex` attribute.
  * 
  * @param base The base component to mix into.
  * @returns The mixed-in base component.
@@ -90,16 +98,3 @@ export function WithFocusable<T extends MixinBase<BaseComponent>>(base: T): Mixi
   }
   return FocusableComponent;
 }
-
-/**
- * Provides focusable functionality for an element.
- *
- * Elements can enable and disable their focusability with the `isFocusable`
- * symbol property. **Use this instead of changing `tabIndex` directly.**
- *
- * This will preserve externally-set tabindices. If an element sets `tabindex="-1"`,
- * but a user sets `tabindex="0"`, it will still be focusable.
- *
- * To remove user overrides and restore focus control to the element, remove the `tabindex` attribute.
- */
-export abstract class BaseFocusableComponent extends WithFocusable(BaseComponent) implements IBaseFocusableComponent {}


### PR DESCRIPTION
- Added a new `full-width` attribute and corresponding `fullWidth` property to the `<forge-button>` element
- Base button will now directly use the focusable mixin instead of the facade base class for consistency
- Updated the `IBaseButton` interface to correctly inherit from `IBaseFocusableComponent` for more strict typings with symbol properties
- Fixed disabled logic to properly remove the `disabled` attribute on anchor buttons