### PR TITLE
fix(field): updated "popover target" element styles to cover entire field container to fix anchor placement fallback positioning issues

### DIFF
--- a/src/lib/field-next/_core.scss
+++ b/src/lib/field-next/_core.scss
@@ -126,9 +126,8 @@
 
 @mixin popover-target {
   position: absolute;
-  bottom: calc(#{token(focus-indicator-width)} * -1);
-  left: 0;
-  right: 0;
+  inset: calc(#{token(focus-indicator-width)} * -1);
+  pointer-events: none;
 }
 
 @mixin start {


### PR DESCRIPTION
This fixes a problem with popovers "flipping" to opposite sides of the field based on available space in the viewport relative to the anchor element.