### PR TITLE
fix(date-range-picker): fixed a bug where the "to" value was not being rendered in `<input>` when initialized with a default value

### DIFF
--- a/src/lib/date-range-picker/date-range-picker-foundation.ts
+++ b/src/lib/date-range-picker/date-range-picker-foundation.ts
@@ -30,6 +30,11 @@ export class DateRangePickerFoundation extends BaseDatePickerFoundation<IDateRan
     this._toInputBlurListener = evt => this._onToInputBlur(evt);
   }
 
+  public override initialize(): void {
+    super.initialize();
+    this._setFormattedToInputValue(true);
+  }
+
   protected _initializeState(): void {
     this._applyToMask();
 

--- a/src/test/spec/date-range-picker/date-range-component-delegate.spec.ts
+++ b/src/test/spec/date-range-picker/date-range-component-delegate.spec.ts
@@ -1,5 +1,5 @@
 import { removeElement } from '@tylertech/forge-core';
-import { DateRangeComponentDelegate, defineDateRangePickerComponent } from '@tylertech/forge/date-range-picker';
+import { DateRangeComponentDelegate, defineDateRangePickerComponent, IDatePickerRange } from '@tylertech/forge/date-range-picker';
 import { defineTextFieldComponent } from '@tylertech/forge/text-field';
 
 interface ITestContext {
@@ -35,6 +35,19 @@ describe('DateRangeComponentDelegate', function(this: ITestContext) {
     expect(this.context.delegate.value).toEqual({ from: new Date(value.from), to: new Date(value.to) });
     expect(this.context.delegate.element.value?.from).toEqual(new Date(value.from));
     expect(this.context.delegate.element.value?.to).toEqual(new Date(value.to));
+    expect(this.context.delegate.fromInput.value).toEqual(value.from);
+    expect(this.context.delegate.toInput.value).toEqual(value.to);
+  });
+
+  it('should set default value', function(this: ITestContext) {
+    const value = { from: '01/01/2020', to: '02/01/2020' };
+    this.context = setupTestContext(true, value);
+
+    expect(this.context.delegate.value).toEqual({ from: new Date(value.from), to: new Date(value.to) });
+    expect(this.context.delegate.element.value?.from).toEqual(new Date(value.from));
+    expect(this.context.delegate.element.value?.to).toEqual(new Date(value.to));
+    expect(this.context.delegate.fromInput.value).toEqual(value.from);
+    expect(this.context.delegate.toInput.value).toEqual(value.to);
   });
 
   it('should execute change callback when "from" input is modified', function(this: ITestContext) {
@@ -85,10 +98,10 @@ describe('DateRangeComponentDelegate', function(this: ITestContext) {
     expect(this.context.delegate.invalid).toBeFalse();
   });
 
-  function setupTestContext(append = false): ITestDateRangeComponentDelegateContext {
+  function setupTestContext(append = false, defaultValue?: IDatePickerRange): ITestDateRangeComponentDelegateContext {
     const fixture = document.createElement('div');
     fixture.id = 'date-range-delegate-test-fixture';
-    const delegate = new DateRangeComponentDelegate();
+    const delegate = new DateRangeComponentDelegate(defaultValue ? { props: { value: defaultValue }} : undefined);
     fixture.appendChild(delegate.element);
     if (append) {
       document.body.appendChild(fixture);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Updated date-range-picker initialization logic to ensure that the "to" `<input>` receives the formatted `to` date value if set by before init. 