### PR TITLE
fix(list): fixed keyboard navigation and used `gap` instead of `margin` for leading/trailing slots

### DIFF
--- a/src/dev/pages/list/list.ejs
+++ b/src/dev/pages/list/list.ejs
@@ -396,21 +396,15 @@
     <div class="list-demo" role="radiogroup">
       <forge-list aria-label="Choose radio option">
         <forge-list-item>
-          <forge-radio slot="leading">
-            <input type="radio" name="list-radio" aria-label="Select list item one" />
-          </forge-radio>
+          <forge-radio slot="leading" name="list-radio" aria-label="Select list item one"></forge-radio>
           List Item
         </forge-list-item>
         <forge-list-item>
-          <forge-radio slot="leading">
-            <input type="radio" name="list-radio" checked aria-label="Select list item two" />
-          </forge-radio>
+          <forge-radio slot="leading" name="list-radio" checked aria-label="Select list item two"></forge-radio>
           List Item
         </forge-list-item>
         <forge-list-item>
-          <forge-radio slot="leading">
-            <input type="radio" name="list-radio" aria-label="Select list item three" />
-          </forge-radio>
+          <forge-radio slot="leading" name="list-radio" aria-label="Select list item three"></forge-radio>
           List Item
         </forge-list-item>
       </forge-list>
@@ -424,21 +418,15 @@
       <forge-list aria-label="Choose radio option">
         <forge-list-item>
           List Item
-          <forge-radio slot="trailing">
-            <input type="radio" name="list-radio" aria-label="Select list item one" />
-          </forge-radio>
+          <forge-radio slot="trailing" name="list-radio" aria-label="Select list item one"></forge-radio>
         </forge-list-item>
         <forge-list-item>
           List Item
-          <forge-radio slot="trailing">
-            <input type="radio" name="list-radio" checked aria-label="Select list item two" />
-          </forge-radio>
+          <forge-radio slot="trailing" name="list-radio" checked aria-label="Select list item two"></forge-radio>
         </forge-list-item>
         <forge-list-item>
           List Item
-          <forge-radio slot="trailing">
-            <input type="radio" name="list-radio" aria-label="Select list item three" />
-          </forge-radio>
+          <forge-radio slot="trailing" name="list-radio" aria-label="Select list item three"></forge-radio>
         </forge-list-item>
       </forge-list>
     </div>

--- a/src/lib/core/styles/tokens/list/list-item/_tokens.scss
+++ b/src/lib/core/styles/tokens/list/list-item/_tokens.scss
@@ -2,18 +2,20 @@
 @use '../../../utils';
 @use '../../../theme';
 @use '../../../shape';
+@use '../../../spacing';
 @use '../../../typography';
 
 $tokens: (
   // Base
   background-color: utils.module-val(list-item, background-color, transparent),
   shape: utils.module-val(list-item, shape, 0),
-  padding: utils.module-val(list-item, padding, 8px 16px),
+  padding: utils.module-val(list-item, padding, spacing.variable(xsmall) spacing.variable(medium)),
   margin: utils.module-val(list-item, margin, 0),
   height: utils.module-val(list-item, height, 48px),
   dense-height: utils.module-val(list-item, dense-height, 32px),
   indent: utils.module-val(list-item, indent, 56px),
   cursor: utils.module-val(list-item, cursor, pointer),
+  gap: utils.module-val(list-item, gap, spacing.variable(xlarge)),
 
   // Supporting text
   supporting-text-color: utils.module-val(list-item, supporting-text-color, theme.variable(text-medium)),
@@ -42,28 +44,19 @@ $tokens: (
   dense-two-line-height: utils.module-val(list-item, dense-two-line-height, utils.module-ref(list-item, dense-height, 56px, value)),
   dense-three-line-height: utils.module-val(list-item, dense-three-line-height, utils.module-ref(list-item, dense-height, 72px, value)),
   dense-font-size: utils.module-val(list-item, dense-font-size, 0.875rem),
-  dense-indent: utils.module-val(list-item, dense-indent, 48px),
-
-  // Dense leading/trailing
-  dense-leading-margin-end: utils.module-val(list-item, dense-leading-margin-end, utils.module-ref(list-item, leading-margin-end, 24px, value)),
-  dense-trailing-margin-start: utils.module-val(list-item, dense-trailing-margin-start, utils.module-ref(list-item, trailing-margin-start, 24px, value)),
+  dense-indent: utils.module-val(list-item, dense-indent, spacing.variable(xxlarge)),
+  dense-gap: utils.module-val(list-item, dense-gap, spacing.variable(medium)),
 
   // Leading
-  leading-margin-start: utils.module-val(list-item, leading-margin-start, 0),
-  leading-margin-end: utils.module-val(list-item, leading-margin-end, 32px),
   leading-selected-color: utils.module-ref(list-item, leading-selected-color, selected-color),
 
   // Trailing
-  trailing-margin-start: utils.module-val(list-item, trailing-margin-start, 32px),
-  trailing-margin-end: utils.module-val(list-item, trailing-margin-end, 0),
   trailing-selected-color: utils.module-ref(list-item, trailing-selected-color, selected-color),
 
   // Avatar
   avatar-background-color: utils.module-val(list-item, avatar-background-color, theme.variable(text-medium)),
   avatar-color: utils.module-val(list-item, avatar-color, theme.variable(on-primary)),
   avatar-shape: utils.module-val(list-item, avatar-shape, shape.variable(round)),
-  avatar-margin-start: utils.module-val(list-item, avatar-margin-start, 0),
-  avatar-margin-end: utils.module-val(list-item, avatar-margin-end, 16px),
   avatar-size: utils.module-val(list-item, avatar-size, 40px),
 ) !default;
 

--- a/src/lib/list/list-item/_core.scss
+++ b/src/lib/list/list-item/_core.scss
@@ -11,6 +11,7 @@
 @mixin base {
   position: relative;
   display: flex;
+  gap: #{token(gap)};
   align-items: center;
   box-sizing: border-box;
   outline: none;
@@ -92,6 +93,8 @@
 }
 
 @mixin dense {
+  @include override(gap, dense-gap);
+
   height: #{token(dense-one-line-height)};
   min-height: #{token(dense-one-line-height)};
 }
@@ -126,8 +129,7 @@
   align-items: center;
   justify-content: center;
   fill: currentColor;
-  margin-inline-start: #{token(avatar-margin-start)};
-  margin-inline-end: #{token(avatar-margin-end)};
+  margin-inline-end: calc((#{token(gap)} / 2) * -1);
   min-width: #{token(avatar-size)};
   min-height: #{token(avatar-size)};
   border-radius: #{token(avatar-shape)};
@@ -142,30 +144,12 @@
   fill: currentColor;
 }
 
-@mixin leading {
-  margin-inline-start: #{token(leading-margin-start)};
-  margin-inline-end: #{token(leading-margin-end)};
-}
-
 @mixin leading-selected {
   color: #{token(leading-selected-color)};
 }
 
-@mixin leading-dense {
-  margin-inline-end: #{token(dense-leading-margin-end)};
-}
-
-@mixin trailing {
-  margin-inline-start: #{token(trailing-margin-start)};
-  margin-inline-end: #{token(trailing-margin-end)};
-}
-
 @mixin trailing-selected {
   color: #{token(trailing-selected-color)};
-}
-
-@mixin trailing-dense {
-  margin-inline-start: #{token(dense-trailing-margin-start)};
 }
 
 @mixin wrap {

--- a/src/lib/list/list-item/list-item-constants.ts
+++ b/src/lib/list/list-item/list-item-constants.ts
@@ -32,7 +32,7 @@ const classes = {
 
 const selectors = {
   ROOT: `.${classes.ROOT}`,
-  CHECKBOX_RADIO_SELECTOR: ':is(input[type=checkbox], input[type=radio], forge-checkbox):not(:disabled):not([forge-ignore])',
+  CHECKBOX_RADIO_SELECTOR: ':is(input[type=checkbox],input[type=radio],forge-checkbox,forge-radio):not(:disabled):not([forge-ignore])',
   SWITCH_SELECTOR: 'forge-switch:not([disabled]):not([forge-ignore])',
   IGNORE: '[forge-ignore],[data-forge-ignore]'
 };

--- a/src/lib/list/list-item/list-item.scss
+++ b/src/lib/list/list-item/list-item.scss
@@ -163,27 +163,15 @@ slot[name=tertiary-title] {
 
 // Leading slotted elements
 ::slotted([slot=leading]) {
-  @include leading;
-
   :host([selected]) & {
     @include leading-selected;
-  }
-
-  :host([dense]) & {
-    @include leading-dense;
   }
 }
 
 // Trailing slotted elements
 ::slotted([slot=trailing]) {
-  @include trailing;
-
   :host([selected]) & {
     @include trailing-selected;
-  }
-
-  :host([dense]) & {
-    @include trailing-dense;
   }
 }
 

--- a/src/lib/list/list-item/list-item.ts
+++ b/src/lib/list/list-item/list-item.ts
@@ -97,44 +97,39 @@ declare global {
  * @csspart focus-indicator - The forwarded focus indicator's internal indicator element.
  * @csspart state-layer - The forwarded state layer's internal surface element.
  * 
- * @cssprop --forge-list-item-background-color - The background color.
- * @cssprop --forge-list-item-shape - The shape of the list item.
- * @cssprop --forge-list-item-padding - The padding inside of the container element.
- * @cssprop --forge-list-item-margin - The margin around the host element.
- * @cssprop --forge-list-item-height - The height of the container.
- * @cssprop --forge-list-item-dense-height - The height when in the dense state.
- * @cssprop --forge-list-item-indent - The margin inline state when in the indented state.
- * @cssprop --forge-list-item-supporting-text-color - The text color of the supporting text.
- * @cssprop --forge-list-item-supporting-line-height - The line height of the supporting text.
- * @cssprop --forge-list-item-selected-color - The color when in the selected state.
- * @cssprop --forge-list-item-opacity - The opacity of the background color when in the disabled state.
- * @cssprop --forge-list-item-selected-leading-color - The color of the leading content when in the selected state.
- * @cssprop --forge-list-item-selected-trailing-color - The color of the trailing content when in the selected state.
- * @cssprop --forge-list-item-selected-supporting-text-color - The color of the supporting text when in the selected state.
- * @cssprop --forge-list-item-disabled-opacity - The opacity of the element when in the disabled state.
- * @cssprop --forge-list-item-disabled-cursor - The cursor when in the disabled state.
- * @cssprop --forge-list-item-one-line-height - The line height when in the one/single line state.
- * @cssprop --forge-list-item-two-line-height - The line height when in the two line state.
- * @cssprop --forge-list-item-three-line-height - The line height when in the three line state.
- * @cssprop --forge-list-item-dense-one-line-height - The line height when in the dense one/single line state.
- * @cssprop --forge-list-item-dense-two-line-height - The line height when in the dense two line state.
- * @cssprop --forge-list-item-dense-three-line-height - The line height when in the dense three line state.
- * @cssprop --forge-list-item-dense-font-size - The font size when in the dense state.
- * @cssprop --forge-list-item-dense-indent - The margin inline state when in the dense indented state.
- * @cssprop --forge-list-item-dense-leading-margin-end - The margin end of the leading content when in the dense state.
- * @cssprop --forge-list-item-dense-trailing-margin-start - The margin start of the trailing content when in the dense state.
- * @cssprop --forge-list-item-leading-margin-start - The margin start of the leading content.
- * @cssprop --forge-list-item-leading-margin-end - The margin end of the leading content.
- * @cssprop --forge-list-item-leading-selected-color - The color of the leading content when in the selected state.
- * @cssprop --forge-list-item-trailing-margin-start - The margin start of the trailing content.
- * @cssprop --forge-list-item-trailing-margin-end - The margin end of the trailing content.
- * @cssprop --forge-list-item-trailing-selected-color - The color of the trailing content when in the selected state.
- * @cssprop --forge-list-item-avatar-background-color - The background color of the avatar container.
- * @cssprop --forge-list-item-avatar-color - The foreground color of the avatar container.
- * @cssprop --forge-list-item-avatar-shape - The shape of the avatar container.
- * @cssprop --forge-list-item-avatar-margin-start - The margin start of the avatar container.
- * @cssprop --forge-list-item-avatar-margin-end - The margin end of the avatar container.
- * @cssprop --forge-list-item-avatar-size - The height & width of the avatar container.
+ * @cssproperty --forge-list-item-background-color - The background color.
+ * @cssproperty --forge-list-item-shape - The shape of the list item.
+ * @cssproperty --forge-list-item-padding - The padding inside of the container element.
+ * @cssproperty --forge-list-item-margin - The margin around the host element.
+ * @cssproperty --forge-list-item-height - The height of the container.
+ * @cssproperty --forge-list-item-dense-height - The height when in the dense state.
+ * @cssproperty --forge-list-item-indent - The margin inline state when in the indented state.
+ * @cssproperty --forge-list-item-cursor - The cursor when interactive.
+ * @cssproperty --forge-list-item-gap - The gap between the slotted content.
+ * @cssproperty --forge-list-item-supporting-text-color - The text color of the supporting text.
+ * @cssproperty --forge-list-item-supporting-line-height - The line height of the supporting text.
+ * @cssproperty --forge-list-item-selected-color - The color when in the selected state.
+ * @cssproperty --forge-list-item-opacity - The opacity of the background color when in the disabled state.
+ * @cssproperty --forge-list-item-selected-leading-color - The color of the leading content when in the selected state.
+ * @cssproperty --forge-list-item-selected-trailing-color - The color of the trailing content when in the selected state.
+ * @cssproperty --forge-list-item-selected-supporting-text-color - The color of the supporting text when in the selected state.
+ * @cssproperty --forge-list-item-disabled-opacity - The opacity of the element when in the disabled state.
+ * @cssproperty --forge-list-item-disabled-cursor - The cursor when in the disabled state.
+ * @cssproperty --forge-list-item-one-line-height - The line height when in the one/single line state.
+ * @cssproperty --forge-list-item-two-line-height - The line height when in the two line state.
+ * @cssproperty --forge-list-item-three-line-height - The line height when in the three line state.
+ * @cssproperty --forge-list-item-dense-one-line-height - The line height when in the dense one/single line state.
+ * @cssproperty --forge-list-item-dense-two-line-height - The line height when in the dense two line state.
+ * @cssproperty --forge-list-item-dense-three-line-height - The line height when in the dense three line state.
+ * @cssproperty --forge-list-item-dense-font-size - The font size when in the dense state.
+ * @cssproperty --forge-list-item-dense-indent - The margin inline state when in the dense indented state.
+ * @cssproperty --forge-list-item-dense-gap - The gap between the slotted content when in the dense state.
+ * @cssproperty --forge-list-item-leading-selected-color - The color of the leading content when in the selected state.
+ * @cssproperty --forge-list-item-trailing-selected-color - The color of the trailing content when in the selected state.
+ * @cssproperty --forge-list-item-avatar-background-color - The background color of the avatar container.
+ * @cssproperty --forge-list-item-avatar-color - The foreground color of the avatar container.
+ * @cssproperty --forge-list-item-avatar-shape - The shape of the avatar container.
+ * @cssproperty --forge-list-item-avatar-size - The height & width of the avatar container.
  */
 @CustomElement({
   name: LIST_ITEM_CONSTANTS.elementName,

--- a/src/lib/list/list/list-constants.ts
+++ b/src/lib/list/list/list-constants.ts
@@ -20,9 +20,14 @@ const attributes = {
   ...observedAttributes
 };
 
+const events = {
+  SCOPE_TEST: `${elementName}-item-scope-test`
+} as const;
+
 export const LIST_CONSTANTS = {
   elementName,
-  attributes
+  attributes,
+  events
 };
 
 export const ListComponentItemRole = {

--- a/src/lib/list/list/list-foundation.ts
+++ b/src/lib/list/list/list-foundation.ts
@@ -45,6 +45,13 @@ export class ListFoundation implements IListFoundation {
   }
 
   private _onKeydown(evt: KeyboardEvent): void {
+    const path = evt.composedPath();
+    const composedBeforeUs = path.slice(0, path.indexOf(this._adapter.hostElement));
+    const fromListDescendant = composedBeforeUs.some((el: HTMLElement) => el.localName === LIST_CONSTANTS.elementName.toLowerCase());
+    if (fromListDescendant) {
+      return; // We ignore keydown events coming from sub-lists because they are already handling it themselves
+    }
+
     const { key, altKey, ctrlKey, shiftKey, metaKey } = evt;
 
     if (altKey || ctrlKey || shiftKey || metaKey) {

--- a/src/lib/popover/popover.test.ts
+++ b/src/lib/popover/popover.test.ts
@@ -1452,10 +1452,10 @@ async function createFixture({
         ?persistent-hover=${persistentHover}
         animation-type=${animationType ?? nothing}
         trigger-type=${triggerType ?? nothing}>
-        <span>Test popover content<span>
+        <span>Test popover content</span>
         <button type="button" id="content-button" style="pointer-events: none;">Button</button>
         <forge-popover id="nested-popover">Nested popover</forge-popover>
-      </forge-overlay>
+      </forge-popover>
     </div>
   `);
 


### PR DESCRIPTION
- Fixed scope of keyboard navigation to ignore sub-lists
- Updated detection of list items to be properly scoped to the correct list context based on their composition (includes deeply nested list items within shadow roots)
- Updated styles to convert from using start/end `margin` on leading/trailing slotted content to instead use flexbox `gap` on the internal layout.
- Removed old margin tokens
- Added new gap tokens