### PR TITLE
fix(dialog): use `visible` state attribute instead of `open` to control animations

### DIFF
--- a/src/dev/pages/dialog/dialog.scss
+++ b/src/dev/pages/dialog/dialog.scss
@@ -20,6 +20,12 @@ forge-dialog[preset$=-sheet] {
   }
 }
 
+forge-dialog:is([preset=left-sheet], [preset=right-sheet]) {
+  .dialog-container {
+    height: 100%;
+  }
+}
+
 forge-dialog:not([fullscreen])[size-strategy=container-inline] {
   .dialog-container {
     max-width: none;

--- a/src/lib/dialog/_core.scss
+++ b/src/lib/dialog/_core.scss
@@ -48,7 +48,6 @@
 }
 
 @mixin surface {
-  display: inline-flex;
   position: absolute;
   inset: 0;
   

--- a/src/lib/dialog/dialog-adapter.ts
+++ b/src/lib/dialog/dialog-adapter.ts
@@ -1,4 +1,4 @@
-import { getShadowElement } from '@tylertech/forge-core';
+import { getShadowElement, playKeyframeAnimation } from '@tylertech/forge-core';
 import { BACKDROP_CONSTANTS, IBackdropComponent } from '../backdrop';
 import { setDefaultAria } from '../constants';
 import { BaseAdapter, IBaseAdapter } from '../core/base/base-adapter';
@@ -98,7 +98,7 @@ export class DialogAdapter extends BaseAdapter<IDialogComponent> implements IDia
     Array.from(DialogComponent[dialogStack]).filter(dialog => dialog.mode === 'modal' || dialog.mode === 'inline-modal').at(-1)?.[showBackdrop]();
   }
 
-  public hide(): Promise<void> {
+  public async hide(): Promise<void> {
     this._component[setDefaultAria]({
       role: null,
       ariaModal: null
@@ -115,11 +115,9 @@ export class DialogAdapter extends BaseAdapter<IDialogComponent> implements IDia
       return Promise.resolve(close());
     }
 
-    return new Promise<void>(resolve => {
-      this._surfaceElement.addEventListener('animationend', () => resolve(close()), { once: true });
-      this._backdropElement.fadeOut();
-      this._surfaceElement.classList.add(BACKDROP_CONSTANTS.classes.EXITING);
-    });
+    this._backdropElement.fadeOut();
+    await playKeyframeAnimation(this._surfaceElement, BACKDROP_CONSTANTS.classes.EXITING);
+    close();
   }
 
   public addDialogFormSubmitListener(listener: EventListener): void {

--- a/src/lib/dialog/dialog-constants.ts
+++ b/src/lib/dialog/dialog-constants.ts
@@ -4,6 +4,7 @@ const elementName: keyof HTMLElementTagNameMap = `${COMPONENT_NAME_PREFIX}dialog
 
 const observedAttributes = {
   OPEN: 'open',
+  VISIBLE: 'visible',
   MODE: 'mode',
   TYPE: 'type',
   ANIMATION_TYPE: 'animation-type',

--- a/src/lib/dialog/dialog-foundation.ts
+++ b/src/lib/dialog/dialog-foundation.ts
@@ -133,6 +133,7 @@ export class DialogFoundation implements IDialogFoundation {
       await this._hide();
     }
 
+    this._adapter.toggleHostAttribute(DIALOG_CONSTANTS.attributes.VISIBLE, this._open); // We use this for styling purposes to control animations
     this._adapter.toggleHostAttribute(DIALOG_CONSTANTS.attributes.OPEN, this._open);
   }
 

--- a/src/lib/dialog/dialog.scss
+++ b/src/lib/dialog/dialog.scss
@@ -3,7 +3,7 @@
 @use '../backdrop';
 @use '../core/styles/theme';
 
-$can-animate: '[open]:not([animation-type=none])';
+$can-animate: '[visible]:not([animation-type=none])';
 
 @layer base, nonmodal, animation, placement, size-strategy, preset, fullscreen, position-strategy, media;
 
@@ -115,7 +115,7 @@ $can-animate: '[open]:not([animation-type=none])';
   // Open
   //
 
-  :host([open]) {
+  :host([visible]) {
     @include host-open;
   }
 }

--- a/src/lib/dialog/dialog.test.ts
+++ b/src/lib/dialog/dialog.test.ts
@@ -823,6 +823,7 @@ class DialogHarness {
   public get isOpen(): boolean {
     return this.dialogElement.open &&
            this.dialogElement.hasAttribute(DIALOG_CONSTANTS.attributes.OPEN) &&
+           this.dialogElement.hasAttribute(DIALOG_CONSTANTS.attributes.VISIBLE) &&
            this.nativeDialogElement.open &&
            this.nativeDialogElement.hasAttribute(DIALOG_CONSTANTS.attributes.OPEN) &&
            getComputedStyle(this.nativeDialogElement).display !== 'none';


### PR DESCRIPTION
- Using a the `visible` attribute allows us to control animations separate from the "open" state.
  - React binds to attributes instead of properties, this fixes a bug where React was removing the `open` attribute immediately causing the dialog to not complete its exit animation and stay transparently in the DOM.
- Updated the default `display` style for the surface container to use the default (`block`) instead of `inline-flex` to allow for elements to be placed more naturally in the container.
  - This has the drawback of the surface content not automatically expanding to fill the surface, but in these cases it's up to developers to set their own `height` which I feel is more obvious and has less drawbacks.