### PR TITLE
fix(expansion-panel): remove invalid `aria-expanded` attribute set on header

### DIFF
--- a/src/lib/calendar/calendar-foundation.ts
+++ b/src/lib/calendar/calendar-foundation.ts
@@ -1605,7 +1605,8 @@ export class CalendarFoundation implements ICalendarFoundation {
   private _applyMin(): void {
     this._adapter.toggleHostAttribute(CALENDAR_CONSTANTS.attributes.MIN, !!this._minAttribute, this._minAttribute as string);
 
-    if (this._min && this._min.getMonth() > this._month) {
+    if (this._min && (this._min.getMonth() > this._month || this._min.getFullYear() > this._year)) {
+      this._year = this._min.getFullYear();
       this._month = this._min.getMonth();
     }
 

--- a/src/lib/expansion-panel/expansion-panel-adapter.ts
+++ b/src/lib/expansion-panel/expansion-panel-adapter.ts
@@ -51,8 +51,6 @@ export class ExpansionPanelAdapter extends BaseAdapter<IExpansionPanelComponent>
         openIconElement.open = true;
       }
     }
-
-    this._headerElement.setAttribute('aria-expanded', open ? 'true' : 'false');
   }
 
   public setHeaderVisibility(visible: boolean): void {
@@ -125,7 +123,6 @@ export class ExpansionPanelAdapter extends BaseAdapter<IExpansionPanelComponent>
               this._contentElement.style.height = `${this._contentElement.scrollHeight}px`;
             }
             this._contentElement.style.opacity = '1';
-            this._headerElement.setAttribute('aria-expanded', 'true');
             if (openIconElement) {
               openIconElement.open = true;
             }
@@ -136,7 +133,6 @@ export class ExpansionPanelAdapter extends BaseAdapter<IExpansionPanelComponent>
               this._contentElement.style.height = '0px';
             }
             this._contentElement.style.opacity = '0';
-            this._headerElement.setAttribute('aria-expanded', 'false');
             if (openIconElement) {
               openIconElement.open = false;
             }
@@ -158,7 +154,6 @@ export class ExpansionPanelAdapter extends BaseAdapter<IExpansionPanelComponent>
         }
         this._contentElement.style.removeProperty('visibility');
         this._contentElement.style.removeProperty('opacity');
-        this._headerElement.setAttribute('aria-expanded', 'true');
         if (openIconElement) {
           openIconElement.open = true;
         }
@@ -170,7 +165,6 @@ export class ExpansionPanelAdapter extends BaseAdapter<IExpansionPanelComponent>
         }
         this._contentElement.style.opacity = '0';
         this._contentElement.style.visibility = 'hidden';
-        this._headerElement.setAttribute('aria-expanded', 'false');
         if (openIconElement) {
           openIconElement.open = false;
         }

--- a/src/test/spec/date-picker/date-picker.spec.ts
+++ b/src/test/spec/date-picker/date-picker.spec.ts
@@ -86,7 +86,8 @@ describe('DatePickerComponent', function(this: ITestContext) {
       openPopup(this.context.component);
       const calendar = getCalendar(this.context.component);
 
-      expect(calendar.month).toEqual(date.getMonth() + 1);
+      const expectedMonth = date.getMonth() >= 11 ? 0 : date.getMonth() + 1;
+      expect(calendar.month).toEqual(expectedMonth);
     });
 
     it('should open calendar in month of max date if max is before current month', function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N/A

## Describe the new behavior?
Removed the `aria-expanded` attribute being set on the header element when the expansion panel toggles. The header is a generic element that can't accept `aria-expanded`. This should be set on the toggling button instead, which must exist outside of the expansion panel's shadow DOM.
