### PR TITLE
fix(overlay): update how flip positioning is handled

### DIFF
--- a/src/lib/core/utils/utils.ts
+++ b/src/lib/core/utils/utils.ts
@@ -237,3 +237,13 @@ export function replaceElement<T extends HTMLElement>(oldElement: HTMLElement, n
 export function coerceStringToArray<T extends string>(value: string, separator = ','): T[] {
   return value.split(separator).map(p => p.trim()) as T[];
 }
+
+/**
+ * Rounds a value to the nearest pixel based on the device pixel ratio.
+ * @param {number} value The value to round.
+ * @returns {number} The rounded value.
+ */
+export function roundByDPR(value: number): number {
+  const dpr = window.devicePixelRatio || 1;
+  return Math.round(value * dpr) / dpr;
+}

--- a/src/lib/overlay/overlay-adapter.ts
+++ b/src/lib/overlay/overlay-adapter.ts
@@ -137,7 +137,7 @@ export class OverlayAdapter extends BaseAdapter<IOverlayComponent> implements IO
         },
         flip: flip !== 'never',
         flipOptions: {
-          boundary: document.body, // We ensure flip boundaries are always the viewport
+          boundary: SUPPORTS_POPOVER ? document.body : 'clippingAncestors',
           fallbackStrategy: 'initialPlacement',
           fallbackPlacements: fallbackPlacements ?? OVERLAY_FALLBACK_PLACEMENT_MAP[placement] ?? DEFAULT_FALLBACK_PLACEMENTS,
           crossAxis: flip === 'cross' || flip === 'auto',

--- a/src/lib/overlay/overlay-adapter.ts
+++ b/src/lib/overlay/overlay-adapter.ts
@@ -1,7 +1,7 @@
 import { autoUpdate, Boundary } from '@floating-ui/dom';
 import { getShadowElement } from '@tylertech/forge-core';
 import { BaseAdapter, IBaseAdapter } from '../core/base/base-adapter';
-import { positionElementAsync, PositionPlacement, VirtualElement } from '../core/utils/position-utils';
+import { DEFAULT_FALLBACK_PLACEMENTS, positionElementAsync, PositionPlacement, VirtualElement } from '../core/utils/position-utils';
 import { locateElementById } from '../core/utils/utils';
 import { IOverlayComponent, OverlayComponent } from './overlay';
 import {
@@ -12,6 +12,7 @@ import {
   OverlayPositionStrategy,
   overlayStack,
   OVERLAY_CONSTANTS,
+  OVERLAY_FALLBACK_PLACEMENT_MAP,
   SUPPORTS_POPOVER
 } from './overlay-constants';
 
@@ -31,7 +32,6 @@ export interface IPositionElementConfig {
   anchorElement: HTMLElement | VirtualElement;
   strategy: OverlayPositionStrategy;
   placement: PositionPlacement;
-  auto: boolean;
   hide: OverlayHideState;
   offset: IOverlayOffset;
   shift: boolean;
@@ -100,7 +100,6 @@ export class OverlayAdapter extends BaseAdapter<IOverlayComponent> implements IO
     anchorElement,
     strategy,
     placement,
-    auto,
     hide,
     offset,
     shift,
@@ -136,23 +135,18 @@ export class OverlayAdapter extends BaseAdapter<IOverlayComponent> implements IO
         shiftOptions: {
           boundary: boundaryEl
         },
-        auto,
-        autoOptions: {
-          boundary: boundaryEl
-        },
-        flip: !auto && flip !== 'never',
+        flip: flip !== 'never',
         flipOptions: {
-          boundary: boundaryEl,
-          fallbackAxisSideDirection: flip === 'auto' ? 'start' : undefined,
-          fallbackPlacements,
+          boundary: document.body, // We ensure flip boundaries are always the viewport
+          fallbackStrategy: 'initialPlacement',
+          fallbackPlacements: fallbackPlacements ?? OVERLAY_FALLBACK_PLACEMENT_MAP[placement] ?? DEFAULT_FALLBACK_PLACEMENTS,
           crossAxis: flip === 'cross' || flip === 'auto',
           mainAxis: flip === 'main' || flip === 'auto'
         },
         arrowElement: this._component.arrowElement,
         topLayer: !this._component.inline && SUPPORTS_POPOVER,
         offset: Boolean(offsetOptions),
-        offsetOptions,
-        transform: false
+        offsetOptions
       });
 
       const side = result.placement.split('-')[0];

--- a/src/lib/overlay/overlay-constants.ts
+++ b/src/lib/overlay/overlay-constants.ts
@@ -61,7 +61,7 @@ export interface IOverlayOffset {
 }
 
 export type OverlayPositionStrategy = 'absolute' | 'fixed';
-export type OverlayPlacement = PositionPlacement | 'auto';
+export type OverlayPlacement = PositionPlacement;
 export type OverlayHideState = 'anchor-hidden' | 'never';
 export type OverlayFlipState = 'auto' | 'main' | 'cross' | 'never';
 export type OverlayLightDismissReason = 'click' | 'escape';
@@ -75,3 +75,29 @@ export interface OverlayLightDismissEventData {
 }
 
 export const overlayStack = Symbol('overlayStack');
+
+/**
+ * This is a map of fallback placements for each placement. The fallback placements are used when the
+ * original placement is not possible due to the boundary or other constraints.
+ */
+export const OVERLAY_FALLBACK_PLACEMENT_MAP: Record<OverlayPlacement, OverlayPlacement[]> = {
+  // Left
+  left: ['right', 'bottom', 'top', 'top-start', 'top-end', 'left-start', 'left-end', 'right-start', 'right-end'],
+  'left-start': ['left-end', 'right-start', 'right-end', 'bottom', 'top'],
+  'left-end': ['left-start', 'right-end', 'right-start', 'bottom', 'top', 'bottom-start', 'bottom-end'],
+
+  // Right
+  right: ['left', 'bottom', 'top', 'top-start', 'top-end', 'left-start', 'left-end', 'right-start', 'right-end'],
+  'right-start': ['right-end', 'left-start', 'left-end', 'bottom', 'top'],
+  'right-end': ['right-start', 'left-end', 'left-start', 'bottom', 'top', 'bottom-start', 'bottom-end'],
+
+  // Top
+  top: ['bottom', 'left', 'right', 'bottom-start', 'left-start', 'left-end', 'right-start', 'right-end'],
+  'top-start': ['bottom-start', 'left', 'right', 'left-start', 'left-end', 'right-start', 'right-end'],
+  'top-end': ['bottom-end', 'left', 'right', 'right-start', 'right-end', 'left-start', 'left-end'],
+
+  // Bottom
+  bottom: ['top', 'left', 'right', 'top-start', 'left-start', 'left-end', 'right-start', 'right-end'],
+  'bottom-start': ['top-start', 'left', 'right', 'left-start', 'left-end', 'right-start', 'right-end'],
+  'bottom-end': ['top-end', 'left', 'right', 'right-start', 'right-end', 'left-start', 'left-end']
+};

--- a/src/lib/overlay/overlay-foundation.ts
+++ b/src/lib/overlay/overlay-foundation.ts
@@ -69,15 +69,10 @@ export class OverlayFoundation extends BaseOverlayFoundation<IOverlayAdapter> im
       return;
     }
 
-    // Placement can only accept `PositionPlacement` values, so we coerce the value to a
-    // `PositionPlacement` when `'auto'` is provided
-    const positionPlacement = this._placement === 'auto' ? 'bottom' : this._placement;
-
     this._adapter.positionElement({
       anchorElement: this._anchorElement,
       strategy: this._positionStrategy,
-      placement: positionPlacement,
-      auto: this._placement === 'auto',
+      placement: this._placement,
       hide: this._hide,
       offset: this._offset,
       shift: this._shift,

--- a/src/lib/popover/popover.test.ts
+++ b/src/lib/popover/popover.test.ts
@@ -872,14 +872,14 @@ describe('Popover', () => {
       await sendMouse({ type: 'click', position: [100, 10], button: 'right' });      
       expect(popover.open).to.be.true;
 
-      const originalOverlayPosition = { x: overlayRootElement.style.left, y: overlayRootElement.style.top };
+      const originalOverlayPosition = overlayRootElement.style.translate;
 
       await sendMouse({ type: 'click', position: [200, 10], button: 'right' });
 
-      const newOverlayPosition = { x: overlayRootElement.style.left, y: overlayRootElement.style.top };
+      const newOverlayPosition = overlayRootElement.style.translate;
 
       expect(popover.open).to.be.true;
-      expect(originalOverlayPosition).not.to.deep.equal(newOverlayPosition);
+      expect(originalOverlayPosition).not.to.equal(newOverlayPosition);
     });
   });
 
@@ -1315,8 +1315,7 @@ describe('Popover', () => {
       const overlayRoot = harness.popoverElement.overlay.shadowRoot?.querySelector(OVERLAY_CONSTANTS.selectors.ROOT) as HTMLElement;
 
       expect(harness.isOpen).to.be.true;
-      expect(overlayRoot.style.top).to.equal('100px');
-      expect(overlayRoot.style.left).to.equal('100px');
+      expect(overlayRoot.style.translate).to.equal('100px 100px');
     });
   });
 });

--- a/src/lib/typings.d.ts
+++ b/src/lib/typings.d.ts
@@ -10,7 +10,8 @@ declare module '*.scss' {
   export default css;
 }
 
-// Patch HTMLElement to add popover methods. Remove this when TypeScript is updated.
+// Patch HTMLElement to add popover methods
+// TODO: Remove this when TypeScript is updated.
 interface HTMLElement {
   popoverTargetElement: HTMLElement | null;
   popover: 'manual' | 'auto' | null | undefined;


### PR DESCRIPTION
- Adjust default configuration for flip middleware to use `document.body` as the default boundary for `:top-layer` elements
- Create map for fallback placements to use with the flip middleware that specifies specific fallbacks placements per placement
- Removed the "auto" middleware configuration. This will likely never be used.
- Default to using the "fixed" position strategy
- Always use `translate` transform for positioning instead of `top` and `left` for performance reasons