### PR TITLE
fix(list-item): fixed a bug where clicking list items would uncheck slotted radio buttons

### DIFF
--- a/src/lib/list/list-item/list-item-adapter.ts
+++ b/src/lib/list/list-item/list-item-adapter.ts
@@ -145,22 +145,24 @@ export class ListItemAdapter extends BaseAdapter<IListItemComponent> implements 
   public setSelected(value: boolean): void {
     if (value) {
       addClass(LIST_ITEM_CONSTANTS.classes.SELECTED, this._listItemElement);
-      // We are treating selected and activated as the same state, and mdc-states hooks right into --activated
-      // addClass(LIST_ITEM_CONSTANTS.classes.ACTIVATED, this._listItemElement);
     } else {
       removeClass(LIST_ITEM_CONSTANTS.classes.SELECTED, this._listItemElement);
-      // removeClass(LIST_ITEM_CONSTANTS.classes.ACTIVATED, this._listItemElement);
     }
   }
 
   /**
-   * Attemps to toggle a checkbox or radio button within the list item if it can find one.
+   * Attempts to toggle a checkbox or radio button within the list item if it can find one.
    */
   public tryToggleCheckboxRadio(value?: boolean): void {
     const checkable = this._component.querySelector(LIST_ITEM_CONSTANTS.selectors.CHECKBOX_RADIO_SELECTOR) as HTMLInputElement;
     if (checkable) {
       const force = typeof value === 'boolean';
       const currentState = checkable.checked;
+
+      // We don't uncheck radio buttons unless we are forcing a value from the selection state
+      if (!force && checkable.matches('input[type=radio]:checked')) {
+        return;
+      }
       
       // Check if we are just toggling or forcing to a specific checked state
       checkable.checked = force ? value as boolean : !checkable.checked;

--- a/src/test/spec/list/list-item/list-item.spec.ts
+++ b/src/test/spec/list/list-item/list-item.spec.ts
@@ -527,6 +527,18 @@ describe('ListItemComponent', function(this: ITestContext) {
       expect(this.context.getRadioInput1().checked).toBe(true);
     });
 
+    it('should not uncheck radio when clicked after already checked', function(this: ITestContext) {
+      this.context = setupRadioTestContext();
+
+      expect(this.context.getRadioInput1().checked).toBeFalse();
+      
+      this.context.getRootElement1().click();
+      expect(this.context.getRadioInput1().checked).toBeTrue();
+
+      this.context.getRootElement1().click();
+      expect(this.context.getRadioInput1().checked).toBeTrue();
+    });
+
     it('should not check radio with the "forge-ignore" attribute applied when list-item is clicked', function(this: ITestContext) {
       this.context = setupRadioTestContext();
       const radioInput1 = this.context.getRadioInput1();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Clicking on a list item that contains a slotted `<input type="radio">` element will no longer uncheck the radio. This is to be consistent with the native radio button functionality in the browser.

## Additional information
Toggling selection state of the list/list-item programmatically will still uncheck the radio. This is a synchronization of selection state rather than user interaction toggling/selecting a list item so it makes sense to ensure the radio reflects the selection state as it currently does.
