### PR TITLE
fix(list): fixed a bug where keyboard navigation was not scoped within sub-lists

### DIFF
--- a/src/lib/core/base/base-adapter.ts
+++ b/src/lib/core/base/base-adapter.ts
@@ -1,7 +1,8 @@
 import { emitEvent, toggleAttribute } from '@tylertech/forge-core';
 import { IBaseComponent } from './base-component';
 
-export interface IBaseAdapter {
+export interface IBaseAdapter<T extends HTMLElement = HTMLElement> {
+  readonly hostElement: T;
   readonly isConnected: boolean;
   removeHostAttribute(name: string): void;
   getHostAttribute(name: string): string | null;
@@ -19,8 +20,12 @@ export interface IBaseAdapter {
   removeBodyAttribute(name: string): void;
 }
 
-export class BaseAdapter<T extends IBaseComponent> implements IBaseAdapter {
+export class BaseAdapter<T extends IBaseComponent> implements IBaseAdapter<T> {
   constructor(protected _component: T) {}
+
+  public get hostElement(): T {
+    return this._component;
+  }
 
   public getHostAttribute(name: string): string | null {
     return this._component.getAttribute(name);

--- a/src/lib/list/list/list-constants.ts
+++ b/src/lib/list/list/list-constants.ts
@@ -10,12 +10,12 @@ const attributes = {
   SELECTED_VALUE: 'selected-value'
 };
 
-const selectors = {
-  FOCUSABLE_LIST_ITEMS: '.forge-list-item:not(.forge-list-item--static):not(.forge-list-item--disabled)'
-};
+const events = {
+  SCOPE_TEST: `${elementName}-item-scope-test`
+} as const;
 
 export const LIST_CONSTANTS = {
   elementName,
   attributes,
-  selectors
+  events
 };

--- a/src/lib/list/list/list-foundation.ts
+++ b/src/lib/list/list/list-foundation.ts
@@ -42,6 +42,13 @@ export class ListFoundation implements IListFoundation {
   }
 
   private _onKeydown(evt: KeyboardEvent): void {
+    const path = evt.composedPath();
+    const composedBeforeUs = path.slice(0, path.indexOf(this._adapter.hostElement));
+    const fromListDescendant = composedBeforeUs.some((el: HTMLElement) => el.localName === LIST_CONSTANTS.elementName.toLowerCase());
+    if (fromListDescendant) {
+      return; // We ignore keydown events coming from sub-lists because they are already handling it themselves
+    }
+
     const isArrowDown = evt.key === 'ArrowDown' || evt.keyCode === 40;
     const isArrowUp = evt.key === 'ArrowUp' || evt.keyCode === 38;
     const isHome = evt.key === 'Home' || evt.keyCode === 36;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
`<forge-list>` elements will now ignore `keydown` events that originate from within sub-lists. This allows for each list to manage its own keyboard navigation without ancestor lists conflicting with the focus management within a specific `<forge-list>` scope/context.

Additionally, improved the detection of child `<forge-list-item>` elements by ensuring that keyboard navigation is properly scoped to the nearest `<forge-list>` parent element.

## Additional information
Fixes #452 
