### PR TITLE
feat(forge-core): update core styles

### DIFF
--- a/src/lib/forge-core.scss
+++ b/src/lib/forge-core.scss
@@ -1,9 +1,5 @@
-@use './utils/mixins-core';
-
-body, html {
-  @include mixins-core.root-reset;
-}
+@use './utils/mixins-core' as *;
 
 body {
-  @include mixins-core.body-base;
+  @include body-base;
 }

--- a/src/lib/utils/_mixins-core.scss
+++ b/src/lib/utils/_mixins-core.scss
@@ -1,13 +1,9 @@
-@use '@material/theme/theme' as mdc-theme;
-
-@mixin root-reset {
-  height: 100%;
-  width: 100%;
-}
+/* stylelint-disable unit-allowed-list */
+@use '../core/styles/theme';
 
 @mixin body-base {
-  @include mdc-theme.property(background-color, background);
-
+  background-color: #{theme.variable(surface-dim)};
   margin: 0;
-  overflow: hidden;
+  height: 100dvh;
+  width: 100dvw;
 }


### PR DESCRIPTION
This change adjusts the `forge-core.css` stylesheet by adjusting our default styles to be more flexible, without overriding `overflow` to better support mobile usage.

- Use dynamic viewport units for `height` and `width` on the `<body>`
- Remove `overflow: hidden` on the `<body>`
- Remove applying styles on the root `<html>` element