### PR TITLE
fix(open-icon): auto-register correct "horizontal" icon

### DIFF
--- a/src/lib/open-icon/open-icon.ts
+++ b/src/lib/open-icon/open-icon.ts
@@ -1,5 +1,5 @@
 import { CustomElement, attachShadowTemplate, coerceBoolean, FoundationProperty } from '@tylertech/forge-core';
-import { tylIconKeyboardArrowLeft, tylIconKeyboardArrowDown } from '@tylertech/tyler-icons/standard';
+import { tylIconKeyboardArrowRight, tylIconKeyboardArrowDown } from '@tylertech/tyler-icons/standard';
 import { OpenIconFoundation } from './open-icon-foundation';
 import { OpenIconAdapter } from './open-icon-adapter';
 import { OPEN_ICON_CONSTANTS } from './open-icon-constants';
@@ -41,7 +41,7 @@ export class OpenIconComponent extends BaseComponent implements IOpenIconCompone
 
   constructor() {
     super();
-    IconRegistry.define([tylIconKeyboardArrowLeft, tylIconKeyboardArrowDown]);
+    IconRegistry.define([tylIconKeyboardArrowRight, tylIconKeyboardArrowDown]);
     attachShadowTemplate(this, template, styles);
     this._foundation = new OpenIconFoundation(new OpenIconAdapter(this));
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The open icon was incorrectly auto-registering the `keyboard_arrow_left` icon for its "horizontal" orientation mode, when it actually expects to use the `keyboard_arrow_right` icon. We now correctly register the `keyboard_arrow_right` icon.

Until this is released, consumers can register the correct icon themselves if using the horizontal orientation.
