### PR TITLE
fix(list): adjusted list and list-item styles to account for edge cases

### DIFF
--- a/src/lib/core/styles/tokens/list/list-item/_tokens.scss
+++ b/src/lib/core/styles/tokens/list/list-item/_tokens.scss
@@ -9,7 +9,7 @@ $tokens: (
   // Base
   background-color: utils.module-val(list-item, background-color, transparent),
   shape: utils.module-val(list-item, shape, 0),
-  padding: utils.module-val(list-item, padding, spacing.variable(xsmall) spacing.variable(medium)),
+  padding: utils.module-val(list-item, padding, 0 spacing.variable(medium)),
   margin: utils.module-val(list-item, margin, 0),
   height: utils.module-val(list-item, height, 48px),
   dense-height: utils.module-val(list-item, dense-height, 32px),
@@ -25,13 +25,13 @@ $tokens: (
 
   // Selected
   selected-color: utils.module-val(list-item, selected-color, theme.variable(primary)),
-  selected-opacity: utils.module-val(list-item, selected-opacity, 0.08),
+  selected-opacity: utils.module-val(list-item, selected-opacity, theme.emphasis(lowest)),
   selected-leading-color: utils.module-ref(list-item, selected-leading-color, selected-color),
   selected-trailing-color: utils.module-ref(list-item, selected-trailing-color, selected-color),
   selected-supporting-text-color: utils.module-val(list-item, selected-supporting-text-color, theme.variable(text-medium)),
 
   // Disabled
-  disabled-opacity: utils.module-val(list-item, disabled-opacity, 0.38),
+  disabled-opacity: utils.module-val(list-item, disabled-opacity, theme.emphasis(medium-low)),
   disabled-cursor: utils.module-val(list-item, disabled-cursor, not-allowed),
 
   // Line variants
@@ -45,7 +45,7 @@ $tokens: (
   dense-three-line-height: utils.module-val(list-item, dense-three-line-height, utils.module-ref(list-item, dense-height, 72px, value)),
   dense-font-size: utils.module-val(list-item, dense-font-size, 0.875rem),
   dense-indent: utils.module-val(list-item, dense-indent, spacing.variable(xxlarge)),
-  dense-gap: utils.module-val(list-item, dense-gap, spacing.variable(medium)),
+  dense-gap: utils.module-val(list-item, dense-gap, spacing.variable(xsmall)),
 
   // Leading
   leading-selected-color: utils.module-ref(list-item, leading-selected-color, selected-color),
@@ -58,6 +58,9 @@ $tokens: (
   avatar-color: utils.module-val(list-item, avatar-color, theme.variable(on-primary)),
   avatar-shape: utils.module-val(list-item, avatar-shape, shape.variable(round)),
   avatar-size: utils.module-val(list-item, avatar-size, 40px),
+
+  // Wrap
+  wrap-padding: utils.module-val(list-item, wrap-padding, spacing.variable(xsmall) spacing.variable(medium)),
 ) !default;
 
 @function get($key) {

--- a/src/lib/core/styles/tokens/list/list/_tokens.scss
+++ b/src/lib/core/styles/tokens/list/list/_tokens.scss
@@ -1,8 +1,9 @@
 @use '../../../utils';
 
 $tokens: (
+  spacing: utils.module-val(list, spacing, 0),
   container-color: utils.module-val(list, container-color, transparent),
-  block-padding: utils.module-val(list, block-padding, 8px),
+  block-padding: utils.module-val(list, block-padding, 0),
   inline-padding: utils.module-val(list, inline-padding, 0),
 ) !default;
 

--- a/src/lib/core/styles/tokens/list/list/_tokens.scss
+++ b/src/lib/core/styles/tokens/list/list/_tokens.scss
@@ -2,9 +2,7 @@
 
 $tokens: (
   spacing: utils.module-val(list, spacing, 0),
-  container-color: utils.module-val(list, container-color, transparent),
-  block-padding: utils.module-val(list, block-padding, 0),
-  inline-padding: utils.module-val(list, inline-padding, 0),
+  container-color: utils.module-val(list, container-color, transparent)
 ) !default;
 
 @function get($key) {

--- a/src/lib/core/styles/tokens/popover/_tokens.scss
+++ b/src/lib/core/styles/tokens/popover/_tokens.scss
@@ -4,6 +4,7 @@
 @use '../../theme';
 @use '../../shape';
 @use '../../border';
+@use '../../spacing';
 @use '../../animation';
 
 $tokens: (
@@ -64,6 +65,7 @@ $tokens: (
   // Preset - Dropdown
   preset-dropdown-max-height: utils.module-val(popover, preset-dropdown-max-height, 256px),
   preset-dropdown-overflow: utils.module-val(popover, preset-dropdown-overflow, auto visible),
+  preset-dropdown-padding-block: utils.module-val(popover, preset-dropdown-padding-block, spacing.variable(xsmall)),
 ) !default;
 
 @function get($key) {

--- a/src/lib/list/list-item/_core.scss
+++ b/src/lib/list/list-item/_core.scss
@@ -153,6 +153,8 @@
 }
 
 @mixin wrap {
+  @include override(padding, wrap-padding);
+
   height: auto;
 }
 
@@ -160,6 +162,7 @@
   white-space: normal;
   overflow: visible;
   text-overflow: clip;
+  line-height: normal;
 }
 
 @mixin supporting-text-wrap {

--- a/src/lib/list/list-item/list-item.ts
+++ b/src/lib/list/list-item/list-item.ts
@@ -100,6 +100,7 @@ declare global {
  * @cssproperty --forge-list-item-background-color - The background color.
  * @cssproperty --forge-list-item-shape - The shape of the list item.
  * @cssproperty --forge-list-item-padding - The padding inside of the container element.
+ * @cssproperty --forge-list-item-wrap-padding - The padding inside of the container element when `wrap` is enabled.
  * @cssproperty --forge-list-item-margin - The margin around the host element.
  * @cssproperty --forge-list-item-height - The height of the container.
  * @cssproperty --forge-list-item-dense-height - The height when in the dense state.

--- a/src/lib/list/list/_core.scss
+++ b/src/lib/list/list/_core.scss
@@ -3,11 +3,16 @@
 @forward './token-utils';
 
 @mixin base {
-  display: block;
+  display: grid;
+  gap: #{token(spacing)};
   outline: none;
   background-color: #{token(container-color)};
   padding: #{token(block-padding)} #{token(inline-padding)};
   margin: 0;
   border-radius: inherit;
   min-width: inherit;
+}
+
+@mixin inner {
+  min-width: 0;
 }

--- a/src/lib/list/list/_core.scss
+++ b/src/lib/list/list/_core.scss
@@ -7,7 +7,6 @@
   gap: #{token(spacing)};
   outline: none;
   background-color: #{token(container-color)};
-  padding: #{token(block-padding)} #{token(inline-padding)};
   margin: 0;
   border-radius: inherit;
   min-width: inherit;

--- a/src/lib/list/list/list.html
+++ b/src/lib/list/list/list.html
@@ -1,5 +1,7 @@
 <template>
   <div class="forge-list" part="root">
-    <slot></slot>
+    <div class="inner">
+      <slot></slot>
+    </div>
   </div>
 </template>

--- a/src/lib/list/list/list.scss
+++ b/src/lib/list/list/list.scss
@@ -35,3 +35,7 @@
 .forge-list {
   @include base;
 }
+
+.inner {
+  @include inner;
+}

--- a/src/lib/list/list/list.ts
+++ b/src/lib/list/list/list.ts
@@ -37,9 +37,8 @@ declare global {
  * 
  * @slot - The default/unnamed slot for child list items.
  *
- * @cssproperty --forge-list-container-color - The background color of the list surface,
- * @cssproperty --forge-list-block-padding - The block padding of the list before and after the list items.
- * @cssproperty --forge-list-inline-padding - The inline padding of the list next to the list items.
+ * @cssproperty --forge-list-container-color - The background color of the list surface.
+ * @cssproperty --forge-list-spacing - The spacing between the list items.
  * 
  * @property {string} role - The role of the list. Default is 'list'. Valid values are 'list', 'listbox', and 'menu'.
  * @property {boolean} static - Whether the list has all static items or not.

--- a/src/lib/popover/_core.scss
+++ b/src/lib/popover/_core.scss
@@ -46,6 +46,8 @@
 @mixin preset-dropdown {
   @include override(max-height, preset-dropdown-max-height);
   @include override(overflow, preset-dropdown-overflow);
+
+  padding-block: #{token(preset-dropdown-padding-block)};
 }
 
 @mixin zoom-base {


### PR DESCRIPTION
- Removed the default internal `padding` in the `<forge-list>` since it should be controlled by the consumer in their own context without us making assumptions.
- Added a `spacing` token for easily adjusting the space between list items through the `<forge-list>`
- Fixed how block padding is applied when `wrap` is used on the `<forge-list-item>`
- Set `line-height: normal` on text content when `wrap` is used to ensure that wrapping text is properly spaced