### PR TITLE
feat(banner): add before dismiss event and theme updates

### DIFF
--- a/src/dev/pages/banner/banner.html
+++ b/src/dev/pages/banner/banner.html
@@ -24,6 +24,7 @@ include('./src/partials/page.ejs', {
       { type: 'switch', label: 'Persistent', id: 'opt-persistent' },
       { type: 'switch', label: 'Show icon', id: 'opt-show-icon', defaultValue: true },
       { type: 'switch', label: 'Use more text', id: 'opt-more-text' },
+      { type: 'switch', label: 'Prevent dismiss', id: 'opt-prevent-dismiss' }
     ]
   }
 })

--- a/src/dev/pages/banner/banner.ts
+++ b/src/dev/pages/banner/banner.ts
@@ -12,7 +12,14 @@ IconRegistry.define([
 const banner = document.querySelector('#banner') as IBannerComponent;
 const leadingIcon = document.querySelector('#leading-icon') as HTMLElement;
 const textEl = document.querySelector('#text') as HTMLElement;
+const preventDismissToggle = document.querySelector('#opt-prevent-dismiss') as ISwitchComponent;
 
+banner.addEventListener(BANNER_CONSTANTS.events.BEFORE_DISMISS, evt => {
+  console.log(evt);
+  if (preventDismissToggle.on) {
+    evt.preventDefault();
+  }
+});
 banner.addEventListener(BANNER_CONSTANTS.events.DISMISSED, evt => {
   console.log(evt);
   dismissedToggle.on = true;

--- a/src/lib/banner/_core.scss
+++ b/src/lib/banner/_core.scss
@@ -42,6 +42,12 @@
   padding-block: #{token(padding-block)};
 }
 
+@mixin dismiss-button-container {
+  display: flex;
+  align-items: center;
+  gap: #{token(gap)};
+}
+
 @mixin dismissed {
   grid-template-rows: 0fr;
   opacity: 0;

--- a/src/lib/banner/banner-adapter.ts
+++ b/src/lib/banner/banner-adapter.ts
@@ -8,6 +8,7 @@ export interface IBannerAdapter extends IBaseAdapter {
   setDismissButtonVisibility(visible: boolean): void;
   addDismissListener(callback: EventListener): void;
   removeDismissListener(callback: EventListener): void;
+  startDismissCompleteListener(): Promise<void>;
   setDismissed(value: boolean): void;
 }
 
@@ -15,17 +16,22 @@ export class BannerAdapter extends BaseAdapter<IBannerComponent> implements IBan
   private _rootElement: HTMLElement = this._component;
   private _dismissButtonElement: HTMLButtonElement;
   private _iconSlotElement: HTMLSlotElement;
+  private _buttonSlotElement: HTMLSlotElement;
 
   constructor(component: IBannerComponent) {
     super(component);
     this._rootElement = getShadowElement(component, '.forge-banner');
     this._dismissButtonElement = getShadowElement(component, BANNER_CONSTANTS.selectors.DISMISS_BUTTON) as HTMLButtonElement;
     this._iconSlotElement = getShadowElement(component, BANNER_CONSTANTS.selectors.ICON_SLOT) as HTMLSlotElement;
+    this._buttonSlotElement = getShadowElement(component, BANNER_CONSTANTS.selectors.BUTTON_SLOT) as HTMLSlotElement;
   }
   
   public initialize(): void {
     this._iconSlotElement.addEventListener('slotchange', this._onIconSlotChange.bind(this));
+    this._buttonSlotElement.addEventListener('slotchange', this._onButtonSlotChange.bind(this));
+
     this._onIconSlotChange();
+    this._onButtonSlotChange();
   }
 
   public setDismissButtonVisibility(visible: boolean): void {
@@ -44,7 +50,17 @@ export class BannerAdapter extends BaseAdapter<IBannerComponent> implements IBan
     this._rootElement.inert = value;
   }
 
+  public async startDismissCompleteListener(): Promise<void> {
+    return new Promise<void>(resolve => {
+      this._rootElement.addEventListener('transitionend', () => resolve(), { once: true });
+    });
+  }
+
   private _onIconSlotChange(): void {
     this._rootElement.classList.toggle(BANNER_CONSTANTS.classes.HAS_ICON, this._iconSlotElement.assignedNodes().length > 0);
+  }
+
+  private _onButtonSlotChange(): void {
+    this._rootElement.classList.toggle(BANNER_CONSTANTS.classes.HAS_BUTTON, this._buttonSlotElement.assignedNodes().length > 0);
   }
 }

--- a/src/lib/banner/banner-constants.ts
+++ b/src/lib/banner/banner-constants.ts
@@ -14,12 +14,14 @@ const attributes = {
 };
 
 const classes = {
-  HAS_ICON: 'has-icon'
+  HAS_ICON: 'has-icon',
+  HAS_BUTTON: 'has-button'
 };
 
 const selectors = {
   DISMISS_BUTTON: '[part=dismiss-button]',
-  ICON_SLOT: 'slot[name=icon]'
+  ICON_SLOT: 'slot[name=icon]',
+  BUTTON_SLOT: 'slot[name=button]'
 };
 
 const defaults = {
@@ -27,6 +29,7 @@ const defaults = {
 };
 
 const events = {
+  BEFORE_DISMISS: `${elementName}-before-dismiss`,
   DISMISSED: `${elementName}-dismissed`
 };
 

--- a/src/lib/banner/banner-foundation.ts
+++ b/src/lib/banner/banner-foundation.ts
@@ -25,10 +25,14 @@ export class BannerFoundation implements IBannerFoundation {
   }
 
   private async _onDismiss(): Promise<void> {
+    if (this._dismissed || this._persistent) {
+      return;
+    }
+
     const originalDismissed = this._dismissed;
     this._dismissed = !this._dismissed;
 
-    const evt = new CustomEvent(BANNER_CONSTANTS.events.DISMISSED, { bubbles: true, composed: true, cancelable: true });
+    const evt = new CustomEvent(BANNER_CONSTANTS.events.BEFORE_DISMISS, { bubbles: true, composed: true, cancelable: true });
     this._adapter.dispatchHostEvent(evt);
     this._dismissed = originalDismissed;
 
@@ -36,7 +40,10 @@ export class BannerFoundation implements IBannerFoundation {
       return;
     }
 
+    const dismissComplete = this._adapter.startDismissCompleteListener();
     this.dismissed = !this._dismissed;
+    await dismissComplete;
+    this._adapter.dispatchHostEvent(new CustomEvent(BANNER_CONSTANTS.events.DISMISSED, { bubbles: true, composed: true }));
   }
 
   private _addDismissListener(): void {

--- a/src/lib/banner/banner.html
+++ b/src/lib/banner/banner.html
@@ -8,13 +8,15 @@
           <slot name="button"></slot>
         </div>
       </div>
-      <div>
-        <forge-icon-button part="dismiss-button">
-          <forge-icon name="cancel"></forge-icon>
-        </forge-icon-button>
-        <forge-tooltip type="label" placement="bottom">
-          <slot name="dismiss-tooltip">Dismiss</slot>
-        </forge-tooltip>
+      <div class="dismiss-button-container">
+        <slot name="dismiss-button">
+          <forge-icon-button part="dismiss-button">
+            <forge-icon name="cancel"></forge-icon>
+          </forge-icon-button>
+          <forge-tooltip type="label" placement="bottom">
+            <slot name="dismiss-tooltip">Dismiss</slot>
+          </forge-tooltip>
+        </slot>
       </div>
     </div>
   </div>

--- a/src/lib/banner/banner.scss
+++ b/src/lib/banner/banner.scss
@@ -34,7 +34,20 @@
     @include container;
   }
 
-  forge-icon-button {
+  .dismiss-button-container {
+    @include dismiss-button-container;
+  }
+
+  ::slotted(forge-button[slot=dismiss-button]) {
+    @include button.provide-theme((
+      primary-color: #{token(color)}
+    ));
+  }
+  
+  ::slotted(forge-icon-button[slot=dismiss-button]),
+  forge-icon-button[part=dismiss-button] {
+    color: #{token(icon-color)};
+    
     @include icon-button.provide-theme((
       focus-indicator-color: #{token(color)}
     ));
@@ -49,6 +62,14 @@
   @include button.provide-theme((
     primary-color: #{token(color)}
   ));
+}
+
+//
+// Slotted -icon
+//
+
+::slotted([slot=icon]) {
+  color: #{token(icon-color)};
 }
 
 //
@@ -69,6 +90,7 @@
   :host([theme=#{$theme}]) {
     .forge-banner {
       @include override(background, theme.variable(#{$theme}-container), value);
+      @include override(icon-color, theme.variable(on-#{$theme}-container), value);
     }
   }
 }
@@ -77,6 +99,7 @@
 :host([theme=danger]) {
   .forge-banner {
     @include override(background, theme.variable(error-container), value);
+    @include override(icon-color, theme.variable(on-error-container), value);
   }
 }
 
@@ -84,6 +107,7 @@
 :host([theme=info-secondary]) {
   .forge-banner {
     @include override(background, theme.variable(surface-container), value);
+    @include override(icon-color, theme.variable(on-surface-container), value);
   }
 }
 
@@ -92,7 +116,7 @@
 //
 
 @container (max-width: 600px) {
-  .forge-banner {
+  .forge-banner.has-button {
     .container {
       display: grid;
       grid-template-rows: [content] 1fr [button] auto;
@@ -113,6 +137,10 @@
     .button-container {
       grid-row: button;
       grid-column: content;
+    }
+
+    .dismiss-button-container {
+      align-items: flex-start;
     }
   }
 }

--- a/src/lib/banner/banner.ts
+++ b/src/lib/banner/banner.ts
@@ -25,6 +25,7 @@ declare global {
   }
 
   interface HTMLElementEventMap {
+    'forge-banner-before-dismiss': CustomEvent<void>;
     'forge-banner-dismissed': CustomEvent<void>;
   }
 }
@@ -42,10 +43,12 @@ declare global {
  * @attribute {boolean} persistent - Controls the visibility of the built-in dismiss button.
  * @attribute {BannerTheme} theme - The theme of the banner.
  * 
+ * @event {CustomEvent} forge-banner-before-dismiss - Dispatched before the banner is dismissed. Cancelable to prevent dismissal.
  * @event {CustomEvent} forge-banner-dismissed - Dispatched when the banner is dismissed.
  * 
  * @cssproperty --forge-banner-background - The background color of the banner.
  * @cssproperty --forge-banner-color - The text color of the banner.
+ * @cssproperty --forge-banner-icon-color - The color of the icon.
  * @cssproperty --forge-banner-gap - The gap between the contents.
  * @cssproperty --forge-banner-padding-inline - The inline padding.
  * @cssproperty --forge-banner-padding-block - The block padding.
@@ -109,7 +112,7 @@ export class BannerComponent extends BaseComponent implements IBannerComponent {
 
   /** @deprecated Use `persistent` instead. */
   public get canDismiss(): boolean {
-    return this.persistent;
+    return !this.persistent;
   }
   public set canDismiss(value: boolean) {
     this.persistent = !value;

--- a/src/lib/core/styles/tokens/banner/_tokens.scss
+++ b/src/lib/core/styles/tokens/banner/_tokens.scss
@@ -8,6 +8,7 @@
 $tokens: (
   background: utils.module-val(banner, background, theme.variable(info-container)),
   color: utils.module-val(banner, color, theme.variable(text-high)),
+  icon-color: utils.module-val(banner, icon-color, theme.variable(on-info-container)),
   gap: utils.module-val(banner, gap, spacing.variable(small)),
   padding-inline: utils.module-val(banner, padding-inline, spacing.variable(large)),
   padding-block: utils.module-val(banner, padding-block, spacing.variable(small)),


### PR DESCRIPTION
- Added new cancelable `forge-banner-before-dismiss` event
- Updated `forge-banner-dismissed` event to dispatch after the dismiss animation is complete
- Updated theme to set icon/dismiss button color
- Fix `canDismiss` getter bug
- Update layout styles when in small container to account for no slotted button content