### PR TITLE
fix(tooltip): ensure `white-space` style is not inherited from ancestors to avoid overflow with wrapping text

### DIFF
--- a/src/lib/tooltip/_core.scss
+++ b/src/lib/tooltip/_core.scss
@@ -30,6 +30,7 @@
   pointer-events: none;
   text-align: #{token(content-align)};
   line-height: normal;
+  white-space: normal;
 
   animation-duration: #{token(animation-duration)};
   animation-timing-function: #{token(animation-timing)};


### PR DESCRIPTION
Due to our tooltips being inline in the DOM now, they can inadvertently inherit CSS styles from their ancestors. This fixes a specific issue with overflow when placed inside of an element that could potentially set something like `white-space: nowrap` but we should be aware of this potential problem for other individual style properties.