### PR TITLE
feat(list-dropdown): refactored to use `<forge-popover>` instead of `<forge-popup>` internally

### DIFF
--- a/src/dev/src/component-list.ts
+++ b/src/dev/src/component-list.ts
@@ -118,7 +118,7 @@ function getComponentCount(groups: IComponentGroup[]): number {
 function buildComponentsList(groups: IComponentGroup[]): HTMLElement[] {
   if (!groups.length) {
     const emptyText = document.createElement('div');
-    emptyText.classList.add('forge-typography--label');
+    emptyText.classList.add('forge-typography--label1');
     emptyText.textContent = 'No components found.';
     return [emptyText];
   }

--- a/src/lib/autocomplete/autocomplete-adapter.ts
+++ b/src/lib/autocomplete/autocomplete-adapter.ts
@@ -5,7 +5,8 @@ import { AUTOCOMPLETE_CONSTANTS, IAutocompleteOption, IAutocompleteOptionGroup }
 import { TEXT_FIELD_CONSTANTS } from '../text-field';
 import { IListDropdown, IListDropdownConfig, ListDropdown } from '../list-dropdown';
 import { CHIP_FIELD_CONSTANTS } from '../chip-field';
-import { IPopupComponent, POPUP_CONSTANTS } from '../popup';
+import { IPopoverComponent } from '../popover/popover';
+import { POPOVER_CONSTANTS } from '../popover';
 
 export interface IAutocompleteAdapter extends IBaseAdapter {
   setInputElement(): HTMLInputElement;
@@ -15,7 +16,7 @@ export interface IAutocompleteAdapter extends IBaseAdapter {
   initializeInputAccessibility(identifier: string): void;
   isWrappingChipField(): boolean;
   show(config: IListDropdownConfig, popupTarget: string): void;
-  hide(listener: () => void): void;
+  hide(listener: () => void, options: { destroy?: boolean }): Promise<void>;
   focus(): void;
   setOptions(options: IAutocompleteOption[] | IAutocompleteOptionGroup[]): void;
   appendOptions(options: IAutocompleteOption[] | IAutocompleteOptionGroup[]): void;
@@ -104,21 +105,30 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
     this._tryToggleDropdownIconRotation(true);
   }
 
-  public hide(listener: () => void): void {
+  public async hide(listener: () => void, { destroy = false } = {}): Promise<void> {
+    this.setBusyVisibility(false);
+    this._tryToggleDropdownIconRotation(false);
+    this._inputElement?.removeAttribute('aria-activedescendant');
+    this._inputElement?.removeAttribute('aria-controls');
+    this._inputElement?.setAttribute('aria-expanded', 'false');
+
     if (!this._listDropdown) {
       return;
     }
-    const { targetElement } = this._listDropdown.dropdownElement as IPopupComponent;
-    targetElement.removeEventListener(POPUP_CONSTANTS.events.BLUR, listener);
-    this.setBusyVisibility(false);
-    this._tryToggleDropdownIconRotation(false);
-    this._inputElement.removeAttribute('aria-activedescendant');
-    this._inputElement.removeAttribute('aria-controls');
-    this._inputElement.setAttribute('aria-expanded', 'false');
-    this._listDropdown.close();
+
+    const { anchorElement } = this._listDropdown.dropdownElement as IPopoverComponent;
+    if (anchorElement && anchorElement instanceof HTMLElement) {
+      anchorElement?.removeEventListener(POPOVER_CONSTANTS.events.TOGGLE, listener);
+    }
+
+    if (destroy) {
+      this._listDropdown.destroy();
+    } else {
+      await this._listDropdown.close();
+    }
+
     this._listDropdown = undefined;
   }
-
 
   public setBusyVisibility(isVisible: boolean): void {
     this._listDropdown?.setBusyVisibility(isVisible);
@@ -128,9 +138,9 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
     if (!this._listDropdown || !this._listDropdown.dropdownElement) {
       return;
     }
-    const dropdownElement = this._listDropdown.dropdownElement as IPopupComponent;
-    if (dropdownElement.targetElement) {
-      dropdownElement.targetElement.addEventListener(POPUP_CONSTANTS.events.BLUR, listener);
+    const dropdownElement = this._listDropdown.dropdownElement as IPopoverComponent;
+    if (dropdownElement.anchorElement && dropdownElement.anchorElement instanceof HTMLElement) {
+      dropdownElement.anchorElement.addEventListener(POPOVER_CONSTANTS.events.TOGGLE, listener);
     }
   }
 
@@ -265,7 +275,7 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
     }
     // We need to wait for the next animation frame to ensure that the layout has been updated
     window.requestAnimationFrame(() => {
-      const dropdownEl = this.getPopupElement() as IPopupComponent | undefined;
+      const dropdownEl = this.getPopupElement() as IPopoverComponent | undefined;
       dropdownEl?.position();
     });
   }

--- a/src/lib/autocomplete/autocomplete-constants.ts
+++ b/src/lib/autocomplete/autocomplete-constants.ts
@@ -1,8 +1,8 @@
 import { COMPONENT_NAME_PREFIX, KEYSTROKE_DEBOUNCE_THRESHOLD } from '../constants';
 import { IListItemComponent } from '../list';
 import { IListDropdownConfig, IListDropdownOption, IListDropdownOptionGroup, ListDropdownOptionGroupBuilder } from '../list-dropdown';
-import { IPopupPosition } from '../popup';
 import { FIELD_CONSTANTS } from '../field/field-constants';
+import { IOverlayOffset } from '../overlay/overlay-constants';
 
 const elementName: keyof HTMLElementTagNameMap = `${COMPONENT_NAME_PREFIX}autocomplete`;
 
@@ -68,7 +68,7 @@ export interface IAutocompletePopupConfiguration {
   popupTarget: string;
   dropdownConfig: IListDropdownConfig;
   popupClasses: string[];
-  popupOffset: IPopupPosition;
+  popupOffset: IOverlayOffset;
   syncPopupWidth: boolean;
   listener: (value: string) => void;
   scrollEndListener: () => void;

--- a/src/lib/autocomplete/autocomplete-foundation.ts
+++ b/src/lib/autocomplete/autocomplete-foundation.ts
@@ -113,9 +113,7 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
       this._detachListeners();
       this._isInitialized = false;
     }
-    if (this._isDropdownOpen) {
-      this._closeDropdown();
-    }
+    this._closeDropdown({ destroy: true });
   }
 
   public async forceFilter({ preserveValue }: IAutocompleteForceFilterOptions): Promise<void> {
@@ -495,12 +493,12 @@ export class AutocompleteFoundation extends ListDropdownAwareFoundation implemen
     }
   }
 
-  private _closeDropdown(): void {
+  private _closeDropdown({ destroy = false } = {}): void {
     if (this._multiple) {
       this._filterText = '';
     }
     this._isDropdownOpen = false;
-    this._adapter.hide(this._dismissListener);
+    this._adapter.hide(this._dismissListener, { destroy });
     this._sortSelectedOptions();
     this._adapter.toggleHostAttribute(AUTOCOMPLETE_CONSTANTS.attributes.OPEN, this._isDropdownOpen);
   }

--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -5,7 +5,7 @@ import { IconComponent, IconRegistry } from '../icon';
 import { LinearProgressComponent } from '../linear-progress';
 import { ListComponent, ListItemComponent } from '../list';
 import { IListDropdownAware, ListDropdownAware } from '../list-dropdown/list-dropdown-aware';
-import { PopupComponent } from '../popup';
+import { PopoverComponent } from '../popover/popover';
 import { SkeletonComponent } from '../skeleton';
 import { TextFieldComponent } from '../text-field';
 import { AutocompleteAdapter } from './autocomplete-adapter';
@@ -60,7 +60,7 @@ declare global {
   name: AUTOCOMPLETE_CONSTANTS.elementName,
   dependencies: [
     TextFieldComponent,
-    PopupComponent,
+    PopoverComponent,
     ListComponent,
     ListItemComponent,
     DividerComponent,

--- a/src/lib/autocomplete/build.json
+++ b/src/lib/autocomplete/build.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "../../../node_modules/@tylertech/forge-cli/config/build-schema.json",
-  "extends": "../build.json"
-}

--- a/src/lib/core/styles/tokens/popover/_tokens.scss
+++ b/src/lib/core/styles/tokens/popover/_tokens.scss
@@ -34,23 +34,24 @@ $tokens: (
   arrow-border-width: utils.module-val(popover, arrow-border-width, border.variable(thin)),
 
   // Animation
-  animation-timing: utils.module-val(popover, animation-timing, animation.variable(easing-decelerate)),
+  animation-enter-duration: utils.module-val(popover, animation-enter-duration, animation.variable(duration-short3)),
+  animation-enter-timing: utils.module-val(popover, animation-enter-timing, animation.variable(easing-decelerate)),
   animation-exit-duration: utils.module-val(popover, animation-exit-duration, animation.variable(duration-short2)),
   animation-exit-timing: utils.module-val(popover, animation-exit-timing, animation.variable(easing-accelerate)),
 
-  zoom-duration: utils.module-val(popover, zoom-duration, animation.variable(duration-short3)),
-  zoom-timing: utils.module-ref(popover, zoom-timing, animating-timing),
+  zoom-enter-duration: utils.module-ref(popover, zoom-enter-duration, animation-enter-duration),
+  zoom-enter-timing: utils.module-ref(popover, zoom-enter-timing, animation-enter-timing),
   zoom-exit-duration: utils.module-ref(popover, zoom-exit-duration, animation-exit-duration),
   zoom-exit-timing: utils.module-ref(popover, zoom-exit-timing, animation-exit-timing),
 
-  slide-duration: utils.module-val(popover, slide-duration, animation.variable(duration-short3)),
-  slide-timing: utils.module-ref(popover, slide-timing, animating-timing),
-  slide-offset: utils.module-val(popover, slide-offset, 24px),
+  slide-enter-duration: utils.module-ref(popover, slide-enter-duration, animation-enter-duration),
+  slide-enter-timing: utils.module-ref(popover, slide-enter-timing, animation-enter-timing),
   slide-exit-duration: utils.module-ref(popover, slide-exit-duration, animation-exit-duration),
   slide-exit-timing: utils.module-ref(popover, slide-exit-timing, animation-exit-timing),
+  slide-offset: utils.module-val(popover, slide-offset, 24px),
 
-  fade-duration: utils.module-val(popover, fade-duration, animation.variable(duration-medium2)),
-  fade-timing: utils.module-ref(popover, fade-timing, animating-timing),
+  fade-enter-duration: utils.module-val(popover, fade-enter-duration, animation.variable(duration-medium2)),
+  fade-enter-timing: utils.module-ref(popover, fade-enter-timing, animation-enter-timing),
   fade-exit-duration: utils.module-ref(popover, fade-exit-duration, animation-exit-duration),
   fade-exit-timing: utils.module-ref(popover, fade-exit-timing, animation-exit-timing),
 

--- a/src/lib/core/styles/tokens/popover/_tokens.scss
+++ b/src/lib/core/styles/tokens/popover/_tokens.scss
@@ -8,12 +8,19 @@
 
 $tokens: (
   // Base
+  width: utils.module-val(popover, width, auto),
+  height: utils.module-val(popover, height, auto),
+  min-width: utils.module-val(popover, min-width, none),
+  max-width: utils.module-val(popover, max-width, none),
+  min-height: utils.module-val(popover, min-height, none),
+  max-height: utils.module-val(popover, max-height, none),
   background: utils.module-val(popover, background, theme.variable(surface-bright)),
   border-radius: utils.module-val(popover, border-radius, shape.variable(medium)),
   box-shadow: utils.module-val(popover, box-shadow, theme.variable(popup-elevation)),
   border-width: utils.module-val(popover, border-width, 0),
   border-style: utils.module-val(popover, border-style, solid),
   border-color: utils.module-val(popover, border-color, theme.variable(outline)),
+  overflow: utils.module-val(popover, overflow, initial),
 
   // Arrow
   arrow-size: utils.module-val(popover, arrow-size, 12px),
@@ -28,22 +35,34 @@ $tokens: (
 
   // Animation
   animation-timing: utils.module-val(popover, animation-timing, animation.variable(easing-decelerate)),
+  animation-exit-duration: utils.module-val(popover, animation-exit-duration, animation.variable(duration-short2)),
+  animation-exit-timing: utils.module-val(popover, animation-exit-timing, animation.variable(easing-accelerate)),
 
   zoom-duration: utils.module-val(popover, zoom-duration, animation.variable(duration-short3)),
   zoom-timing: utils.module-ref(popover, zoom-timing, animating-timing),
+  zoom-exit-duration: utils.module-ref(popover, zoom-exit-duration, animation-exit-duration),
+  zoom-exit-timing: utils.module-ref(popover, zoom-exit-timing, animation-exit-timing),
 
   slide-duration: utils.module-val(popover, slide-duration, animation.variable(duration-short3)),
   slide-timing: utils.module-ref(popover, slide-timing, animating-timing),
   slide-offset: utils.module-val(popover, slide-offset, 24px),
+  slide-exit-duration: utils.module-ref(popover, slide-exit-duration, animation-exit-duration),
+  slide-exit-timing: utils.module-ref(popover, slide-exit-timing, animation-exit-timing),
 
   fade-duration: utils.module-val(popover, fade-duration, animation.variable(duration-medium2)),
   fade-timing: utils.module-ref(popover, fade-timing, animating-timing),
+  fade-exit-duration: utils.module-ref(popover, fade-exit-duration, animation-exit-duration),
+  fade-exit-timing: utils.module-ref(popover, fade-exit-timing, animation-exit-timing),
 
   // No anchor
   position-inline-start: utils.module-val(popover, position-inline-start, auto),
   position-inline-end: utils.module-val(popover, position-inline-end, auto),
   position-block-start: utils.module-val(popover, position-block-start, auto),
   position-block-end: utils.module-val(popover, position-block-end, auto),
+
+  // Preset - Dropdown
+  preset-dropdown-max-height: utils.module-val(popover, preset-dropdown-max-height, 256px),
+  preset-dropdown-overflow: utils.module-val(popover, preset-dropdown-overflow, auto visible),
 ) !default;
 
 @function get($key) {

--- a/src/lib/core/utils/feature-detection.ts
+++ b/src/lib/core/utils/feature-detection.ts
@@ -29,3 +29,11 @@ export function supportsHover(): boolean {
   // return window.matchMedia('(hover: hover)').matches;
   return !Platform.isMobile;
 }
+
+/**
+ * Detects if the browser is set to prefer reduced motion.
+ * @returns {boolean}
+ */
+export function prefersReducedMotion(): boolean {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}

--- a/src/lib/list-dropdown/list-dropdown-adapter.ts
+++ b/src/lib/list-dropdown/list-dropdown-adapter.ts
@@ -52,7 +52,7 @@ export class ListDropdownAdapter implements IListDropdownAdapter {
     this._dropdownElement = createDropdown(config, this._targetElement);
 
     if (config.type !== ListDropdownType.None && config.type !== ListDropdownType.Menu) {
-      this._dropdownElement.setAttribute('preset', 'dropdown');
+      this._dropdownElement.preset = 'dropdown';
     }
 
     this.syncWidth(!!config.syncWidth, config.targetWidthCallback);

--- a/src/lib/list-dropdown/list-dropdown-adapter.ts
+++ b/src/lib/list-dropdown/list-dropdown-adapter.ts
@@ -1,16 +1,17 @@
-import { IListDropdownOption, IListDropdownOpenConfig, IListDropdownOptionGroup, LIST_DROPDOWN_CONSTANTS } from './list-dropdown-constants';
+import { IListDropdownOption, IListDropdownOpenConfig, IListDropdownOptionGroup, LIST_DROPDOWN_CONSTANTS, ListDropdownType } from './list-dropdown-constants';
 import { createDropdown, createList, createListItems, createAsyncElement, createBusyElement, createCheckboxElement } from './list-dropdown-utils';
-import { IPopupComponent, POPUP_CONSTANTS } from '../popup';
 import { IListComponent } from '../list/list';
 import { LIST_ITEM_CONSTANTS, IListItemComponent } from '../list/list-item';
-import { ScrollEvents, getShadowElement, IScrollObserverConfiguration, ScrollAxisObserver, removeAllChildren, isFunction, removeElement, replaceElement, createVisuallyHiddenElement, isDeepEqual, tryScrollIntoView } from '@tylertech/forge-core';
+import { ScrollEvents, getShadowElement, IScrollObserverConfiguration, ScrollAxisObserver, removeAllChildren, isFunction, removeElement, replaceElement, createVisuallyHiddenElement, isDeepEqual, tryScrollIntoView, closestElement } from '@tylertech/forge-core';
 import { ILinearProgressComponent } from '../linear-progress';
 import { ICON_CONSTANTS, IIconComponent } from '../icon';
+import { IPopoverComponent, POPOVER_CONSTANTS } from '../popover';
 
 export interface IListDropdownAdapter {
   dropdownElement: HTMLElement | undefined;
   open(config: IListDropdownOpenConfig, selectCallback: (value: any, id: string) => void, closeCb: () => void): void;
   close(): void;
+  remove(): void;
   setScrollBottomListener(listener: () => void, scrollThreshold: number): void;
   removeScrollBottomListener(listener: () => void): void;
   getActiveOptionIndex(): number;
@@ -31,7 +32,7 @@ export interface IListDropdownAdapter {
 }
 
 export class ListDropdownAdapter implements IListDropdownAdapter {
-  private _dropdownElement: IPopupComponent | undefined;
+  private _dropdownElement: IPopoverComponent | undefined;
   private _listElement: IListComponent | undefined;
   private _announcerElement: HTMLElement | undefined;
   private _scrollObserver: ScrollAxisObserver | undefined;
@@ -49,6 +50,11 @@ export class ListDropdownAdapter implements IListDropdownAdapter {
   public open(config: IListDropdownOpenConfig, selectCallback: (value: any, id: string) => void, closeCb: () => void): void {
     // Now lets create the popup and append the children
     this._dropdownElement = createDropdown(config, this._targetElement);
+
+    if (config.type !== ListDropdownType.None && config.type !== ListDropdownType.Menu) {
+      this._dropdownElement.setAttribute('preset', 'dropdown');
+    }
+
     this.syncWidth(!!config.syncWidth, config.targetWidthCallback);
 
     // If we are configured to show a busy indicator (linear progress bar across the top), then create and append it first
@@ -108,15 +114,26 @@ export class ListDropdownAdapter implements IListDropdownAdapter {
     this._announcerElement.id = `${config.id}-activedescendant`;
     this._dropdownElement.appendChild(this._announcerElement);
 
+    // Append to root node
+    const hostDocument = this._targetElement.ownerDocument ?? document;
+    const hostElement = (closestElement(POPOVER_CONSTANTS.selectors.HOST, this._targetElement) as HTMLElement) ?? hostDocument.body;
+    hostElement.appendChild(this._dropdownElement);
+
     // Open the popup
+    this._dropdownElement.setAttribute(POPOVER_CONSTANTS.attributes.HOST, '');
     this._dropdownElement.open = true;
   }
 
-  public close(): void {
+  public async close(): Promise<void> {
     if (!this._dropdownElement) {
       return;
     }
-    this._dropdownElement.open = false;
+    await this._dropdownElement.hideAsync();
+    this.remove();
+  }
+
+  public remove(): void {
+    this._dropdownElement?.remove();
     this._dropdownElement = undefined;
     this._listElement = undefined;
     this._announcerElement = undefined;
@@ -125,9 +142,9 @@ export class ListDropdownAdapter implements IListDropdownAdapter {
   public setScrollBottomListener(listener: () => void, scrollThreshold: number): void {
     if (this._dropdownElement) {
       if (!this._scrollObserver) {
-        const scrollTarget = getShadowElement(this._dropdownElement, POPUP_CONSTANTS.selectors.CONTAINER);
         const scrollConfig: IScrollObserverConfiguration = { scrollThreshold };
-        this._scrollObserver = new ScrollAxisObserver(scrollTarget, scrollConfig);
+        const scrollContainer = getShadowElement(this._dropdownElement, POPOVER_CONSTANTS.selectors.SURFACE) as HTMLElement;
+        this._scrollObserver = new ScrollAxisObserver(scrollContainer, scrollConfig);
         this._scrollObserver.addListener(ScrollEvents.ScrolledEnd, listener);
       }
     }
@@ -237,7 +254,8 @@ export class ListDropdownAdapter implements IListDropdownAdapter {
 
   public syncWidth(sync: boolean, targetWidthCallback?: () => number): void {
     if (this._dropdownElement) {
-      this._dropdownElement.style[sync ? 'width' : 'minWidth'] = `${this._getTargetElementWidth(targetWidthCallback)}px`;
+      const propertyName = sync ? '--forge-popover-width' : '--forge-popover-min-width';
+      this._dropdownElement.style.setProperty(propertyName, `${this._getTargetElementWidth(targetWidthCallback)}px`);
     }
   }
 
@@ -338,7 +356,7 @@ export class ListDropdownAdapter implements IListDropdownAdapter {
 
   private _scrollListItemIntoView(listItem: HTMLElement | undefined, behavior: 'auto' | 'smooth' = 'auto', block: 'nearest' | 'center' = 'nearest'): void {
     if (listItem && this._dropdownElement && this._dropdownElement.isConnected) {
-      const scrollContainer = getShadowElement(this._dropdownElement, POPUP_CONSTANTS.selectors.CONTAINER);
+      const scrollContainer = getShadowElement(this._dropdownElement, POPOVER_CONSTANTS.selectors.SURFACE) as HTMLElement;
       if (scrollContainer) {
         tryScrollIntoView(scrollContainer, listItem, behavior, block);
       }

--- a/src/lib/list-dropdown/list-dropdown-constants.ts
+++ b/src/lib/list-dropdown/list-dropdown-constants.ts
@@ -1,5 +1,6 @@
-import { IconExternalType, IIconComponent } from '../icon';
-import { IPopupPosition, PopupPlacement } from '../popup';
+import type { IIconComponent } from '../icon';
+import type { IOverlayOffset } from '../overlay/overlay-constants';
+import { PositionPlacement } from '../core/utils/position-utils';
 
 const attributes = {
   POPUP_CLASSES: 'popup-classes',
@@ -88,10 +89,10 @@ export interface IListDropdownConfig<T = any> {
   dense?: boolean;
   type?: ListDropdownType;
   popupClasses?: string | string[];
-  popupOffset?: IPopupPosition;
+  popupOffset?: IOverlayOffset;
   popupStatic?: boolean;
-  popupPlacement?: PopupPlacement;
-  popupFallbackPlacements?: PopupPlacement[];
+  popupPlacement?: PositionPlacement;
+  popupFallbackPlacements?: PositionPlacement[];
   optionLimit?: number;
   optionBuilder?: ListDropdownOptionBuilder;
   observeScroll?: boolean;

--- a/src/lib/list-dropdown/list-dropdown-foundation.ts
+++ b/src/lib/list-dropdown/list-dropdown-foundation.ts
@@ -5,7 +5,7 @@ import { getFlattenedOptions } from './list-dropdown-utils';
 export interface IListDropdownFoundation {
   dropdownElement: HTMLElement | undefined;
   open(): void;
-  close(): void;
+  close(): Promise<void>;
   getActiveOptionIndex(): number;
   getActiveOption(): IListDropdownOption | undefined;
   toggleOptionMultiple(index: number, isSelected: boolean): void;
@@ -46,9 +46,7 @@ export class ListDropdownFoundation implements IListDropdownFoundation {
   }
 
   public destroy(): void {
-    if (this._open) {
-      this.close();
-    }
+    this._adapter.remove();
   }
 
   public open(): void {
@@ -67,13 +65,13 @@ export class ListDropdownFoundation implements IListDropdownFoundation {
     }
   }
 
-  public close(): void {
+  public async close(): Promise<void> {
     if (this._open) {
       this._open = false;
-      this._adapter.close();
       if (this._config.observeScroll && this._config.scrollEndListener) {
         this._adapter.removeScrollBottomListener(this._scrollEndListener);
       }
+      await this._adapter.close();
     }
   }
 

--- a/src/lib/list-dropdown/list-dropdown-utils.ts
+++ b/src/lib/list-dropdown/list-dropdown-utils.ts
@@ -4,7 +4,8 @@ import { ICON_CLASS_NAME } from '../constants';
 import { IIconComponent } from '../icon';
 import { ILinearProgressComponent, LINEAR_PROGRESS_CONSTANTS } from '../linear-progress';
 import { IListComponent, LIST_CONSTANTS } from '../list/list';
-import { IPopupComponent, PopupAnimationType, POPUP_CONSTANTS } from '../popup';
+import { POPOVER_CONSTANTS } from '../popover';
+import { IPopoverComponent } from '../popover/popover';
 import { ISkeletonComponent, SKELETON_CONSTANTS } from '../skeleton';
 import { IListDropdownCascadingElementFactoryConfig, IListDropdownOpenConfig, IListDropdownOption, IListDropdownOptionGroup, ListDropdownAsyncStyle, ListDropdownIconType, ListDropdownType, LIST_DROPDOWN_CONSTANTS } from './list-dropdown-constants';
 
@@ -15,7 +16,7 @@ export enum ListDropdownOptionType { Option, Group }
  * @param config 
  * @param targetElement 
  */
-export function createDropdown(config: IListDropdownOpenConfig, targetElement: HTMLElement): IPopupComponent {
+export function createDropdown(config: IListDropdownOpenConfig, targetElement: HTMLElement): IPopoverComponent {
   const dropdownElement = createPopupDropdown(config, targetElement);
   const dropdownId =  `list-dropdown-popup-${config.id}`;
 
@@ -45,37 +46,30 @@ export function createDropdown(config: IListDropdownOpenConfig, targetElement: H
   return dropdownElement;
 }
 
-export function createPopupDropdown(config: IListDropdownOpenConfig, targetElement: HTMLElement): IPopupComponent {
-  const popupElement = document.createElement('forge-popup');
-  popupElement.targetElement = targetElement;
-  popupElement.placement = config.popupPlacement || 'bottom-start';
-  popupElement.manageFocus = false;
-  popupElement.static = !!config.popupStatic;
+export function createPopupDropdown(config: IListDropdownOpenConfig, targetElement: HTMLElement): IPopoverComponent {
+  const popoverElement = document.createElement('forge-popover');
+  popoverElement.anchorElement = targetElement;
+  popoverElement.placement = config.popupPlacement || 'bottom-start';
+  popoverElement.persistent = Boolean(config.popupStatic);
 
   if (config.popupFallbackPlacements?.length) {
-    popupElement.fallbackPlacements = config.popupFallbackPlacements;
+    popoverElement.fallbackPlacements = config.popupFallbackPlacements;
   }
 
   if (config.constrainViewportWidth) {
-    popupElement.setAttribute(POPUP_CONSTANTS.attributes.CONSTRAIN_VIEWPORT_WIDTH, '');
+    popoverElement.setAttribute(POPOVER_CONSTANTS.attributes.CONSTRAIN_VIEWPORT_WIDTH, '');
   }
 
   if (config.popupOffset) {
-    popupElement.offset = config.popupOffset;
+    popoverElement.offset = config.popupOffset;
   }
 
   // Set the animations based on our type
-  switch (config.type) {
-    case ListDropdownType.Menu:
-      popupElement.animationType = PopupAnimationType.Menu;
-      break;
-    case ListDropdownType.None:
-      popupElement.animationType = PopupAnimationType.None;
-      break;
-    default:
-      popupElement.animationType = PopupAnimationType.Dropdown;
+  if (config.type === ListDropdownType.None) {
+    popoverElement.animationType = 'none';
   }
-  return popupElement;
+
+  return popoverElement;
 }
 
 export function createList(config: IListDropdownOpenConfig): IListComponent {

--- a/src/lib/list-dropdown/list-dropdown.ts
+++ b/src/lib/list-dropdown/list-dropdown.ts
@@ -8,7 +8,7 @@ import { IconRegistry } from '../icon';
 export interface IListDropdown {
   dropdownElement: HTMLElement | undefined;
   open(): void;
-  close(): void;
+  close(): Promise<void>;
   destroy(): void;
   getActiveOptionIndex(): number;
   getActiveOption(): IListDropdownOption | undefined;
@@ -46,8 +46,8 @@ export class ListDropdown implements IListDropdown {
   }
 
   /** Closes the dropdown. */
-  public close(): void {
-    this._foundation.close();
+  public close(): Promise<void> {
+    return this._foundation.close();
   }
 
   /** Gets the currently highlighted option index in the dropdown. */

--- a/src/lib/menu/build.json
+++ b/src/lib/menu/build.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "../../../node_modules/@tylertech/forge-cli/config/build-schema.json",
-  "extends": "../build.json"
-}

--- a/src/lib/menu/menu-adapter.ts
+++ b/src/lib/menu/menu-adapter.ts
@@ -12,8 +12,9 @@ export interface IMenuAdapter extends IBaseAdapter {
   hasTargetElement(): boolean;
   addTargetListener(event: string, callback: (event: Event) => void, bubbles?: boolean): void;
   removeTargetListener(event: string, callback: (event: Event) => void): void;
+  destroyListDropdown(): void;
   attachMenu(config: IListDropdownConfig): void;
-  detachMenu(): void;
+  detachMenu(): Promise<void>;
   setOptions(options: Array<IMenuOption | IMenuOptionGroup>): void;
   getActiveOptionIndex(): number;
   setActiveOption(index: number): void;
@@ -99,7 +100,14 @@ export class MenuAdapter extends BaseAdapter<IMenuComponent> implements IMenuAda
     }
   }
 
-  public detachMenu(): void {
+  public destroyListDropdown(): void {
+    if (this._listDropdown) {
+      this._listDropdown.destroy();
+      this._listDropdown = undefined;
+    }
+  }
+
+  public async detachMenu(): Promise<void> {
     if (this._targetElement) {
       this._targetElement.removeAttribute('aria-activedescendant');
       this._targetElement.removeAttribute('aria-expanded');
@@ -107,7 +115,7 @@ export class MenuAdapter extends BaseAdapter<IMenuComponent> implements IMenuAda
     }
 
     if (this._listDropdown) {
-      this._listDropdown.close();
+      await this._listDropdown.close();
       this._listDropdown.destroy();
       this._listDropdown = undefined;
     }

--- a/src/lib/menu/menu.ts
+++ b/src/lib/menu/menu.ts
@@ -1,14 +1,15 @@
 import { attachShadowTemplate, coerceBoolean, CustomElement, ensureChild, FoundationProperty, isDefined } from '@tylertech/forge-core';
 import { tylIconArrowRight } from '@tylertech/tyler-icons/standard';
-import { CircularProgressComponent } from '../circular-progress';
+import { PositionPlacement } from '../core/utils/position-utils';
 import { IconRegistry } from '../icon';
-import { LinearProgressComponent } from '../linear-progress';
 import { ListComponent } from '../list';
 import { IListDropdownAware, ListDropdownAware } from '../list-dropdown/list-dropdown-aware';
-import { IPopupPosition, PopupComponent, PopupPlacement } from '../popup';
+import type { IOverlayOffset } from '../overlay/overlay-constants';
+import { PopoverComponent } from '../popover';
 import { MenuAdapter } from './menu-adapter';
 import { IMenuActiveChangeEventData, IMenuOption, IMenuOptionGroup, IMenuSelectEventData, MenuMode, MenuOptionBuilder, MenuOptionFactory, MENU_CONSTANTS } from './menu-constants';
 import { MenuFoundation } from './menu-foundation';
+
 import template from './menu.html';
 import styles from './menu.scss';
 
@@ -17,13 +18,13 @@ export interface IMenuComponent extends IListDropdownAware {
   options: Array<IMenuOption | IMenuOptionGroup> | MenuOptionFactory;
   selectedIndex: number;
   selectedValue: number;
-  placement: PopupPlacement;
-  fallbackPlacements: PopupPlacement[];
+  placement: PositionPlacement;
+  fallbackPlacements: PositionPlacement[];
   dense: boolean;
   iconClass: string;
   persistSelection: boolean;
   mode: MenuMode;
-  popupOffset: IPopupPosition;
+  popupOffset: IOverlayOffset;
   optionBuilder: MenuOptionBuilder | undefined;
   popupElement: HTMLElement | undefined;
   propagateKeyEvent(evt: KeyboardEvent): void;
@@ -51,7 +52,7 @@ declare global {
 @CustomElement({
   name: MENU_CONSTANTS.elementName,
   dependencies: [
-    PopupComponent,
+    PopoverComponent,
     ListComponent
   ]
 })
@@ -98,7 +99,7 @@ export class MenuComponent extends ListDropdownAware implements IMenuComponent {
         this._foundation.open = isDefined(newValue);
         break;
       case MENU_CONSTANTS.attributes.PLACEMENT:
-        this._foundation.placement = newValue as PopupPlacement;
+        this._foundation.placement = newValue as PositionPlacement;
         break;
       case MENU_CONSTANTS.attributes.SELECTED_INDEX:
         this._foundation.selectedIndex = Number(newValue);
@@ -143,11 +144,11 @@ export class MenuComponent extends ListDropdownAware implements IMenuComponent {
 
   /** Gets/sets the menu placement (default is bottom-left). */
   @FoundationProperty()
-  public declare placement: `${PopupPlacement}`;
+  public declare placement: `${PositionPlacement}`;
 
   /** Gets/sets the fallback menu placement for overriding the default of any side. */
   @FoundationProperty()
-  public declare fallbackPlacements: `${PopupPlacement}`[];
+  public declare fallbackPlacements: `${PositionPlacement}`[];
 
   /** Gets/sets dense state of the list options used in the menu popup. */
   @FoundationProperty()
@@ -170,7 +171,7 @@ export class MenuComponent extends ListDropdownAware implements IMenuComponent {
 
   /** Sets the position adjustment on the internal popup element. */
   @FoundationProperty()
-  public declare popupOffset: IPopupPosition;
+  public declare popupOffset: IOverlayOffset;
 
   /** Sets the callback that will be executed for each option in the dropdown for producing custom option templates. */
   @FoundationProperty()

--- a/src/lib/popover/_animations.scss
+++ b/src/lib/popover/_animations.scss
@@ -10,6 +10,16 @@
   }
 }
 
+@keyframes zoomout {
+  from {
+    transform: scale(1);
+  }
+
+  to {
+    transform: scale(0.8);
+  }
+}
+
 @keyframes slidein {
   from {
     transform: translateX(#{token(slidein-x, custom)}) translateY(#{token(slidein-y, custom)});
@@ -20,6 +30,16 @@
   }
 }
 
+@keyframes slideout {
+  from {
+    transform: translateX(0) translateY(0);
+  }
+
+  to {
+    transform: translateX(#{token(slidein-x, custom)}) translateY(#{token(slidein-y, custom)});
+  }
+}
+
 @keyframes fadein {
   from {
     opacity: 0;
@@ -27,5 +47,15 @@
 
   to {
     opacity: 1;
+  }
+}
+
+@keyframes fadeout {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
   }
 }

--- a/src/lib/popover/_core.scss
+++ b/src/lib/popover/_core.scss
@@ -1,9 +1,14 @@
 @use './token-utils' as *;
+@use '../core/styles/scrollbar';
 
 @forward './token-utils';
 
 @mixin base {
+  @include scrollbar.base;
+
   position: relative;
+  overflow: #{token(overflow)};
+  box-sizing: border-box;
 
   background: #{token(background)};
 
@@ -12,6 +17,13 @@
   border-width: #{token(border-width)};
   border-style: #{token(border-style)};
   border-color: #{token(border-color)};
+
+  width: #{token(width)};
+  height: #{token(height)};
+  min-width: #{token(min-width)};
+  max-width: #{token(max-width)};
+  min-height: #{token(min-height)};
+  max-height: #{token(max-height)};
 }
 
 @mixin arrow {
@@ -31,11 +43,22 @@
   clip-path: #{token(arrow-clip-path, custom)};
 }
 
+@mixin preset-dropdown {
+  @include override(max-height, preset-dropdown-max-height);
+  @include override(overflow, preset-dropdown-overflow);
+}
+
 @mixin zoom-base {
   animation-duration: #{token(zoom-duration)};
   animation-timing-function: #{token(zoom-timing)};
   animation-name: fadein, zoomin;
   transform-origin: #{token(zoomin-origin, custom)};
+}
+
+@mixin zoom-exit {
+  animation-duration: #{token(zoom-exit-duration)};
+  animation-timing-function: #{token(zoom-exit-timing)};
+  animation-name: fadeout, zoomout;
 }
 
 @mixin slide-base {
@@ -44,8 +67,20 @@
   animation-name: fadein, slidein;
 }
 
+@mixin slide-exit {
+  animation-duration: #{token(slide-exit-duration)};
+  animation-timing-function: #{token(slide-exit-timing)};
+  animation-name: fadeout, slideout;
+}
+
 @mixin fade-base {
   animation-duration: #{token(fade-duration)};
   animation-timing-function: #{token(fade-timing)};
   animation-name: fadein;
+}
+
+@mixin fade-exit {
+  animation-duration: #{token(fade-exit-duration)};
+  animation-timing-function: #{token(fade-exit-timing)};
+  animation-name: fadeout;
 }

--- a/src/lib/popover/_core.scss
+++ b/src/lib/popover/_core.scss
@@ -49,8 +49,8 @@
 }
 
 @mixin zoom-base {
-  animation-duration: #{token(zoom-duration)};
-  animation-timing-function: #{token(zoom-timing)};
+  animation-duration: #{token(zoom-enter-duration)};
+  animation-timing-function: #{token(zoom-enter-timing)};
   animation-name: fadein, zoomin;
   transform-origin: #{token(zoomin-origin, custom)};
 }
@@ -62,8 +62,8 @@
 }
 
 @mixin slide-base {
-  animation-duration: #{token(slide-duration)};
-  animation-timing-function: #{token(slide-timing)};
+  animation-duration: #{token(slide-enter-duration)};
+  animation-timing-function: #{token(slide-enter-timing)};
   animation-name: fadein, slidein;
 }
 
@@ -74,8 +74,8 @@
 }
 
 @mixin fade-base {
-  animation-duration: #{token(fade-duration)};
-  animation-timing-function: #{token(fade-timing)};
+  animation-duration: #{token(fade-enter-duration)};
+  animation-timing-function: #{token(fade-enter-timing)};
   animation-name: fadein;
 }
 

--- a/src/lib/popover/popover-adapter.ts
+++ b/src/lib/popover/popover-adapter.ts
@@ -1,4 +1,5 @@
 import { getShadowElement } from '@tylertech/forge-core';
+import { prefersReducedMotion } from '../core/utils/feature-detection';
 import { VirtualElement } from '../core/utils/position-utils';
 import { IOverlayComponent, OVERLAY_CONSTANTS } from '../overlay';
 import { IOverlayAwareAdapter, OverlayAwareAdapter } from '../overlay/base/overlay-aware-adapter';
@@ -66,6 +67,12 @@ export class PopoverAdapter extends OverlayAwareAdapter<IPopoverComponent> imple
   }
 
   public hide(): Promise<void> {
+    if (prefersReducedMotion()) {
+      this._surfaceElement.classList.remove(POPOVER_CONSTANTS.classes.EXITING);
+      this._overlayElement.open = false;
+      return Promise.resolve();
+    }
+
     return new Promise(resolve => {
       this._surfaceElement.addEventListener('animationend', evt => {
         this._surfaceElement.classList.remove(POPOVER_CONSTANTS.classes.EXITING);

--- a/src/lib/popover/popover-constants.ts
+++ b/src/lib/popover/popover-constants.ts
@@ -3,8 +3,7 @@ import { OverlayLightDismissReason } from '../overlay';
 
 const elementName = `${COMPONENT_NAME_PREFIX}popover`;
 
-const attributes = {
-  OPEN: 'open',
+const observedAttributes = {
   ARROW: 'arrow',
   ANIMATION_TYPE: 'animation-type',
   TRIGGER_TYPE: 'trigger-type',
@@ -12,6 +11,12 @@ const attributes = {
   PERSISTENT_HOVER: 'persistent-hover',
   HOVER_DELAY: 'hover-delay',
   HOVER_DISMISS_DELAY: 'hover-dismiss-delay',
+  PRESET: 'preset'
+};
+
+const attributes = {
+  ...observedAttributes,
+  OPEN: 'open',
   HOST: 'forge-popover-host',
   CONSTRAIN_VIEWPORT_WIDTH: 'constrain-viewport-width'
 };
@@ -37,11 +42,13 @@ const events = {
 
 const defaults = {
   TRIGGER_TYPE: 'click' as PopoverTriggerType,
-  HOVER_DELAY: 0
+  HOVER_DELAY: 0,
+  PRESET: 'popover' as PopoverPreset
 };
 
 export const POPOVER_CONSTANTS = {
   elementName,
+  observedAttributes,
   attributes,
   classes,
   selectors,
@@ -55,6 +62,7 @@ export const POPOVER_HOVER_TIMEOUT = 500;
 export type PopoverAnimationType = 'none' | 'zoom' | 'slide' | 'fade';
 export type PopoverTriggerType = 'click' | 'hover' | 'focus' | 'longpress' | 'doubleclick' | 'contextmenu' | 'manual';
 export type PopoverDismissReason = OverlayLightDismissReason | PopoverTriggerType | 'destroy';
+export type PopoverPreset = 'popover' | 'dropdown';
 
 export interface IPopoverToggleEventData {
   newState: 'closed' | 'open';

--- a/src/lib/popover/popover-constants.ts
+++ b/src/lib/popover/popover-constants.ts
@@ -11,15 +11,19 @@ const attributes = {
   LONGPRESS_DELAY: 'longpress-delay',
   PERSISTENT_HOVER: 'persistent-hover',
   HOVER_DELAY: 'hover-delay',
-  HOVER_DISMISS_DELAY: 'hover-dismiss-delay'
+  HOVER_DISMISS_DELAY: 'hover-dismiss-delay',
+  HOST: 'forge-popover-host',
+  CONSTRAIN_VIEWPORT_WIDTH: 'constrain-viewport-width'
 };
 
 const classes = {
-  ARROW: 'arrow'
+  ARROW: 'arrow',
+  EXITING: 'exiting'
 };
 
 const selectors = {
-  SURFACE: '.forge-popover'
+  SURFACE: '.forge-popover',
+  HOST: `[${attributes.HOST}]`
 };
 
 const parts = {

--- a/src/lib/popover/popover-foundation.ts
+++ b/src/lib/popover/popover-foundation.ts
@@ -2,7 +2,7 @@ import { IOverlayAwareFoundation, OverlayAwareFoundation } from '../overlay/base
 import { OverlayLightDismissEventData } from '../overlay/overlay-constants';
 import { WithLongpressListener } from '../core/mixins/interactions/longpress/with-longpress-listener';
 import { IPopoverAdapter } from './popover-adapter';
-import { PopoverAnimationType, IPopoverToggleEventData, PopoverTriggerType, POPOVER_CONSTANTS, PopoverDismissReason, POPOVER_HOVER_TIMEOUT } from './popover-constants';
+import { PopoverAnimationType, IPopoverToggleEventData, PopoverTriggerType, POPOVER_CONSTANTS, PopoverDismissReason, POPOVER_HOVER_TIMEOUT, PopoverPreset } from './popover-constants';
 import { IDismissibleStackState, DismissibleStack } from '../core/utils/dismissible-stack';
 import { VirtualElement } from '../core/utils/position-utils';
 
@@ -14,6 +14,7 @@ export interface IPopoverFoundation extends IOverlayAwareFoundation {
   persistentHover: boolean;
   hoverDismissDelay: number;
   hoverDelay: number;
+  preset: PopoverPreset;
   hideAsync(): Promise<void>;
   dispatchBeforeToggleEvent(state: IDismissibleStackState): boolean;
 }
@@ -28,6 +29,7 @@ export class PopoverFoundation extends BaseClass implements IPopoverFoundation {
   private _persistentHover = false;
   private _hoverDismissDelay = POPOVER_HOVER_TIMEOUT;
   private _hoverDelay = POPOVER_CONSTANTS.defaults.HOVER_DELAY;
+  private _preset = POPOVER_CONSTANTS.defaults.PRESET;
   private _previouslyFocusedElement: HTMLElement | null = null;
 
   // Hover trigger state
@@ -575,6 +577,18 @@ export class PopoverFoundation extends BaseClass implements IPopoverFoundation {
     if (this._hoverDismissDelay !== value) {
       this._hoverDismissDelay = value;
       this._adapter.setHostAttribute(POPOVER_CONSTANTS.attributes.HOVER_DISMISS_DELAY, String(this._hoverDismissDelay));
+    }
+  }
+
+  public get preset(): PopoverPreset {
+    return this._preset ?? POPOVER_CONSTANTS.defaults.PRESET;
+  }
+  public set preset(value: PopoverPreset) {
+    value = value ?? POPOVER_CONSTANTS.defaults.PRESET;
+    if (this._preset !== value) {
+      this._preset = value;
+      const hasPreset = value !== POPOVER_CONSTANTS.defaults.PRESET;
+      this._adapter.toggleHostAttribute(POPOVER_CONSTANTS.attributes.PRESET, hasPreset, this._preset);
     }
   }
 }

--- a/src/lib/popover/popover.scss
+++ b/src/lib/popover/popover.scss
@@ -106,6 +106,25 @@ forge-overlay {
 }
 
 //
+// Preset - Dropdown
+//
+
+:host([preset=dropdown]) {
+  .forge-popover {
+    @include preset-dropdown;
+  }
+}
+
+//
+// Constrain viewport width
+//
+:host([constrain-viewport-width]) {
+  .forge-popover {
+    @include override(max-width, 100vw, value);
+  }
+}
+
+//
 // Animation
 // 
 
@@ -199,6 +218,10 @@ forge-overlay {
         }
       }
     }
+
+    .forge-popover.exiting {
+      @include zoom-exit;
+    }
   }
 }
 
@@ -235,6 +258,10 @@ forge-overlay {
         @include override(slidein-x, #{token(slide-offset)}, value);
       }
     }
+
+    .forge-popover.exiting {
+      @include slide-exit;
+    }
   }
 }
 
@@ -245,5 +272,9 @@ forge-overlay {
 :host([animation-type=fade]) {
   .forge-popover {
     @include fade-base;
+
+    &.exiting {
+      @include fade-exit;
+    }
   }
 }

--- a/src/lib/popover/popover.scss
+++ b/src/lib/popover/popover.scss
@@ -3,278 +3,304 @@
 @use '../core/styles/theme';
 @use '../overlay';
 
-//
-// Host
-//
+@layer base, animation, preset, reduced-motion;
 
-:host {
-  display: contents;
+@layer base {
 
-  @include theme.provide((
-    surface: theme.variable(surface-bright)
-  ));
-}
+  //
+  // Host
+  //
 
-:host([hidden]) {
-  display: none;
-}
+  :host {
+    display: contents;
 
-//
-// Base
-//
-
-forge-overlay {
-  @include tokens;
-}
-
-.forge-popover {
-  // Custom private calculation tokens
-  #{declare(arrow-translate-x)}: 0;
-  #{declare(arrow-translate-y)}: 0;
-  #{declare(arrow-rotation)}: 0;
-  #{declare(slidein-x)}: 0;
-  #{declare(slidein-y)}: 0;
-  #{declare(zoomin-origin)}: 50% 50% 0;
-  #{declare(arrow-clip-path)}:
-    polygon(
-      calc(#{token(border-width)} * -1) calc(#{token(border-width)} * -1),
-      calc(100% + #{token(border-width)}) calc(#{token(border-width)} * -1),
-      calc(100% + #{token(border-width)}) calc(100% + #{token(border-width)})
-    );
-}
-
-.forge-popover {
-  @include base;
-}
-
-//
-// No anchor
-//
-
-:host([open][no-anchor]) {
-  forge-overlay {
-    // Alias the overlay position CSS custom properties to use popover-specific tokens
-    @include overlay.provide-theme((
-      position-inline-start: #{token(position-inline-start, custom)},
-      position-inline-end: #{token(position-inline-end, custom)},
-      position-block-start: #{token(position-block-start, custom)},
-      position-block-end: #{token(position-block-end, custom)}
+    @include theme.provide((
+      surface: theme.variable(surface-bright)
     ));
   }
-}
 
-//
-// Arrow
-//
+  :host([hidden]) {
+    display: none;
+  }
 
-:host([arrow]) {
+  //
+  // Base
+  //
+
+  forge-overlay {
+    @include tokens;
+  }
+
   .forge-popover {
-    @include override(border-width, arrow-border-width);
+    // Custom private calculation tokens
+    #{declare(arrow-translate-x)}: 0;
+    #{declare(arrow-translate-y)}: 0;
+    #{declare(arrow-rotation)}: 0;
+    #{declare(slidein-x)}: 0;
+    #{declare(slidein-y)}: 0;
+    #{declare(zoomin-origin)}: 50% 50% 0;
+    #{declare(arrow-clip-path)}:
+      polygon(
+        calc(#{token(border-width)} * -1) calc(#{token(border-width)} * -1),
+        calc(100% + #{token(border-width)}) calc(#{token(border-width)} * -1),
+        calc(100% + #{token(border-width)}) calc(100% + #{token(border-width)})
+      );
   }
 
-  .arrow {
-    @include arrow;
+  .forge-popover {
+    @include base;
   }
 
-  forge-overlay[position-placement^=top] {
+  //
+  // No anchor
+  //
+
+  :host([open][no-anchor]) {
+    forge-overlay {
+      // Alias the overlay position CSS custom properties to use popover-specific tokens
+      @include overlay.provide-theme((
+        position-inline-start: #{token(position-inline-start, custom)},
+        position-inline-end: #{token(position-inline-end, custom)},
+        position-block-start: #{token(position-block-start, custom)},
+        position-block-end: #{token(position-block-end, custom)}
+      ));
+    }
+  }
+
+  //
+  // Arrow
+  //
+
+  :host([arrow]) {
+    .forge-popover {
+      @include override(border-width, arrow-border-width);
+    }
+
     .arrow {
-      @include override(arrow-translate-y, calc(#{token(border-width)} * -1), value);
-      @include override(arrow-rotation, #{token(arrow-top-rotation)}, value);
-    }
-  }
-  
-  forge-overlay[position-placement^=right] {
-    .arrow {
-      @include override(arrow-translate-x, #{token(border-width)}, value);
-      @include override(arrow-rotation, #{token(arrow-right-rotation)}, value);
-    }
-  }
-  
-  forge-overlay[position-placement^=bottom] {
-    .arrow {
-      @include override(arrow-translate-y, #{token(border-width)}, value);
-      @include override(arrow-rotation, #{token(arrow-bottom-rotation)}, value);
-    }
-  }
-  
-  forge-overlay[position-placement^=left] {
-    .arrow {
-      @include override(arrow-translate-x, calc(#{token(border-width)} * -1), value);
-      @include override(arrow-rotation, #{token(arrow-left-rotation)}, value);
-    }
-  }
-}
-
-//
-// Preset - Dropdown
-//
-
-:host([preset=dropdown]) {
-  .forge-popover {
-    @include preset-dropdown;
-  }
-}
-
-//
-// Constrain viewport width
-//
-:host([constrain-viewport-width]) {
-  .forge-popover {
-    @include override(max-width, 100vw, value);
-  }
-}
-
-//
-// Animation
-// 
-
-//
-// Zoom (default)
-//
-
-:host(:not([animation-type])),
-:host([animation-type=zoom]) {
-  .forge-popover {
-    @include zoom-base;
-  }
-
-  forge-overlay[open] {
-    &[position-placement^=top] {
-      &:not([position-placement*='-']) {
-        .forge-popover {
-          @include override(zoomin-origin, bottom center, value);
-        }
-      }
-
-      &[position-placement$=-start] {
-        .forge-popover {
-          @include override(zoomin-origin, bottom left, value);
-        }
-      }
-
-      &[position-placement$=-end] {
-        .forge-popover {
-          @include override(zoomin-origin, bottom right, value);
-        }
-      }
+      @include arrow;
     }
 
-    &[position-placement^=right] {
-      &:not([position-placement*='-']) {
-        .forge-popover {
-          @include override(zoomin-origin, left center, value);
-        }
-      }
-
-      &[position-placement$=-start] {
-        .forge-popover {
-          @include override(zoomin-origin, left top, value);
-        }
-      }
-
-      &[position-placement$=-end] {
-        .forge-popover {
-          @include override(zoomin-origin, left bottom, value);
-        }
-      }
-    }
-
-    &[position-placement^=bottom] {
-      &:not([position-placement*='-']) {
-        .forge-popover {
-          @include override(zoomin-origin, top center, value);
-        }
-      }
-
-      &[position-placement$=-start] {
-        .forge-popover {
-          @include override(zoomin-origin, top left, value);
-        }
-      }
-
-      &[position-placement$=-end] {
-        .forge-popover {
-          @include override(zoomin-origin, top right, value);
-        }
-      }
-    }
-
-    &[position-placement^=left] {
-      &:not([position-placement*='-']) {
-        .forge-popover {
-          @include override(zoomin-origin, right center, value);
-        }
-      }
-
-      &[position-placement$=-start] {
-        .forge-popover {
-          @include override(zoomin-origin, right top, value);
-        }
-      }
-
-      &[position-placement$=-end] {
-        .forge-popover {
-          @include override(zoomin-origin, right bottom, value);
-        }
-      }
-    }
-
-    .forge-popover.exiting {
-      @include zoom-exit;
-    }
-  }
-}
-
-//
-// Slide
-//
-
-:host([animation-type=slide]) {
-  .forge-popover {
-    @include slide-base;
-  }
-
-  forge-overlay[open] {
-    &[position-placement^=top] {
-      .forge-popover {
-        @include override(slidein-y, #{token(slide-offset)}, value);
+    forge-overlay[position-placement^=top] {
+      .arrow {
+        @include override(arrow-translate-y, calc(#{token(border-width)} * -1), value);
+        @include override(arrow-rotation, #{token(arrow-top-rotation)}, value);
       }
     }
     
-    &[position-placement^=right] {
-      .forge-popover {
-        @include override(slidein-x, calc(#{token(slide-offset)} * -1), value);
+    forge-overlay[position-placement^=right] {
+      .arrow {
+        @include override(arrow-translate-x, #{token(border-width)}, value);
+        @include override(arrow-rotation, #{token(arrow-right-rotation)}, value);
       }
     }
     
-    &[position-placement^=bottom] {
-      .forge-popover {
-        @include override(slidein-y, calc(#{token(slide-offset)} * -1), value);
+    forge-overlay[position-placement^=bottom] {
+      .arrow {
+        @include override(arrow-translate-y, #{token(border-width)}, value);
+        @include override(arrow-rotation, #{token(arrow-bottom-rotation)}, value);
       }
     }
     
-    &[position-placement^=left] {
-      .forge-popover {
-        @include override(slidein-x, #{token(slide-offset)}, value);
+    forge-overlay[position-placement^=left] {
+      .arrow {
+        @include override(arrow-translate-x, calc(#{token(border-width)} * -1), value);
+        @include override(arrow-rotation, #{token(arrow-left-rotation)}, value);
       }
-    }
-
-    .forge-popover.exiting {
-      @include slide-exit;
     }
   }
 }
 
-//
-// Fade
-//
+@layer preset {
+  //
+  // Preset - Dropdown
+  //
 
-:host([animation-type=fade]) {
-  .forge-popover {
-    @include fade-base;
+  :host([preset=dropdown]) {
+    .forge-popover {
+      @include preset-dropdown;
+    }
+  }
 
-    &.exiting {
-      @include fade-exit;
+  //
+  // Constrain viewport width
+  //
+  :host([constrain-viewport-width]) {
+    .forge-popover {
+      @include override(max-width, 100vw, value);
+    }
+  }
+}
+
+@layer animation {
+
+  //
+  // Animation
+  // 
+
+  //
+  // Zoom (default)
+  //
+
+  :host(:not([animation-type])),
+  :host([animation-type=zoom]) {
+    .forge-popover {
+      @include zoom-base;
+    }
+
+    forge-overlay[open] {
+      &[position-placement^=top] {
+        &:not([position-placement*='-']) {
+          .forge-popover {
+            @include override(zoomin-origin, bottom center, value);
+          }
+        }
+
+        &[position-placement$=-start] {
+          .forge-popover {
+            @include override(zoomin-origin, bottom left, value);
+          }
+        }
+
+        &[position-placement$=-end] {
+          .forge-popover {
+            @include override(zoomin-origin, bottom right, value);
+          }
+        }
+      }
+
+      &[position-placement^=right] {
+        &:not([position-placement*='-']) {
+          .forge-popover {
+            @include override(zoomin-origin, left center, value);
+          }
+        }
+
+        &[position-placement$=-start] {
+          .forge-popover {
+            @include override(zoomin-origin, left top, value);
+          }
+        }
+
+        &[position-placement$=-end] {
+          .forge-popover {
+            @include override(zoomin-origin, left bottom, value);
+          }
+        }
+      }
+
+      &[position-placement^=bottom] {
+        &:not([position-placement*='-']) {
+          .forge-popover {
+            @include override(zoomin-origin, top center, value);
+          }
+        }
+
+        &[position-placement$=-start] {
+          .forge-popover {
+            @include override(zoomin-origin, top left, value);
+          }
+        }
+
+        &[position-placement$=-end] {
+          .forge-popover {
+            @include override(zoomin-origin, top right, value);
+          }
+        }
+      }
+
+      &[position-placement^=left] {
+        &:not([position-placement*='-']) {
+          .forge-popover {
+            @include override(zoomin-origin, right center, value);
+          }
+        }
+
+        &[position-placement$=-start] {
+          .forge-popover {
+            @include override(zoomin-origin, right top, value);
+          }
+        }
+
+        &[position-placement$=-end] {
+          .forge-popover {
+            @include override(zoomin-origin, right bottom, value);
+          }
+        }
+      }
+
+      .forge-popover.exiting {
+        @include zoom-exit;
+      }
+    }
+  }
+
+  //
+  // Slide
+  //
+
+  :host([animation-type=slide]) {
+    .forge-popover {
+      @include slide-base;
+    }
+
+    forge-overlay[open] {
+      &[position-placement^=top] {
+        .forge-popover {
+          @include override(slidein-y, #{token(slide-offset)}, value);
+        }
+      }
+      
+      &[position-placement^=right] {
+        .forge-popover {
+          @include override(slidein-x, calc(#{token(slide-offset)} * -1), value);
+        }
+      }
+      
+      &[position-placement^=bottom] {
+        .forge-popover {
+          @include override(slidein-y, calc(#{token(slide-offset)} * -1), value);
+        }
+      }
+      
+      &[position-placement^=left] {
+        .forge-popover {
+          @include override(slidein-x, #{token(slide-offset)}, value);
+        }
+      }
+
+      .forge-popover.exiting {
+        @include slide-exit;
+      }
+    }
+  }
+
+  //
+  // Fade
+  //
+
+  :host([animation-type=fade]) {
+    .forge-popover {
+      @include fade-base;
+
+      &.exiting {
+        @include fade-exit;
+      }
+    }
+  }
+}
+
+@layer reduced-motion {
+  //
+  // Prefers reduced motion
+  //
+
+  @media (prefers-reduced-motion: reduce) {
+    .forge-popover {
+      animation: none;
+
+      &.exiting {
+        animation: none;
+      }
     }
   }
 }

--- a/src/lib/popover/popover.test.ts
+++ b/src/lib/popover/popover.test.ts
@@ -658,7 +658,7 @@ describe('Popover', () => {
       expect(harness.isOpen).to.be.true;
       
       await harness.hoverOutside();
-      await timer(POPOVER_HOVER_TIMEOUT + 100);
+      await timer(POPOVER_HOVER_TIMEOUT + EXIT_ANIMATION_DURATION);
 
       expect(harness.isOpen).to.be.false;
     });

--- a/src/lib/popover/popover.test.ts
+++ b/src/lib/popover/popover.test.ts
@@ -4,7 +4,7 @@ import { nothing } from 'lit';
 import { elementUpdated, fixture, html } from '@open-wc/testing';
 import { sendMouse, sendKeys } from '@web/test-runner-commands';
 import { timer } from '@tylertech/forge-testing';
-import { IPopoverToggleEventData, PopoverAnimationType, PopoverTriggerType, POPOVER_CONSTANTS, POPOVER_HOVER_TIMEOUT } from './popover-constants';
+import { IPopoverToggleEventData, PopoverAnimationType, PopoverPreset, PopoverTriggerType, POPOVER_CONSTANTS, POPOVER_HOVER_TIMEOUT } from './popover-constants';
 import { LONGPRESS_TRIGGER_DELAY } from '../core/mixins/interactions/longpress/with-longpress-listener';
 import type { IPopoverComponent } from './popover';
 import type { IOverlayComponent } from '../overlay/overlay';
@@ -35,6 +35,7 @@ describe('Popover', () => {
       expect(harness.popoverElement.persistentHover).to.be.false;
       expect(harness.popoverElement.hoverDelay).to.equal(POPOVER_CONSTANTS.defaults.HOVER_DELAY);
       expect(harness.popoverElement.hoverDismissDelay).to.equal(POPOVER_HOVER_TIMEOUT);
+      expect(harness.popoverElement.preset).to.equal(POPOVER_CONSTANTS.defaults.PRESET);
     });
 
     it('should provide internal overlay element reference', async () => {
@@ -84,6 +85,36 @@ describe('Popover', () => {
 
       expect(harness.popoverElement.animationType).to.equal('none');
       expect(getComputedStyle(harness.surfaceElement).animationName).to.equal('none');
+    });
+
+    it('should set preset via attribute', async () => {
+      const harness = await createFixture({ preset: 'dropdown' });
+
+      expect(harness.popoverElement.preset).to.equal('dropdown');
+      expect(harness.popoverElement.getAttribute(POPOVER_CONSTANTS.attributes.PRESET)).to.equal('dropdown');
+    });
+
+    it('should set preset via property', async () => {
+      const harness = await createFixture();
+
+      expect(harness.popoverElement.hasAttribute(POPOVER_CONSTANTS.attributes.PRESET)).to.be.false;
+
+      harness.popoverElement.preset = 'dropdown';
+
+      expect(harness.popoverElement.preset).to.equal('dropdown');
+      expect(harness.popoverElement.getAttribute(POPOVER_CONSTANTS.attributes.PRESET)).to.equal('dropdown');
+    });
+
+    it('should remove preset attribute when setting preset to default value', async () => {
+      const harness = await createFixture({ preset: 'dropdown' });
+
+      expect(harness.popoverElement.preset).to.equal('dropdown');
+      expect(harness.popoverElement.getAttribute(POPOVER_CONSTANTS.attributes.PRESET)).to.equal('dropdown');
+
+      harness.popoverElement.preset = 'popover';
+
+      expect(harness.popoverElement.preset).to.equal('popover');
+      expect(harness.popoverElement.hasAttribute(POPOVER_CONSTANTS.attributes.PRESET)).to.be.false;
     });
   });
 
@@ -1476,6 +1507,7 @@ interface IPopoverFixtureConfig {
   triggerType?: PopoverTriggerType;
   persistentHover?: boolean;
   hoverDelay?: number;
+  preset?: PopoverPreset;
 }
 
 async function createFixture({
@@ -1486,7 +1518,8 @@ async function createFixture({
   animationType,
   triggerType,
   persistentHover = false,
-  hoverDelay
+  hoverDelay,
+  preset
 }: IPopoverFixtureConfig = {}): Promise<PopoverHarness> {
   const container = await fixture(html`
     <div style="display: flex; justify-content: center; align-items: center; height: 300px; width: 300px;">
@@ -1500,7 +1533,8 @@ async function createFixture({
         ?persistent-hover=${persistentHover}
         ?hoverDelay=${hoverDelay}
         animation-type=${animationType ?? nothing}
-        trigger-type=${triggerType ?? nothing}>
+        trigger-type=${triggerType ?? nothing}
+        preset=${preset ?? nothing}>
         <span>Test popover content</span>
         <button type="button" id="content-button" style="pointer-events: none;">Button</button>
         <forge-popover id="nested-popover">Nested popover</forge-popover>

--- a/src/lib/popover/popover.test.ts
+++ b/src/lib/popover/popover.test.ts
@@ -14,6 +14,8 @@ import { VirtualElement } from '../core/utils/position-utils';
 
 import './popover';
 
+const EXIT_ANIMATION_DURATION = 200;
+
 describe('Popover', () => {
   afterEach(async () => {
     // Always reset mouse position to avoid initial hover state issues when a test starts
@@ -280,6 +282,7 @@ describe('Popover', () => {
       harness.popoverElement.addEventListener(POPOVER_CONSTANTS.events.TOGGLE, toggleSpy);
 
       await harness.clickTrigger();
+      await harness.exitAnimation();
 
       expect(toggleSpy).to.have.been.calledOnce;
       expect(toggleSpy.firstCall.args[0].detail).to.deep.equal({ oldState: 'open', newState: 'closed' });
@@ -325,6 +328,7 @@ describe('Popover', () => {
       harness.popoverElement.addEventListener(POPOVER_CONSTANTS.events.TOGGLE, toggleSpy);
 
       await harness.clickTrigger();
+      await harness.exitAnimation();
 
       expect(harness.isOpen).to.be.false;
     });
@@ -367,6 +371,7 @@ describe('Popover', () => {
       harness.popoverElement.addEventListener(POPOVER_CONSTANTS.events.TOGGLE, toggleSpy);
 
       await harness.clickTrigger();
+      await harness.exitAnimation();
 
       expect(toggleSpy).to.have.been.calledOnce;
     });
@@ -459,6 +464,7 @@ describe('Popover', () => {
       const harness = await createFixture({ open: true });
 
       await harness.clickTrigger();
+      await harness.exitAnimation();
 
       expect(harness.isOpen).to.be.false;
     });
@@ -470,6 +476,7 @@ describe('Popover', () => {
       expect(harness.isOpen).to.be.true;
 
       await harness.clickTrigger();
+      await harness.exitAnimation();
       expect(harness.isOpen).to.be.false;
     });
 
@@ -525,6 +532,7 @@ describe('Popover', () => {
       expect(harness.isOpen).to.be.true;
 
       await harness.blurTrigger();
+      await harness.exitAnimation();
       expect(harness.isOpen).to.be.false;
     });
 
@@ -576,6 +584,7 @@ describe('Popover', () => {
       expect(harness.isOpen).to.be.true;
 
       await sendKeys({ press: 'Tab' });
+      await harness.exitAnimation();
 
       expect(document.activeElement).not.to.equal(harness.triggerElement);
       expect(document.activeElement).not.to.equal(harness.contentButton);
@@ -678,6 +687,7 @@ describe('Popover', () => {
       await elementUpdated(harness.popoverElement);
       await harness.hoverOutside();
       await timer(POPOVER_HOVER_TIMEOUT + 100);
+      await harness.exitAnimation();
 
       expect(harness.isOpen).to.be.false;
     });
@@ -696,6 +706,7 @@ describe('Popover', () => {
 
       await harness.hoverOutside();
       await timer(customDelay + 100);
+      await harness.exitAnimation();
 
       expect(harness.isOpen).to.be.false;
     });
@@ -769,6 +780,7 @@ describe('Popover', () => {
       expect(harness.isOpen).to.be.true;
 
       await harness.clickOutside();
+      await harness.exitAnimation();
       expect(harness.isOpen).to.be.false;
     });
 
@@ -835,6 +847,7 @@ describe('Popover', () => {
       expect(harness.isOpen).to.be.true;
 
       harness.doubleClickTrigger();
+      await harness.exitAnimation();
       expect(harness.isOpen).to.be.false;
     });
 
@@ -991,6 +1004,7 @@ describe('Popover', () => {
       expect(harness.isOpen).to.be.true;
       
       await harness.blurTrigger();
+      await harness.exitAnimation();
       expect(harness.isOpen).to.be.false;
     });
 
@@ -1010,6 +1024,7 @@ describe('Popover', () => {
       
       await harness.hoverOutside();
       await timer(POPOVER_HOVER_TIMEOUT + 100);
+      await harness.exitAnimation();
 
       expect(harness.isOpen).to.be.false;
     });
@@ -1020,6 +1035,7 @@ describe('Popover', () => {
       const harness = await createFixture({ open: true });
 
       await harness.clickOutside();
+      await harness.exitAnimation();
 
       expect(harness.isOpen).to.be.false;
     });
@@ -1036,6 +1052,7 @@ describe('Popover', () => {
       const harness = await createFixture({ open: true });
 
       await harness.pressEscapeKey();
+      await harness.exitAnimation();
 
       expect(harness.isOpen).to.be.false;
     });
@@ -1240,6 +1257,7 @@ describe('Popover', () => {
       harness.nestedPopoverElement.open = true;
 
       await harness.clickSurface();
+      await harness.exitAnimation();
 
       expect(harness.isOpen).to.be.true;
       expect(harness.nestedPopoverElement.open).to.be.false;
@@ -1301,6 +1319,7 @@ describe('Popover', () => {
       expect(document.activeElement).to.be.equal(autofocusEl);
 
       await harness.pressEscapeKey();
+      await harness.exitAnimation();
 
       expect(document.activeElement).to.be.equal(harness.triggerElement);
     });
@@ -1441,6 +1460,10 @@ class PopoverHarness {
 
   public async pressEscapeKey(): Promise<void> {
     await sendKeys({ press: 'Escape' });
+  }
+
+  public exitAnimation(): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, 200));
   }
 }
 

--- a/src/lib/popover/popover.ts
+++ b/src/lib/popover/popover.ts
@@ -18,6 +18,7 @@ export interface IPopoverComponent extends IOverlayAware, IDismissible {
   persistentHover: boolean;
   hoverDelay: number;
   hoverDismissDelay: number;
+  hideAsync(): Promise<void>;
 }
 
 declare global {
@@ -172,4 +173,8 @@ export class PopoverComponent extends OverlayAware<IPopoverFoundation> implement
 
   @FoundationProperty()
   public declare hoverDismissDelay: number;
+
+  public hideAsync(): Promise<void> {
+    return this._foundation.hideAsync();
+  }
 }

--- a/src/lib/popover/popover.ts
+++ b/src/lib/popover/popover.ts
@@ -1,6 +1,6 @@
 import { attachShadowTemplate, coerceBoolean, coerceNumber, CustomElement, FoundationProperty } from '@tylertech/forge-core';
 import { PopoverAdapter } from './popover-adapter';
-import { IPopoverToggleEventData, PopoverAnimationType, PopoverTriggerType, POPOVER_CONSTANTS } from './popover-constants';
+import { IPopoverToggleEventData, PopoverAnimationType, PopoverPreset, PopoverTriggerType, POPOVER_CONSTANTS } from './popover-constants';
 import { IPopoverFoundation, PopoverFoundation } from './popover-foundation';
 import { OverlayComponent, OVERLAY_CONSTANTS } from '../overlay';
 import { IOverlayAware, OverlayAware } from '../overlay/base/overlay-aware';
@@ -18,6 +18,7 @@ export interface IPopoverComponent extends IOverlayAware, IDismissible {
   persistentHover: boolean;
   hoverDelay: number;
   hoverDismissDelay: number;
+  preset: PopoverPreset;
   hideAsync(): Promise<void>;
 }
 
@@ -44,6 +45,7 @@ declare global {
  * @property {boolean} persistentHover - Whether or not the popover should remain open when the user hovers outside the popover.
  * @property {number} hoverDismissDelay - The delay in milliseconds before the popover is dismissed when the user hovers outside of the popover.
  * @property {number} hoverDelay - The delay in milliseconds before the popover is shown.
+ * @property {PopoverPreset} preset - The preset to use for the popover.
  * 
  * @attribute {string} arrow - Whether or not the popover should render an arrow.
  * @attribute {string} animation-type - The animation type to use for the popover. Valid values are `'none'`, `'fade'`, `'slide'`, and `'zoom'` (default).
@@ -52,6 +54,7 @@ declare global {
  * @attribute {string} persistent-hover - Whether or not the popover should remain open when the user hovers outside the popover.
  * @attribute {string} hover-dismiss-delay - The delay in milliseconds before the popover is dismissed when the user hovers outside of the popover.
  * @attribute {number} hover-delay - The delay in milliseconds before the popover is shown.
+ * @attribute {string} preset - The preset to use for the popover.
  * 
  * @event {CustomEvent<IPopoverToggleEventData} forge-popover-beforetoggle - Dispatches before the popover is toggled, and is cancelable.
  * @event {CustomEvent<IPopoverToggleEventData} forge-popover-toggle - Dispatches after the popover is toggled.
@@ -62,6 +65,12 @@ declare global {
  * @cssproperty --forge-popover-border-width - The border width of the popover surface.
  * @cssproperty --forge-popover-border-style - The border style of the popover surface.
  * @cssproperty --forge-popover-border-color - The border color of the popover surface.
+ * @cssproperty --forge-popover-width - The width of the popover surface. Defaults to `auto`.
+ * @cssproperty --forge-popover-height - The height of the popover surface. Defaults to `auto`.
+ * @cssproperty --forge-popover-min-width - The minimum width of the popover surface. Defaults to `none`.
+ * @cssproperty --forge-popover-max-width - The maximum width of the popover surface. Defaults to `none`.
+ * @cssproperty --forge-popover-min-height - The minimum height of the popover surface. Defaults to `none`.
+ * @cssproperty --forge-popover-max-height - The maximum height of the popover surface. Defaults to `none`.
  * @cssproperty --forge-popover-arrow-size - The size of the arrow.
  * @cssproperty --forge-popover-arrow-height - The height of the arrow.
  * @cssproperty --forge-popover-arrow-width - The width of the arrow.
@@ -84,6 +93,8 @@ declare global {
  * @cssproperty --forge-popover-position-block-end - The `block-end` position of the popover.
  * @cssproperty --forge-popover-position-inline-start - The `inline-start` position of the popover.
  * @cssproperty --forge-popover-position-inline-end - The `inline-end` position of the popover.
+ * @cssproperty --forge-popover-preset-dropdown-max-height - The maximum height of the popover when using `preset="dropdown"`. Defaults to `256px`.
+ * @cssproperty --forge-popover-preset-dropdown-overflow - The overflow behavior of the popover when using `preset="dropdown"`. Defaults to `auto visible` (vertical scrolling only).
  * 
  * @slot - The content to render inside the popover.
  * 
@@ -98,13 +109,7 @@ export class PopoverComponent extends OverlayAware<IPopoverFoundation> implement
   public static get observedAttributes(): string[] {
     return [
       ...Object.values(OVERLAY_CONSTANTS.observedAttributes),
-      POPOVER_CONSTANTS.attributes.ARROW,
-      POPOVER_CONSTANTS.attributes.ANIMATION_TYPE,
-      POPOVER_CONSTANTS.attributes.TRIGGER_TYPE,
-      POPOVER_CONSTANTS.attributes.LONGPRESS_DELAY,
-      POPOVER_CONSTANTS.attributes.PERSISTENT_HOVER,
-      POPOVER_CONSTANTS.attributes.HOVER_DELAY,
-      POPOVER_CONSTANTS.attributes.HOVER_DISMISS_DELAY
+      ...Object.values(POPOVER_CONSTANTS.observedAttributes)
     ];
   }
 
@@ -128,26 +133,29 @@ export class PopoverComponent extends OverlayAware<IPopoverFoundation> implement
 
   public attributeChangedCallback(name: string, oldValue: string, newValue: string): void {
     switch (name) {
-      case POPOVER_CONSTANTS.attributes.ARROW:
+      case POPOVER_CONSTANTS.observedAttributes.ARROW:
         this.arrow = coerceBoolean(newValue);
         return;
-      case POPOVER_CONSTANTS.attributes.ANIMATION_TYPE:
+      case POPOVER_CONSTANTS.observedAttributes.ANIMATION_TYPE:
         this.animationType = newValue as PopoverAnimationType;
         return;
-      case POPOVER_CONSTANTS.attributes.TRIGGER_TYPE:
+      case POPOVER_CONSTANTS.observedAttributes.TRIGGER_TYPE:
         this.triggerType = newValue?.trim() ? coerceStringToArray<PopoverTriggerType>(newValue) : POPOVER_CONSTANTS.defaults.TRIGGER_TYPE;
         return;
-      case POPOVER_CONSTANTS.attributes.LONGPRESS_DELAY:
+      case POPOVER_CONSTANTS.observedAttributes.LONGPRESS_DELAY:
         this.longpressDelay = coerceNumber(newValue);
         return;
-      case POPOVER_CONSTANTS.attributes.PERSISTENT_HOVER:
+      case POPOVER_CONSTANTS.observedAttributes.PERSISTENT_HOVER:
         this.persistentHover = coerceBoolean(newValue);
         return;
-      case POPOVER_CONSTANTS.attributes.HOVER_DELAY:
+      case POPOVER_CONSTANTS.observedAttributes.HOVER_DELAY:
         this.hoverDelay = coerceNumber(newValue);
         return;
-      case POPOVER_CONSTANTS.attributes.HOVER_DISMISS_DELAY:
+      case POPOVER_CONSTANTS.observedAttributes.HOVER_DISMISS_DELAY:
         this.hoverDismissDelay = coerceNumber(newValue);
+        return;
+      case POPOVER_CONSTANTS.observedAttributes.PRESET:
+        this.preset = newValue as PopoverPreset;
         return;
     }
     super.attributeChangedCallback(name, oldValue, newValue);
@@ -173,6 +181,9 @@ export class PopoverComponent extends OverlayAware<IPopoverFoundation> implement
 
   @FoundationProperty()
   public declare hoverDismissDelay: number;
+
+  @FoundationProperty()
+  public declare preset: PopoverPreset;
 
   public hideAsync(): Promise<void> {
     return this._foundation.hideAsync();

--- a/src/lib/select/build.json
+++ b/src/lib/select/build.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "../../../node_modules/@tylertech/forge-cli/config/build-schema.json",
-  "extends": "../build.json"
-}

--- a/src/lib/select/core/base-select-adapter.ts
+++ b/src/lib/select/core/base-select-adapter.ts
@@ -7,7 +7,7 @@ import { IOptionComponent, OPTION_CONSTANTS } from '../option';
 import { IOptionGroupComponent, OPTION_GROUP_CONSTANTS } from '../option-group';
 import { ISelectOption, ISelectOptionGroup, SelectOptionListenerDestructor } from './base-select-constants';
 import { isOptionGroupObject } from './select-utils';
-import { IPopupComponent, POPUP_CONSTANTS } from '../../popup';
+import { IPopoverComponent, POPOVER_CONSTANTS } from '../../popover';
 
 export interface IBaseSelectAdapter extends IBaseAdapter {
   initializeAccessibility(): void;
@@ -19,6 +19,7 @@ export interface IBaseSelectAdapter extends IBaseAdapter {
   setOptions(options: ISelectOption[] | ISelectOptionGroup[], clear?: boolean): void;
   open(config: IListDropdownConfig): void;
   close(): void;
+  destroyListDropdown(): void;
   setDismissListener(listener: () => void): void;
   scrollSelectedOptionIntoView(): void;
   activateSelectedOption(): void;
@@ -110,21 +111,25 @@ export abstract class BaseSelectAdapter extends BaseAdapter<IBaseSelectComponent
     this._listDropdown.open();
   }
 
-  public close(): void {
+  public async close(): Promise<void> {
     if (this._listDropdown) {
-      this._listDropdown.close();
-      this._listDropdown.destroy();
-      this._listDropdown = undefined;
+      await this._listDropdown.close();
+      this.destroyListDropdown();
     }
+  }
+
+  public destroyListDropdown(): void {
+    this._listDropdown?.destroy();
+    this._listDropdown = undefined;
   }
 
   public setDismissListener(listener: () => void): void {
     if (!this._listDropdown || !this._listDropdown.dropdownElement) {
       return;
     }
-    const dropdownElement = this._listDropdown.dropdownElement as IPopupComponent;
-    if (dropdownElement.targetElement) {
-      dropdownElement.targetElement.addEventListener(POPUP_CONSTANTS.events.BLUR, listener);
+    const dropdownElement = this._listDropdown.dropdownElement as IPopoverComponent;
+    if (dropdownElement.anchorElement && dropdownElement.anchorElement instanceof HTMLElement) {
+      dropdownElement.anchorElement.addEventListener(POPOVER_CONSTANTS.events.TOGGLE, listener);
     }
   }
 
@@ -215,7 +220,7 @@ export abstract class BaseSelectAdapter extends BaseAdapter<IBaseSelectComponent
     }
     // We need to wait for the next animation frame to ensure that the layout has been updated
     window.requestAnimationFrame(() => {
-      const dropdownEl = this.popupElement as IPopupComponent | undefined;
+      const dropdownEl = this.popupElement as IPopoverComponent | undefined;
       dropdownEl?.position();
     });
   }

--- a/src/lib/select/core/base-select-foundation.ts
+++ b/src/lib/select/core/base-select-foundation.ts
@@ -89,13 +89,12 @@ export abstract class BaseSelectFoundation<T extends IBaseSelectAdapter> extends
     this._adapter.removeTargetListener('focus', this._focusListener);
     this._adapter.removeTargetListener('keydown', this._keydownListener);
 
-    if (this._open) {
-      this._closeDropdown();
-    }
-
     if (this._optionListenerDestructor) {
       this._optionListenerDestructor();
     }
+ 
+    this._open = false;
+    this._adapter.destroyListDropdown();
   }
 
   public appendOptions(options: ISelectOption[] | ISelectOptionGroup[]): void {

--- a/src/lib/select/core/base-select.ts
+++ b/src/lib/select/core/base-select.ts
@@ -10,7 +10,7 @@ import {
 } from './base-select-constants';
 import { IBaseSelectFoundation } from './base-select-foundation';
 import { IListDropdownAware, ListDropdownAware } from '../../list-dropdown/list-dropdown-aware';
-import { IPopupComponent } from '../../popup';
+import type { IPopoverComponent } from '../../popover/popover';
 
 
 export interface IBaseSelectComponent extends IListDropdownAware {
@@ -21,7 +21,7 @@ export interface IBaseSelectComponent extends IListDropdownAware {
   open: boolean;
   optionBuilder: SelectOptionBuilder;
   selectedTextBuilder: SelectSelectedTextBuilder;
-  popupElement: IPopupComponent | undefined;
+  popupElement: IPopoverComponent | undefined;
   beforeValueChange: SelectBeforeValueChangeCallback<any>;
   appendOptions(options: ISelectOption[] | ISelectOption[]): void;
   selectAll(): void;
@@ -72,7 +72,7 @@ export abstract class BaseSelectComponent<T extends IBaseSelectFoundation> exten
    * @readonly
    */
   @FoundationProperty({ set: false })
-  public declare popupElement: IPopupComponent | undefined;
+  public declare popupElement: IPopoverComponent | undefined;
   
   public attributeChangedCallback(name: string, oldValue: string, newValue: string): void {
     super.attributeChangedCallback(name, oldValue, newValue);

--- a/src/lib/select/select-dropdown/select-dropdown-adapter.ts
+++ b/src/lib/select/select-dropdown/select-dropdown-adapter.ts
@@ -67,11 +67,11 @@ export class SelectDropdownAdapter extends BaseSelectAdapter implements ISelectD
     this._targetElement.setAttribute('aria-expanded', 'true');
   }
 
-  public close(): void {
+  public close(): Promise<void> {
     this._targetElement.setAttribute('aria-expanded', 'false');
     this._targetElement.removeAttribute('aria-activedescendant');
     this._targetElement.removeAttribute('aria-controls');
-    super.close();
+    return super.close();
   }
 
   public attach(selector: string): void {

--- a/src/lib/select/select-dropdown/select-dropdown.ts
+++ b/src/lib/select/select-dropdown/select-dropdown.ts
@@ -7,12 +7,12 @@ import { BASE_SELECT_CONSTANTS } from '../core/base-select-constants';
 import { SelectDropdownAdapter } from './select-dropdown-adapter';
 import { OptionComponent } from '../option';
 import { OptionGroupComponent } from '../option-group';
-import { PopupComponent } from '../../popup';
 import { ListComponent, ListItemComponent } from '../../list';
 import { CircularProgressComponent } from '../../circular-progress';
 import { ScaffoldComponent } from '../../scaffold';
 import { ToolbarComponent } from '../../toolbar';
 import { IconButtonComponent } from '../../icon-button';
+import { PopoverComponent } from '../../popover/popover';
 
 import template from './select-dropdown.html';
 import styles from './select-dropdown.scss';
@@ -34,8 +34,6 @@ declare global {
 }
 
 /**
- * The web component class behind the `<forge-select-dropdown>` custom element.
- * 
  * @tag forge-select-dropdown
  */
 @CustomElement({
@@ -43,7 +41,7 @@ declare global {
   dependencies: [
     OptionComponent,
     OptionGroupComponent,
-    PopupComponent,
+    PopoverComponent,
     ListComponent,
     ListItemComponent,
     CircularProgressComponent,

--- a/src/lib/select/select/select-adapter.ts
+++ b/src/lib/select/select/select-adapter.ts
@@ -129,12 +129,12 @@ export class SelectAdapter extends BaseSelectAdapter implements ISelectAdapter {
     toggleClass(this._selectElement, true, SELECT_CONSTANTS.classes.OPENED);
   }
 
-  public close(): void {
+  public close(): Promise<void> {
     this._component.setAttribute('aria-expanded', 'false');
     this._component.removeAttribute('aria-activedescendant');
     this._component.removeAttribute('aria-controls');
     toggleClass(this._selectElement, false, SELECT_CONSTANTS.classes.OPENED);
-    super.close();
+    return super.close();
   }
 
   public updateActiveDescendant(id: string): void {

--- a/src/lib/select/select/select.ts
+++ b/src/lib/select/select/select.ts
@@ -4,7 +4,6 @@ import { SelectAdapter } from './select-adapter';
 import { SelectFoundation } from './select-foundation';
 import { SELECT_CONSTANTS } from './select-constants';
 import { OptionComponent } from '../option';
-import { PopupComponent } from '../../popup';
 import { ListComponent, ListItemComponent } from '../../list';
 import { OptionGroupComponent } from '../option-group';
 import { IconComponent, IconRegistry } from '../../icon';
@@ -18,6 +17,7 @@ import { IBaseSelectComponent } from '../core/base-select';
 
 import template from './select.html';
 import styles from './select.scss';
+import { PopoverComponent } from '../../popover';
 
 export interface ISelectComponent extends IBaseSelectComponent {
   density: FieldDensityType;
@@ -42,8 +42,6 @@ declare global {
 }
 
 /**
- * The custom element class behind the `<forge-select>` component.
- * 
  * @tag forge-select
  */
 @CustomElement({
@@ -51,7 +49,7 @@ declare global {
   dependencies: [
     OptionComponent,
     OptionGroupComponent,
-    PopupComponent,
+    PopoverComponent,
     ListComponent,
     ListItemComponent,
     CircularProgressComponent,

--- a/src/lib/time-picker/time-picker-adapter.ts
+++ b/src/lib/time-picker/time-picker-adapter.ts
@@ -30,7 +30,7 @@ export interface ITimePickerAdapter extends BaseAdapter<ITimePickerComponent> {
   isInputFocused(): boolean;
   setDisabled(isDisabled: boolean): void;
   attachDropdown(config: IListDropdownConfig): void;
-  detachDropdown(): void;
+  detachDropdown(options: { destroy?: boolean }): Promise<void>;
   setActiveDescendant(id: string): void;
   propagateKey(key: string): void;
   getTargetElementWidth(selector: string): number;
@@ -198,10 +198,13 @@ export class TimePickerAdapter extends BaseAdapter<ITimePickerComponent> impleme
     this._inputElement.setAttribute('aria-controls', `list-dropdown-popup-${config.id}`);
   }
   
-  public detachDropdown(): void {
+  public async detachDropdown({ destroy = false } = {}): Promise<void> {
     if (this._listDropdown) {
-      this._listDropdown.close();
-      this._listDropdown.destroy();
+      if (destroy) {
+        this._listDropdown.destroy();
+      } else {
+        await this._listDropdown.close();
+      }
       this._listDropdown = undefined;
     }
     this._inputElement.removeAttribute('aria-controls');

--- a/src/lib/time-picker/time-picker-foundation.ts
+++ b/src/lib/time-picker/time-picker-foundation.ts
@@ -147,7 +147,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
     }
 
     // Ensure we remove our dropdown
-    this._closeDropdown();
+    this._closeDropdown({ destroy: true });
 
     // Cleanup any resources used in the adapter
     this._adapter.destroy();
@@ -183,7 +183,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
         if (this._open) {
           evt.preventDefault();
           evt.stopPropagation();
-          this._closeDropdown(true);
+          this._closeDropdown({ emitCloseEvent: true });
         }
         break;
       case 'Down':
@@ -275,7 +275,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
     evt.preventDefault();
 
     if (this._open) {
-      this._closeDropdown(true);
+      this._closeDropdown({ emitCloseEvent: true });
     } else {
       if (!Platform.isMobile) {
         this._adapter.tryFocusInput();
@@ -304,7 +304,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
     this._formatInputValue();
 
     if (this._open && !this._adapter.isInputFocused()) {
-      this._closeDropdown(true);
+      this._closeDropdown({ emitCloseEvent: true });
     }
   }
 
@@ -359,7 +359,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
       this._adapter.tryCreateToggle();
       this._adapter.addToggleListener('mousedown', this._toggleMousedownListener);
     } else if (this._open) {
-      this._closeDropdown(true);
+      this._closeDropdown({ emitCloseEvent: true });
     }
   }
 
@@ -393,7 +393,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
     }
 
     if (this._open) {
-      this._closeDropdown(true);
+      this._closeDropdown({ emitCloseEvent: true });
     }
 
     // Let's attempt to coerce our time string into a known format to help with ease of entry
@@ -488,7 +488,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
   }
 
   private _onSelect(value: ITimePickerOptionValue): void {
-    this._closeDropdown(true);
+    this._closeDropdown({ emitCloseEvent: true });
 
     // Check if the "Now" option was selected
     if (!value.isCustom && value.metadata === 'now') {
@@ -606,7 +606,7 @@ export class TimePickerFoundation implements ITimePickerFoundation {
       type: ListDropdownType.Standard,
       options,
       selectCallback: value => this._onSelect(value),
-      closeCallback: () => this._closeDropdown(true),
+      closeCallback: () => this._closeDropdown({ emitCloseEvent: true }),
       activeChangeCallback: id => this._adapter.setActiveDescendant(id),
       targetWidthCallback: () => this._adapter.getTargetElementWidth(this._popupTarget)
     };
@@ -614,11 +614,11 @@ export class TimePickerFoundation implements ITimePickerFoundation {
     this._adapter.emitHostEvent(TIME_PICKER_CONSTANTS.events.OPEN, undefined, false);
   }
 
-  private _closeDropdown(emitCloseEvent = false): void {
+  private _closeDropdown({ destroy = false, emitCloseEvent = false } = {}): void {
     this._open = false;
     this._dropdownConfig = undefined;
     this._adapter.removeHostAttribute(TIME_PICKER_CONSTANTS.attributes.OPEN);
-    this._adapter.detachDropdown();
+    this._adapter.detachDropdown({ destroy });
     if (emitCloseEvent) {
       this._adapter.emitHostEvent(TIME_PICKER_CONSTANTS.events.CLOSE, true, false);
     }

--- a/src/lib/time-picker/time-picker.ts
+++ b/src/lib/time-picker/time-picker.ts
@@ -14,10 +14,10 @@ import {
 } from './time-picker-constants';
 import { IconRegistry, IconComponent } from '../icon';
 import { IconButtonComponent } from '../icon-button';
-import { PopupComponent } from '../popup';
 import { DialogComponent } from '../dialog';
 import { ListComponent, ListItemComponent } from '../list';
 import { BaseComponent, IBaseComponent } from '../core/base/base-component';
+import { PopoverComponent } from '../popover/popover';
 
 import template from './time-picker.html';
 import styles from './time-picker.scss';
@@ -75,7 +75,7 @@ declare global {
     ListItemComponent,
     IconButtonComponent,
     IconComponent,
-    PopupComponent,
+    PopoverComponent,
     IconComponent,
     DialogComponent
   ]

--- a/src/test/spec/autocomplete/autocomplete.spec.ts
+++ b/src/test/spec/autocomplete/autocomplete.spec.ts
@@ -1,4 +1,4 @@
-import { removeElement } from '@tylertech/forge-core';
+import { getShadowElement, removeElement } from '@tylertech/forge-core';
 import { tick, timer } from '@tylertech/forge-testing';
 import {
   defineAutocompleteComponent,
@@ -14,7 +14,6 @@ import {
   IAutocompleteComponentDelegateConfig,
   IAutocompleteComponentDelegateOptions
 } from '@tylertech/forge/autocomplete';
-import { POPUP_CONSTANTS } from '@tylertech/forge/popup';
 import { LIST_ITEM_CONSTANTS, IListItemComponent, LIST_CONSTANTS } from '@tylertech/forge/list';
 import { IOption, IOptionComponent, OPTION_CONSTANTS } from '@tylertech/forge/select';
 import { SKELETON_CONSTANTS, ISkeletonComponent } from '@tylertech/forge/skeleton';
@@ -24,6 +23,7 @@ import { AVATAR_CONSTANTS, IAvatarComponent } from '@tylertech/forge/avatar';
 import { ICON_CONSTANTS, IconComponent } from '@tylertech/forge/icon';
 import { LIST_DROPDOWN_CONSTANTS } from '@tylertech/forge/list-dropdown';
 import { tryCleanupPopups } from '../../utils';
+import { POPOVER_CONSTANTS } from '../../../lib';
 
 const DEFAULT_FILTER_OPTIONS = [
   { label: 'One', value: 1 },
@@ -54,6 +54,8 @@ const DEFAULT_AUTOCOMPLETE_TEXTFIELD_DELEGATE_CONFIG: IAutocompleteComponentDele
     }
   }
 };
+
+const POPOVER_ANIMATION_DURATION = 200;
 
 interface ITestContext {
   context: ITestAutocompleteContext 
@@ -133,6 +135,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       this.context.component.filter = () => [];
       _triggerDropdownClick(this.context.input);
       await tick();
+      await timer(POPOVER_ANIMATION_DURATION);
 
       expect(this.context.component.popupElement).toBeNull();
     });
@@ -162,7 +165,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       this.context.component.openDropdown();
       await timer();
       this.context.component.closeDropdown();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       expect(this.context.component.open).toBe(false);
       expect(this.context.component.popupElement).toBeNull();
     });
@@ -416,7 +419,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       expect(this.context.component.popupElement).not.toBeNull();
 
       this.context.input.dispatchEvent(new Event('blur'));
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       expect(this.context.component.popupElement).toBeNull();
     });
@@ -435,7 +438,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       _triggerDropdownClick(this.context.input);
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
 
       const activeListItemIndex = _getActiveListItemIndex(this.context.component.popupElement);
@@ -448,7 +451,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       _triggerDropdownClick(this.context.input);
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' })); // 0
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' })); // 1
@@ -464,7 +467,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       _triggerDropdownClick(this.context.input);
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
 
       const activeListItemIndex = _getActiveListItemIndex(this.context.component.popupElement);
@@ -477,7 +480,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       
       _triggerDropdownClick(this.context.input);
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       // We have 3 options
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' })); // Index 0
@@ -495,7 +498,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       _triggerDropdownClick(this.context.input);
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
 
       const activeListItemIndex = _getActiveListItemIndex(this.context.component.popupElement);
@@ -508,7 +511,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       _triggerDropdownClick(this.context.input);
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
@@ -523,10 +526,10 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       _triggerDropdownClick(this.context.input);
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       expect(this.context.component.popupElement).toBeNull();
     });
@@ -586,7 +589,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       _triggerDropdownClick(this.context.input);
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 
@@ -611,7 +614,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       _triggerDropdownClick(this.context.input);
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       _sendInputValue(this.context.input, 'other');
       await timer(AUTOCOMPLETE_CONSTANTS.numbers.DEFAULT_DEBOUNCE_TIME);
@@ -631,7 +634,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       _triggerDropdownClick(this.context.input);
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       this.context.input.blur();
 
       expect(changeSpy).not.toHaveBeenCalled();
@@ -647,7 +650,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       _triggerDropdownClick(this.context.input);
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       await tick();
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
@@ -667,7 +670,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       _triggerDropdownClick(this.context.input);
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       this.context.input.blur();
 
       expect(changeSpy).not.toHaveBeenCalled();
@@ -683,7 +686,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       this.context.component.addEventListener(AUTOCOMPLETE_CONSTANTS.events.CHANGE, changeSpy);
       _triggerDropdownClick(this.context.input);
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
@@ -750,7 +753,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       expect(this.context.component.popupElement).not.toBeNull();
     });
@@ -762,7 +765,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       const activeListItemIndex = _getActiveListItemIndex(this.context.component.popupElement);
       expect(activeListItemIndex).toBe(0);
@@ -777,7 +780,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       this.context.input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       const activeListItemIndex = _getActiveListItemIndex(this.context.component.popupElement);
       expect(activeListItemIndex).toBe(expectedSelectedIndex);
@@ -789,7 +792,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       this.context.input.focus();
       this.context.component.openDropdown();
 
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       this.context.input.value = 'o';
       this.context.input.dispatchEvent(new Event('input'));
@@ -807,7 +810,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       this.context.input.focus();
       this.context.component.openDropdown();
 
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       this.context.input.value = 'o';
       this.context.input.dispatchEvent(new Event('input'));
@@ -830,7 +833,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       this.context.input.dispatchEvent(new Event('input'));
 
       await timer(AUTOCOMPLETE_CONSTANTS.numbers.DEFAULT_DEBOUNCE_TIME);
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       await tick();
 
       const activeListItemIndex = _getActiveListItemIndex(this.context.component.popupElement);
@@ -855,11 +858,12 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       this.context.component.filter = () => DEFAULT_FILTER_OPTIONS;
       this.context.component.openDropdown();
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
-      const popup = this.context.component.popupElement;
+      await timer(POPOVER_ANIMATION_DURATION);
+      const popup = this.context.component.popupElement as HTMLElement;
+      const container = getShadowElement(popup, POPOVER_CONSTANTS.selectors.SURFACE);
 
       expect(this.context.component.syncPopupWidth).toBe(true);
-      expect(popup!.getBoundingClientRect().width).toBe(this.context.input.getBoundingClientRect().width);
+      expect(container!.getBoundingClientRect().width).toBe(this.context.input.getBoundingClientRect().width);
     });
 
     it('should set popup target', async function(this: ITestContext) {
@@ -874,7 +878,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
       this.context.component.openDropdown();
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       const targetElement = this.context.component['_foundation']['_adapter']['_targetElement'];
 
       expect(targetElement).toBe(expectedTargetElement);
@@ -917,8 +921,8 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       const scrolledBottomSpy = jasmine.createSpy('scrolled bottom');
       this.context.component.addEventListener(AUTOCOMPLETE_CONSTANTS.events.SCROLLED_BOTTOM, scrolledBottomSpy);
       await tick();
-      const popup = this.context.component.popupElement;
-      const scrollElement = popup!.shadowRoot!.querySelector(POPUP_CONSTANTS.selectors.CONTAINER) as HTMLElement;
+      const popup = this.context.component.popupElement as HTMLElement;
+      const scrollElement = getShadowElement(popup, POPOVER_CONSTANTS.selectors.SURFACE);
       scrollElement.scrollTop = scrollElement.scrollHeight - this.context.component.observeScrollThreshold;
       await tick();
       expect(scrolledBottomSpy).toHaveBeenCalledTimes(1);
@@ -939,8 +943,8 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       this.context.component.addEventListener(AUTOCOMPLETE_CONSTANTS.events.SCROLLED_BOTTOM, scrolledBottomSpy);
       await tick();
 
-      const popup = this.context.component.popupElement;
-      const scrollElement = popup!.shadowRoot!.querySelector(POPUP_CONSTANTS.selectors.CONTAINER) as HTMLElement;
+      const popup = this.context.component.popupElement as HTMLElement;
+      const scrollElement = getShadowElement(popup, POPOVER_CONSTANTS.selectors.SURFACE);
       scrollElement.scrollTop = scrollElement.scrollHeight;
 
       await tick();
@@ -1096,7 +1100,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       await timer(AUTOCOMPLETE_CONSTANTS.numbers.DEFAULT_DEBOUNCE_TIME);
 
       this.context.input.dispatchEvent(new Event('blur'));
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       expect(this.context.component.popupElement).toBeNull();
     });
@@ -1112,7 +1116,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       _clickListItem(2, this.context.component.popupElement);
 
       this.context.component.closeDropdown();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       this.context.component.openDropdown();
       await tick();
@@ -1132,11 +1136,11 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       this.context.component.filter = () => DEFAULT_FILTER_OPTIONS;
       this.context.component.openDropdown();
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       _sendInputValue(this.context.input, 'a');
       this.context.input.dispatchEvent(new Event('blur'));
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       await tick();
 
       expect(this.context.component.popupElement).toBeNull();
@@ -1153,7 +1157,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       await tick();
       _sendInputValue(this.context.input, 'a');
       await timer(AUTOCOMPLETE_CONSTANTS.numbers.DEFAULT_DEBOUNCE_TIME);
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       await tick();
 
       expect(this.context.component.popupElement).toBeNull();
@@ -1236,7 +1240,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       };
       this.context.component.open = true;
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       const popupGroups = _getPopupGroups(this.context.component.popupElement);
       expect(popupGroups.length).toBe(2);
@@ -1312,6 +1316,18 @@ describe('AutocompleteComponent', function(this: ITestContext) {
       this.context = setupTestContext(true);
       expect(this.context.component.isConnected).toBe(true, 'Expected component to be connected to the DOM');
       expect(this.context.component instanceof AutocompleteComponent).toBe(true, 'Expected component to be instance of AutocompleteComponent');
+    });
+
+    it('should remove popover when removed from DOM while open', async function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      this.context.component.filter = () => DEFAULT_FILTER_OPTIONS;
+      this.context.component.open = true;
+      await tick();
+
+      this.context.component.remove();
+      await tick();
+
+      expect(this.context.component.popupElement).toBeNull();
     });
   });
 
@@ -1514,7 +1530,7 @@ describe('AutocompleteComponent', function(this: ITestContext) {
 
         _triggerDropdownClick(this.context.input);
 
-        await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+        await timer(POPOVER_ANIMATION_DURATION);
         await tick();
         const listItems = _getListItems(this.context.component.popupElement);
         _clickListItem(2, this.context.component.popupElement);

--- a/src/test/spec/list-dropdown/list-dropdown-test-utils.ts
+++ b/src/test/spec/list-dropdown/list-dropdown-test-utils.ts
@@ -1,11 +1,10 @@
-import { removeElement } from '@tylertech/forge-core';
 import { timer } from '@tylertech/forge-testing';
 
 import { ListDropdown, IListDropdownConfig, IListDropdown, IListDropdownFoundation, LIST_DROPDOWN_CONSTANTS, IListDropdownOption } from '@tylertech/forge/list-dropdown';
 import { IListItemComponent, LIST_ITEM_CONSTANTS } from '@tylertech/forge/list';
-import { IPopupComponent, POPUP_CONSTANTS } from '@tylertech/forge/popup';
 import { ISelectOption } from '@tylertech/forge/select';
 import { LINEAR_PROGRESS_CONSTANTS, ILinearProgressComponent } from '@tylertech/forge/linear-progress';
+import { IPopoverComponent, POPOVER_CONSTANTS } from '@tylertech/forge/popover';
 
 export interface IListDropdownTestContext {
   targetElement: HTMLElement;
@@ -14,6 +13,8 @@ export interface IListDropdownTestContext {
   append(): void;
   remove(): void;
 }
+
+const POPOVER_ANIMATION_DURATION = 200;
 
 export interface ITestListDropdownGroup {
   headerElement: HTMLElement;
@@ -41,12 +42,12 @@ export function createListDropdown(config: IListDropdownConfig, targetElement?: 
   };
 }
 
-export function getListDropdownPopup(): IPopupComponent {
-  return document.querySelector(POPUP_CONSTANTS.elementName) as IPopupComponent;
+export function getListDropdownPopup(): IPopoverComponent {
+  return document.querySelector(POPOVER_CONSTANTS.elementName) as IPopoverComponent;
 }
 
 export function delayPopupAnimation(): Promise<void> {
-  return timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+  return timer(POPOVER_ANIMATION_DURATION);
 }
 
 export function getPopupOptions(): ISelectOption[] {

--- a/src/test/spec/list-dropdown/list-dropdown.spec.ts
+++ b/src/test/spec/list-dropdown/list-dropdown.spec.ts
@@ -3,10 +3,12 @@ import { getShadowElement } from '@tylertech/forge-core';
 import { IListDropdownTestContext, createListDropdown, getListItems, getListDropdownPopup, clickListItem, delayPopupAnimation, getBusyVisibility, generateScrollableOptions } from './list-dropdown-test-utils';
 import { IListDropdownConfig, IListDropdownOption, ListDropdownAsyncStyle, ListDropdownHeaderBuilder, IListDropdownOptionGroup, LIST_DROPDOWN_CONSTANTS, ListDropdownFooterBuilder, ListDropdownType, ListDropdownOptionBuilder, ListDropdownTransformCallback } from '@tylertech/forge/list-dropdown';
 import { defineOptionComponent, defineOptionGroupComponent } from '@tylertech/forge/select';
-import { definePopupComponent, POPUP_CONSTANTS, IPopupComponent } from '@tylertech/forge/popup';
 import { defineListComponent, IListComponent, IListItemComponent, LIST_CONSTANTS } from '@tylertech/forge/list';
 import { defineLinearProgressComponent, SKELETON_CONSTANTS, DIVIDER_CONSTANTS, IIconComponent, CIRCULAR_PROGRESS_CONSTANTS } from '@tylertech/forge';
+import { definePopoverComponent, IPopoverComponent, POPOVER_CONSTANTS } from '@tylertech/forge/popover';
 import { tryCleanupPopups, isVisibleInScrollContainer } from '../../utils';
+
+const POPOVER_ANIMATION_DURATION = 200;
 
 interface ITestContext {
   context: IListDropdownTestContext;
@@ -26,7 +28,7 @@ describe('ListDropdown', function(this: ITestContext) {
   };
 
   beforeAll(function(this: ITestContext) {
-    definePopupComponent();
+    definePopoverComponent();
     defineListComponent();
     defineOptionComponent();
     defineOptionGroupComponent();
@@ -56,7 +58,7 @@ describe('ListDropdown', function(this: ITestContext) {
   it('should display options', async function(this: ITestContext) {
     this.context = createListDropdown(DEFAULT_CONFIG);
     this.context.listDropdown.open();
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
     await tick();
 
     const listItems = getListItems();
@@ -71,7 +73,7 @@ describe('ListDropdown', function(this: ITestContext) {
     const selectCallback = jasmine.createSpy('selectCallback') as any;
     this.context = createListDropdown({ ...DEFAULT_CONFIG, selectCallback });
     this.context.listDropdown.open();
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     clickListItem(0);
 
@@ -436,7 +438,7 @@ describe('ListDropdown', function(this: ITestContext) {
 
     const listItems = getListItems();
     const selectedListItem = listItems.find(li => li.value === selectedValue) as IListItemComponent;
-    const scrollContainer = getShadowElement(this.context.listDropdown.dropdownElement!, POPUP_CONSTANTS.selectors.CONTAINER);
+    const scrollContainer = getShadowElement(this.context.listDropdown.dropdownElement!, POPOVER_CONSTANTS.selectors.SURFACE);
 
     expect(isVisibleInScrollContainer(scrollContainer, selectedListItem)).toBeTrue();
   });
@@ -450,7 +452,7 @@ describe('ListDropdown', function(this: ITestContext) {
     const listItems = getListItems();
     const selectedValue = options[99].value;
     const selectedListItem = listItems[99];
-    const scrollContainer = getShadowElement(this.context.listDropdown.dropdownElement!, POPUP_CONSTANTS.selectors.CONTAINER);
+    const scrollContainer = getShadowElement(this.context.listDropdown.dropdownElement!, POPOVER_CONSTANTS.selectors.SURFACE);
 
     expect(isVisibleInScrollContainer(scrollContainer, selectedListItem)).toBeFalse();
 
@@ -470,8 +472,8 @@ describe('ListDropdown', function(this: ITestContext) {
     await delayPopupAnimation();
 
     const popup = this.context.listDropdown.dropdownElement as HTMLElement;
-    const popupRoot = getShadowElement(popup, POPUP_CONSTANTS.selectors.CONTAINER) as HTMLElement;
-    popupRoot.scrollTop = popupRoot.scrollHeight;
+    const scrollContainer = getShadowElement(popup, POPOVER_CONSTANTS.selectors.SURFACE);
+    scrollContainer.scrollTop = scrollContainer.scrollHeight;
     await timer(1000); // Wait for scroll animation (flaky?)
 
     expect(scrollEndListener).toHaveBeenCalledTimes(1);
@@ -487,8 +489,8 @@ describe('ListDropdown', function(this: ITestContext) {
     this.context.listDropdown.setScrollBottomListener(scrollEndListener);
 
     const popup = this.context.listDropdown.dropdownElement as HTMLElement;
-    const popupRoot = getShadowElement(popup, POPUP_CONSTANTS.selectors.CONTAINER) as HTMLElement;
-    popupRoot.scrollTop = popupRoot.scrollHeight;
+    const scrollContainer = getShadowElement(this.context.listDropdown.dropdownElement!, POPOVER_CONSTANTS.selectors.SURFACE);
+    scrollContainer.scrollTop = scrollContainer.scrollHeight;
     await timer(1000); // Wait for scroll animation (flaky?)
 
     expect(scrollEndListener).toHaveBeenCalledTimes(1);
@@ -505,8 +507,8 @@ describe('ListDropdown', function(this: ITestContext) {
     this.context.listDropdown.removeScrollBottomListener();
 
     const popup = this.context.listDropdown.dropdownElement as HTMLElement;
-    const popupRoot = getShadowElement(popup, POPUP_CONSTANTS.selectors.CONTAINER) as HTMLElement;
-    popupRoot.scrollTop = popupRoot.scrollHeight;
+    const scrollContainer = getShadowElement(this.context.listDropdown.dropdownElement!, POPOVER_CONSTANTS.selectors.SURFACE);
+    scrollContainer.scrollTop = scrollContainer.scrollHeight;
     await timer(1000); // Wait for scroll animation (flaky?)
 
     expect(scrollEndListener).not.toHaveBeenCalled();
@@ -631,8 +633,9 @@ describe('ListDropdown', function(this: ITestContext) {
     await delayPopupAnimation();
 
     const popup = getListDropdownPopup();
+    const container = getShadowElement(popup, POPOVER_CONSTANTS.selectors.SURFACE);
 
-    expect(popup.style.minWidth).toBe(`${width}px`);
+    expect(getComputedStyle(container).minWidth).toBe(`${width}px`);
     expect(targetWidthCallback).toHaveBeenCalledTimes(1);
   });
 
@@ -641,23 +644,25 @@ describe('ListDropdown', function(this: ITestContext) {
     const targetWidthCallback = jasmine.createSpy('target width callback', () => width).and.callThrough();
     this.context = createListDropdown({ ...DEFAULT_CONFIG, targetWidthCallback, syncWidth: true });
     this.context.listDropdown.open();
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const popup = getListDropdownPopup();
+    const container = getShadowElement(popup, POPOVER_CONSTANTS.selectors.SURFACE);
 
-    expect(popup.style.width).toBe(`${width}px`);
+    expect(getComputedStyle(container).width).toBe(`${width}px`);
     expect(targetWidthCallback).toHaveBeenCalledTimes(1);
   });
 
   it('should sync width with default target element width', async function(this: ITestContext) {
     this.context = createListDropdown({ ...DEFAULT_CONFIG, syncWidth: true });
     this.context.listDropdown.open();
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const targetElementWidth = getComputedStyle(this.context.targetElement).width;
     const popup = getListDropdownPopup();
+    const container = getShadowElement(popup, POPOVER_CONSTANTS.selectors.SURFACE);
 
-    expect(popup.style.width).toBe(targetElementWidth);
+    expect(getComputedStyle(container).width).toBe(targetElementWidth);
   });
 
   it('should show remove async element options are set', async function(this: ITestContext) {
@@ -751,7 +756,7 @@ describe('ListDropdown', function(this: ITestContext) {
     this.context.listDropdown.open();
     await delayPopupAnimation();
 
-    expect((<IPopupComponent>this.context.listDropdown.dropdownElement).animationType).toBe(ListDropdownType.None);
+    expect((<IPopoverComponent>this.context.listDropdown.dropdownElement).animationType).toBe('none');
   });
 
   it('should limit dropdown options', async function(this: ITestContext) {
@@ -841,7 +846,7 @@ describe('ListDropdown', function(this: ITestContext) {
     ];
     this.context = createListDropdown({ ...DEFAULT_CONFIG, options });
     this.context.listDropdown.open();
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const listItems = getListItems();
     const leadingElement = listItems[0].querySelector('#list-dropdown-leading');
@@ -863,7 +868,7 @@ describe('ListDropdown', function(this: ITestContext) {
     ];
     this.context = createListDropdown({ ...DEFAULT_CONFIG, options });
     this.context.listDropdown.open();
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const listItems = getListItems();
     const trailingElement = listItems[1].querySelector('#list-dropdown-trailing');
@@ -946,7 +951,7 @@ describe('ListDropdown', function(this: ITestContext) {
   it('should set element attributes on options', async function(this: ITestContext) {
     this.context = createListDropdown(DEFAULT_CONFIG);
     this.context.listDropdown.open();
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
     await tick();
 
     const listItems = getListItems();
@@ -961,7 +966,7 @@ describe('ListDropdown', function(this: ITestContext) {
     ];
     this.context = createListDropdown({ ...DEFAULT_CONFIG, options: opts });
     this.context.listDropdown.open();
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
     await tick();
 
     const listItems = getListItems();

--- a/src/test/spec/select/select.spec.ts
+++ b/src/test/spec/select/select.spec.ts
@@ -13,7 +13,6 @@ import {
   BASE_SELECT_CONSTANTS,
   OPTION_GROUP_CONSTANTS
 } from '@tylertech/forge/select';
-import { POPUP_CONSTANTS, IPopupComponent } from '@tylertech/forge/popup';
 import { LIST_ITEM_CONSTANTS, IListItemComponent } from '@tylertech/forge/list/list-item';
 import { removeElement, getShadowElement } from '@tylertech/forge-core';
 import { tick, dispatchNativeEvent, dispatchKeyEvent, timer, deepCopy } from '@tylertech/forge-testing';
@@ -22,6 +21,7 @@ import { LIST_DROPDOWN_CONSTANTS, ListDropdownHeaderBuilder, ListDropdownFooterB
 import { tryCleanupPopups } from '../../utils';
 import { FIELD_CONSTANTS } from '@tylertech/forge/field/field-constants';
 import { floatTick } from '../../utils/floating-label-utils';
+import { IPopoverComponent, POPOVER_CONSTANTS } from '@tylertech/forge/popover';
 
 const DEFAULT_OPTIONS: IOption[] = [
   { value: 'one', label: 'One' },
@@ -44,6 +44,8 @@ const DEFAULT_OPTION_GROUPS: IOptionGroup[] = [
     ]
   }
 ];
+
+const POPOVER_ANIMATION_DURATION = 200;
 
 interface ITestContext {
   context: ITestSelectContext;
@@ -1056,12 +1058,12 @@ describe('SelectComponent', function(this: ITestContext) {
       this.context.component.focus();
       _openDropdown(this.context.component);
       
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       _expectPopupVisibility(this.context.component.popupElement, true);
 
       this.context.component.blur();
       this.context.component.dispatchEvent(new Event('blur'));
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       _expectPopupVisibility(this.context.component.popupElement, false);
     });
@@ -1072,7 +1074,7 @@ describe('SelectComponent', function(this: ITestContext) {
       
       this.context.component.style.width = '50px';
       _openDropdown(this.context.component);
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
       const popupWidth = getComputedStyle(this.context.component.popupElement!).width;
       const componentWidth = getComputedStyle(this.context.component).width;
@@ -1088,9 +1090,9 @@ describe('SelectComponent', function(this: ITestContext) {
       this.context.component.syncPopupWidth = true;
       _openDropdown(this.context.component);
       await tick();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
 
-      const popupWidth = getComputedStyle(this.context.component.popupElement!).width;
+      const popupWidth = getComputedStyle(this.context.component.popupElement?.shadowRoot?.querySelector(POPOVER_CONSTANTS.selectors.SURFACE)!).width;
       const componentWidth = getComputedStyle(this.context.component).width;
 
       expect(this.context.component.syncPopupWidth).toBeTrue();
@@ -1133,7 +1135,7 @@ describe('SelectComponent', function(this: ITestContext) {
       };
       this.context.component.popupHeaderBuilder = headerBuilder;
       _openDropdown(this.context.component);
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       
       const headerElement = this.context.component.popupElement!.querySelector('#select-popup-header');
       expect(headerElement).toBeTruthy();
@@ -1151,7 +1153,7 @@ describe('SelectComponent', function(this: ITestContext) {
       };
       this.context.component.popupFooterBuilder = footerBuilder;
       _openDropdown(this.context.component);
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       
       const footerElement = this.context.component.popupElement!.querySelector('#select-popup-footer');
       expect(footerElement).toBeTruthy();
@@ -1162,7 +1164,7 @@ describe('SelectComponent', function(this: ITestContext) {
       await tick();
       
       _openDropdown(this.context.component);
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       
       const opts = [
         { label: 'New option 1', value: 'new-1' },
@@ -1182,10 +1184,10 @@ describe('SelectComponent', function(this: ITestContext) {
       await tick();
       
       _openDropdown(this.context.component);
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       
       this.context.component.multiple = true;
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       await tick();
       
       expect(this.context.component.open).toBeFalse();
@@ -1200,6 +1202,20 @@ describe('SelectComponent', function(this: ITestContext) {
       _openDropdown(this.context.component);
       
       expect(this.context.component.observeScroll).toBeTrue();
+    });
+
+    it('should remove popover when removed from DOM while open', async function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      await tick();
+      
+      _openDropdown(this.context.component);
+      await timer(POPOVER_ANIMATION_DURATION);
+      
+      removeElement(this.context.component);
+      await timer(POPOVER_ANIMATION_DURATION);
+      
+      expect(this.context.component.popupElement).toBeFalsy();
+      expect(document.querySelector(POPOVER_CONSTANTS.elementName)).toBeFalsy();
     });
   });
 
@@ -1247,9 +1263,9 @@ describe('SelectComponent', function(this: ITestContext) {
       expect(this.context.component.popupElement).toBeDefined();
       expect(this.context.component.popupElement!.isConnected).toBe(true);
       removeElement(this.context.component);
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       expect(this.context.component.popupElement).toBeUndefined();
-      expect(document.querySelector(POPUP_CONSTANTS.elementName)).toBeNull();
+      expect(document.querySelector(POPOVER_CONSTANTS.elementName)).toBeNull();
     });
 
     it('should retrieve correct open state', async function(this: ITestContext) {
@@ -1276,7 +1292,7 @@ describe('SelectComponent', function(this: ITestContext) {
       element.click();
       await tick();
       element.click();
-      await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+      await timer(POPOVER_ANIMATION_DURATION);
       expect(this.context.component.open).toBe(false);
       expect(this.context.component.popupElement).toBeUndefined();
     });
@@ -1615,7 +1631,7 @@ describe('SelectComponent', function(this: ITestContext) {
   }
 
   function _popupAnimation(): Promise<void> {
-    return timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    return timer(POPOVER_ANIMATION_DURATION);
   }
 
   async function _triggerPopupOpen(component: ISelectComponent): Promise<void> {
@@ -1625,18 +1641,18 @@ describe('SelectComponent', function(this: ITestContext) {
     _expectPopupVisibility(component.popupElement, true);
   }
   
-  function _expectPopupVisibility(popupElement: IPopupComponent | undefined, isVisible: boolean): void {
-    const domPopup = document.querySelector(POPUP_CONSTANTS.elementName);
+  function _expectPopupVisibility(popupElement: IPopoverComponent | undefined, isVisible: boolean): void {
+    const domPopup = document.querySelector(POPOVER_CONSTANTS.elementName);
     if (isVisible) {
       expect(popupElement).toBeTruthy();
-      expect(domPopup).toBe(popupElement as IPopupComponent);
+      expect(domPopup).toBe(popupElement as IPopoverComponent);
     } else {
       expect(popupElement).toBeFalsy();
       expect(domPopup).toBeNull();
     }
   }
 
-  function _getOptionContext(popupElement: IPopupComponent | undefined): ITestOptionContext {
+  function _getOptionContext(popupElement: IPopoverComponent | undefined): ITestOptionContext {
     const options = Array.from(popupElement!.querySelectorAll(LIST_ITEM_CONSTANTS.elementName)) as IListItemComponent[];
     const activeOption = options.find(li => li.active) || null;
     const activeIndex = activeOption ? options.indexOf(activeOption) : -1;
@@ -1645,8 +1661,8 @@ describe('SelectComponent', function(this: ITestContext) {
     return { activeIndex, activeOption, options, selectedOptions, selectedIndexes };
   }
 
-  function _expectActiveOption(popupElement: IPopupComponent | undefined, index: number): void {
-    const optionContext = _getOptionContext(popupElement as IPopupComponent);
+  function _expectActiveOption(popupElement: IPopoverComponent | undefined, index: number): void {
+    const optionContext = _getOptionContext(popupElement as IPopoverComponent);
 
     expect(optionContext.activeIndex).toBe(index);
     if (optionContext.activeOption) {
@@ -1658,7 +1674,7 @@ describe('SelectComponent', function(this: ITestContext) {
     element.dispatchEvent(new KeyboardEvent('keydown', { key, keyCode } as Partial<KeyboardEventInit>));
   }
 
-  function _getPopupGroups(popupElement: IPopupComponent | undefined): ITestSelectGroup[] {
+  function _getPopupGroups(popupElement: IPopoverComponent | undefined): ITestSelectGroup[] {
     const groups = Array.from(popupElement!.querySelectorAll(`.${LIST_DROPDOWN_CONSTANTS.classes.GROUP_WRAPPER}`)) as HTMLElement[];
     return groups.map(groupElement => {
       const options = Array.from(groupElement.querySelectorAll(LIST_ITEM_CONSTANTS.elementName)) as IListItemComponent[];

--- a/src/test/spec/time-picker/time-picker.spec.ts
+++ b/src/test/spec/time-picker/time-picker.spec.ts
@@ -1,8 +1,9 @@
 import { defineTimePickerComponent, ITimePickerComponent, ITimePickerFoundation, TIME_PICKER_CONSTANTS, ITimePickerOptionValue, ITimePickerAdapter, ITimePickerOption } from '@tylertech/forge/time-picker';
-import { removeElement, getShadowElement } from '@tylertech/forge-core';
-import { IPopupComponent, POPUP_CONSTANTS, IListItemComponent, LIST_ITEM_CONSTANTS, ICON_BUTTON_CONSTANTS, IIconButtonComponent, TEXT_FIELD_CONSTANTS, defineTextFieldComponent } from '@tylertech/forge';
+import { IPopoverComponent, IListItemComponent, LIST_ITEM_CONSTANTS, ICON_BUTTON_CONSTANTS, IIconButtonComponent, TEXT_FIELD_CONSTANTS, defineTextFieldComponent } from '@tylertech/forge';
 import { timer, tick } from '@tylertech/forge-testing';
 import { getCurrentTimeOfDayMillis, millisToTimeString, hoursToMillis, timeStringToMillis, mergeDateWithTime } from '@tylertech/forge/time-picker/time-picker-utils';
+
+const POPOVER_ANIMATION_DURATION = 200;
 
 interface ITestContext {
   context: ITimePickerTestContext;
@@ -15,7 +16,7 @@ interface ITimePickerTestContext {
   inputElement: HTMLInputElement;
   toggleElement: HTMLButtonElement;
   identifier: string;
-  getPopup(): IPopupComponent;
+  getPopup(): IPopoverComponent;
   getListItems(): IListItemComponent[];
   writeValue(char: string, pos: number, clear?: boolean): void;
 }
@@ -29,10 +30,8 @@ describe('TimePickerComponent', function(this: ITestContext) {
   afterEach(function(this: ITestContext) {
     if (this.context) {
       const popup = this.context.getPopup();
-      if (popup) {
-        removeElement(popup);
-      }
-      removeElement(this.context.component);
+      popup?.remove();
+      this.context.component.remove();
       this.context = undefined as any;
     }
   });
@@ -401,7 +400,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     await tick();
     this.context.toggleElement.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
     await tick();
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
     
     expect(this.context.getPopup()).toBeFalsy();
   });
@@ -418,11 +417,11 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
     this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' }));
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
     expect(this.context.getPopup()).toBeTruthy();
 
     this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'Escape' }));
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     expect(this.context.getPopup()).toBeFalsy();
   });
@@ -619,7 +618,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context.component.value = timeString;
     this.context.component.open = true;
 
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const listItems = this.context.getListItems();
     const matchingListItem = listItems.find(li => li.selected) as IListItemComponent<ITimePickerOptionValue>;
@@ -631,7 +630,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context = _createTimePickerContext();
     this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' }));
 
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const listItems = this.context.getListItems();
     const activeListItemIndex = listItems.findIndex(li => li.active);
@@ -643,13 +642,13 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context = _createTimePickerContext();
     this.context.component.open = true;
 
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
     
     this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' }));
     this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'Tab' }));
     this.context.inputElement.blur();
 
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     expect(this.context.component.value).not.toBeNull();
   });
@@ -664,7 +663,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context.component.startTime = startTime;
     this.context.component.open = true;
 
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const listItems = this.context.getListItems();
     const activeListItem = listItems.find(li => li.selected) as IListItemComponent<ITimePickerOptionValue>;
@@ -676,13 +675,13 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
     this.context.component.open = true;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     expect(this.context.getPopup()).toBeTruthy();
     expect(this.context.component.open).toBe(true);
 
     this.context.component.open = false;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     expect(this.context.getPopup()).toBeFalsy();
     expect(this.context.component.open).toBe(false);
@@ -698,7 +697,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     expect(this.context.component.restrictedTimes).toEqual(restrictedTimes);
 
     this.context.component.open = true;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const listItems = this.context.getListItems();
     const restrictedListItem = listItems.find((li: IListItemComponent<ITimePickerOptionValue>) => li.value.time === firstRestrictedTimeMillis) as IListItemComponent;
@@ -779,7 +778,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     await tick();
 
     this.context.component.open = true;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     expect(this.context.adapter['_targetElement']).toBe(textField.popoverTargetElement);
   });
@@ -798,7 +797,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     await tick();
 
     this.context.component.open = true;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     expect(this.context.component.popupTarget).toBe(TEXT_FIELD_CONSTANTS.elementName);
     expect(this.context.adapter['_targetElement']).toBe(textField);
@@ -808,7 +807,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
     this.context.component.open = true;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const listItems = this.context.getListItems();
     let activeListItemIndex = listItems.findIndex(li => li.active);
@@ -825,7 +824,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
     this.context.component.open = true;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const listItems = this.context.getListItems();
     const originalActiveListItemIndex = listItems.findIndex(li => li.active);
@@ -842,7 +841,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
     this.context.component.open = true;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const listItems = this.context.getListItems();
 
@@ -863,7 +862,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context.component.addEventListener(TIME_PICKER_CONSTANTS.events.CHANGE, changeSpy);
 
     this.context.component.open = true;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const listItems = this.context.getListItems();
 
@@ -918,7 +917,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
 
     this.context.component.showNow = true;
     this.context.component.open = true;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const listItems = this.context.getListItems();
     const listItem = listItems[0] as IListItemComponent<ITimePickerOptionValue>;
@@ -935,7 +934,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context.component.showHourOptions = false;
     this.context.component.customOptions = [];
     this.context.component.open = true;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const listItems = this.context.getListItems();
     const firstListItem = listItems[0] as IListItemComponent<ITimePickerOptionValue>;
@@ -953,7 +952,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context.component.showHourOptions = false;
     this.context.component.customOptions = [];
     this.context.component.open = true;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     expect(this.context.getPopup()).toBeFalsy();
   });
@@ -967,7 +966,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     ];
     this.context.component.customOptions = customOptions;
     this.context.component.open = true;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const listItems = this.context.getListItems();
 
@@ -995,7 +994,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     const toMillisSpy = spyOn<any>(customOptions[0], 'toMilliseconds').and.callThrough();
     this.context.component.customOptions = customOptions;
     this.context.component.open = true;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'Home' })); // Custom options are displayed first
     this.context.inputElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'Enter' }));
@@ -1011,7 +1010,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     this.context.component.min = min;
     this.context.component.max = max;
     this.context.component.open = true;
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
 
     const firstListItemMillis = timeStringToMillis(min, true, false);
     const lastListItemMillis = timeStringToMillis(max, true, false);
@@ -1216,7 +1215,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     
     this.context.inputElement.value = '1';
     this.context.inputElement.dispatchEvent(new InputEvent('input', { inputType: 'insertText' }));
-    await timer(POPUP_CONSTANTS.numbers.ANIMATION_DURATION);
+    await timer(POPOVER_ANIMATION_DURATION);
     await tick();
     
     expect(this.context.component.open).toBeFalse();
@@ -1459,6 +1458,19 @@ describe('TimePickerComponent', function(this: ITestContext) {
     expect(this.context.component.value).toBe('03:01');
   });
 
+  it('should remove popover when removed from DOM while open', async function(this: ITestContext) {
+    this.context = _createTimePickerContext();
+
+    this.context.component.open = true;
+    await timer(POPOVER_ANIMATION_DURATION);
+
+    expect(this.context.getPopup()).toBeTruthy();
+
+    this.context.component.remove();
+
+    expect(this.context.getPopup()).toBeFalsy();
+  });
+
   function _createTimePickerContext(append = true, hasInput = true): ITimePickerTestContext {
     const component = document.createElement('forge-time-picker');
 	  const inputElement = document.createElement('input');
@@ -1474,7 +1486,7 @@ describe('TimePickerComponent', function(this: ITestContext) {
     }
     const foundation = component['_foundation'];
     const identifier = `forge-time-picker-${foundation['_identifier']}`;
-    const getPopup = () => document.querySelector(`[id=list-dropdown-popup-${identifier}]`) as IPopupComponent;
+    const getPopup = () => document.querySelector(`[id=list-dropdown-popup-${identifier}]`) as IPopoverComponent;
 
     return {
       component,

--- a/src/test/utils/utils.ts
+++ b/src/test/utils/utils.ts
@@ -1,8 +1,8 @@
-import { POPUP_CONSTANTS } from '@tylertech/forge';
+import { POPOVER_CONSTANTS, POPUP_CONSTANTS } from '@tylertech/forge';
 import { removeElement, Platform } from '@tylertech/forge-core';
 
 export function tryCleanupPopups(): void {
-  const popups = Array.from(document.querySelectorAll(POPUP_CONSTANTS.elementName)) as HTMLElement[];
+  const popups = Array.from(document.querySelectorAll(`:is(${POPUP_CONSTANTS.elementName},${POPOVER_CONSTANTS.elementName})`)) as HTMLElement[];
   popups.forEach(p => removeElement(p));
 }
 


### PR DESCRIPTION
Refactors the select, menu, autocomplete, and time-picker to use the new `<forge-popover>` through by way of the list-dropdown refactor.

Additionally, some changes were made to the popover:

1. Added exit animations, and updated dependent logic and tests to account for the timeout between the exit animation and the element being removed from the DOM.
2. Added a new `preset="dropdown"` attribute to allow for setting strict pre-defined popover styles for use as dropdowns.
3. Added tokens for various popover surface styles (for use with the presets or custom overrides). Typically we will expect the provided content to drive the design however, so presets and tokens are more of an advanced usage or internal concept.
4. Added support for the legacy `constrain-viewport-width` attribute that was used on the `<forge-popup>` to ensure the popover surface could not be larger than the viewport width when used on small viewports.