### PR TITLE
fix(menu): map deprecated `icon` property to `leadingIcon` when options are loaded from factory

### DIFF
--- a/src/lib/menu/menu-foundation.ts
+++ b/src/lib/menu/menu-foundation.ts
@@ -362,6 +362,7 @@ export class MenuFoundation extends CascadingListDropdownAwareFoundation<IMenuOp
         if (this._open) {
           if (results && isArray(results) && results.length) {
             this._options = results;
+            this._mapIconToLeadingIcon();
             this._adapter.setOptions(results);
             const selectedValues = this._getSelectedValues();
             if (selectedValues.length) {

--- a/src/test/spec/menu/menu.spec.ts
+++ b/src/test/spec/menu/menu.spec.ts
@@ -6,6 +6,7 @@ import {
   IPopupComponent,
   LIST_ITEM_CONSTANTS,
   MENU_CONSTANTS,
+  MenuOptionFactory,
   POPUP_CONSTANTS
 } from '@tylertech/forge';
 import { getShadowElement, removeElement } from '@tylertech/forge-core';
@@ -427,6 +428,30 @@ describe('MenuComponent', function(this: ITestContext) {
 
       expect(leadingIconEl).toBeTruthy();
       expect(leadingIconEl?.textContent).toBe('code');
+    });
+
+    it(`should load leading icons from options factory based on 'leadingIcon' or 'icon' property`, async function(this: ITestContext){
+      this.context = setupTestContext();
+      const options: MenuOptionFactory = () => {
+        return [
+          { icon: 'code', value: '', label: '1' },
+          { leadingIcon: 'code', value: '', label: '2' }
+        ];
+      }
+
+      await tick();
+
+      this.context.component.options = options;
+      this.context.component.open = true;
+      
+      await tick();
+
+      const list = getPopupList(getPopupElement());
+      const listItems = Array.from(list.querySelectorAll(LIST_ITEM_CONSTANTS.elementName)) as IListItemComponent[];
+      const leadingIcons = listItems.map(listItem => listItem.querySelector('i[slot=leading]'));
+
+      expect(leadingIcons[0]).toBeTruthy();
+      expect(leadingIcons[1]).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Calls the existing mapIconToLeadingIcon function when menu `options` is a `MenuOptionFactory`

## Additional information
Maybe a better fix would be to call the existing options setter? This was the lightest touch fix I found