### PR TITLE
fix(dialog): fixed a bug where opening dialogs with focused Forge elements that use the ripple could be misaligned

### DIFF
--- a/src/lib/dialog/dialog-adapter.ts
+++ b/src/lib/dialog/dialog-adapter.ts
@@ -1,6 +1,10 @@
 import { deepQuerySelectorAll, getActiveElement, getShadowElement, removeElement, toggleClass } from '@tylertech/forge-core';
 import { BACKDROP_CONSTANTS, IBackdropComponent } from '../backdrop';
+import { CHECKBOX_CONSTANTS } from '../checkbox/checkbox-constants';
 import { BaseAdapter, IBaseAdapter } from '../core/base/base-adapter';
+import { ICON_BUTTON_CONSTANTS } from '../icon-button/icon-button-constants';
+import { RADIO_CONSTANTS } from '../radio/radio-constants';
+import { SWITCH_CONSTANTS } from '../switch/switch-constants';
 import { IDialogComponent } from './dialog';
 import { DialogPositionType, DIALOG_CONSTANTS } from './dialog-constants';
 
@@ -24,6 +28,7 @@ export interface IDialogAdapter extends IBaseAdapter {
   addRootClass(name: string): void;
   setFullscreen(value: boolean): void;
   setMoveable(value: boolean): void;
+  tryLayoutRippleChildren(): void;
   setMoveTarget(selector: string): boolean;
   setMoveTargetHandler(type: string, listener: (evt: MouseEvent) => void): void;
   removeDragTargetHandler(type: string, listener: (evt: MouseEvent) => void): void;
@@ -150,6 +155,17 @@ export class DialogAdapter extends BaseAdapter<IDialogComponent> implements IDia
 
   public setMoveable(value: boolean): void {
     toggleClass(this._containerElement, value, DIALOG_CONSTANTS.classes.MOVEABLE);
+  }
+
+  public tryLayoutRippleChildren(): void {
+    const selectors = [
+      ICON_BUTTON_CONSTANTS.elementName,
+      SWITCH_CONSTANTS.elementName,
+      CHECKBOX_CONSTANTS.elementName,
+      RADIO_CONSTANTS.elementName
+    ];
+    const rippleChildren = deepQuerySelectorAll(this._component, selectors.join(':focus-within,')) as Array<HTMLElement & { layout(): void }>;
+    rippleChildren.filter(el => typeof el.layout === 'function').forEach(el => el.layout());
   }
 
   public setMoveTarget(selector: string): boolean {

--- a/src/lib/dialog/dialog-foundation.ts
+++ b/src/lib/dialog/dialog-foundation.ts
@@ -212,6 +212,7 @@ export class DialogFoundation implements IDialogFoundation {
     this._adapter.deregisterTransitionEndHandler(this._transitionEndHandler);
     this._adapter.setAnimating(false);
     this._adapter.emitHostEvent(DIALOG_CONSTANTS.events.READY);
+    this._adapter.tryLayoutRippleChildren();
 
     if (this._moveable) {
       this._initMoveTarget();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Adds logic that runs after the dialog has completed animating open to attempt to fix the ripple alignment for focusable Forge elements that use a ripple.

This fix adds some slight overhead to the dialog, but it's the most seamless way to handle it at the moment for backwards compatibility. This code does not need to migrate to 3.0 and beyond due to our separation of the focus state and interaction state.

## Additional information
This is a port of old logic we used to have in the 1.x version of this library. We originally removed it in 2.x because we added a JIT interaction handle for the ripple position, but the problem of the ripple being misaligned in dialogs (due to the scale animation) still exists for common things like using focus traps that set focus to the first focusable element immediately.
