### PR TITLE
fix(calendar): fixed a bug where the calendar would not reflect the correct month if the max date is before the current the month

### DIFF
--- a/src/lib/calendar/calendar-foundation.ts
+++ b/src/lib/calendar/calendar-foundation.ts
@@ -1281,18 +1281,14 @@ export class CalendarFoundation implements ICalendarFoundation {
     const year = date.getFullYear();
     const month = date.getMonth();
     this._focusedDate = date;
-    if (this._year !== year || this._month !== month) {
-      this._month = month;
-      this._setMonth();
-      this._year = year;
-      this._setYear();
-      if (this._view !== 'date') {
-        this._closeMenu(false, setFocus);
-      } else {
-        this._resetDateGrid();
-      }
-    } else if (this._view !== 'date') {
+    this._month = month;
+    this._setMonth();
+    this._year = year;
+    this._setYear();
+    if (this._view !== 'date') {
       this._closeMenu(false, setFocus);
+    } else {
+      this._resetDateGrid();
     }
     this._adapter.setActiveDate(date, setFocus, this._preventFocus);
     this._emitFocusChangeEvent(this._focusedDate);
@@ -1625,7 +1621,8 @@ export class CalendarFoundation implements ICalendarFoundation {
   private _applyMax(): void {
     this._adapter.toggleHostAttribute(CALENDAR_CONSTANTS.attributes.MAX, !!this._maxAttribute, this._maxAttribute as string);
 
-    if (this._max && this._max.getMonth() < this._month) {
+    if (this._max && (this._max.getMonth() < this._month || this._max.getFullYear() < this._year)) {
+      this._year = this._max.getFullYear();
       this._month = this._max.getMonth();
     }
 

--- a/src/test/spec/date-picker/date-picker.spec.ts
+++ b/src/test/spec/date-picker/date-picker.spec.ts
@@ -98,8 +98,9 @@ describe('DatePickerComponent', function(this: ITestContext) {
 
       openPopup(this.context.component);
       const calendar = getCalendar(this.context.component);
+      const expectedMonth = date.getMonth() <= 0 ? 11 : date.getMonth() - 1;
 
-      expect(calendar.month).toEqual(date.getMonth() - 1);
+      expect(calendar.month).toEqual(expectedMonth);
     });
 
     it('should automatically render a toggle button with a Forge text-field component', function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Fixes a bug where if the max date is set to a month prior to the current month, the calendar would not switch to the month of the max month. This was causing an exception to occur when trying to access a date in the incorrect month.
