### PR TITLE
feat(list): add navlist block margin and tokens; rename text-related tokens in list item

### DIFF
--- a/src/lib/core/styles/tokens/list/list-item/_tokens.scss
+++ b/src/lib/core/styles/tokens/list/list-item/_tokens.scss
@@ -7,7 +7,7 @@
 
 $tokens: (
   // Base
-  background-color: utils.module-val(list-item, background-color, transparent),
+  background: utils.module-val(list-item, background, transparent),
   shape: utils.module-val(list-item, shape, 0),
   padding: utils.module-val(list-item, padding, 0 spacing.variable(medium)),
   margin: utils.module-val(list-item, margin, 0),
@@ -18,17 +18,17 @@ $tokens: (
   gap: utils.module-val(list-item, gap, spacing.variable(xlarge)),
 
   // Supporting text
-  supporting-text-color: utils.module-val(list-item, supporting-text-color, theme.variable(text-medium)),
-  supporting-text-font-size: utils.module-val(list-item, supporting-text-font-size, typography.variable(body2, font-size)),
-  supporting-text-font-weight: utils.module-val(list-item, supporting-text-font-weight, typography.variable(body2, font-weight)),
-  supporting-text-line-height: utils.module-val(list-item, supporting-text-line-height, typography.scale('1500')),
+  text-color: utils.module-val(list-item, text-color, theme.variable(text-medium)),
+  text-font-size: utils.module-val(list-item, text-font-size, typography.variable(body2, font-size)),
+  text-font-weight: utils.module-val(list-item, text-font-weight, typography.variable(body2, font-weight)),
+  text-line-height: utils.module-val(list-item, text-line-height, typography.scale('1500')),
 
   // Selected
   selected-color: utils.module-val(list-item, selected-color, theme.variable(primary)),
   selected-opacity: utils.module-val(list-item, selected-opacity, theme.emphasis(lowest)),
   selected-leading-color: utils.module-ref(list-item, selected-leading-color, selected-color),
   selected-trailing-color: utils.module-ref(list-item, selected-trailing-color, selected-color),
-  selected-supporting-text-color: utils.module-val(list-item, selected-supporting-text-color, theme.variable(text-medium)),
+  selected-text-color: utils.module-val(list-item, selected-text-color, theme.variable(text-medium)),
 
   // Disabled
   disabled-opacity: utils.module-val(list-item, disabled-opacity, theme.emphasis(medium-low)),

--- a/src/lib/core/styles/tokens/list/list/_tokens.scss
+++ b/src/lib/core/styles/tokens/list/list/_tokens.scss
@@ -1,8 +1,21 @@
 @use '../../../utils';
+@use '../../../spacing';
+@use '../../../shape';
+@use '../../../typography';
 
 $tokens: (
+  // Base
   spacing: utils.module-val(list, spacing, 0),
-  container-color: utils.module-val(list, container-color, transparent)
+  container-color: utils.module-val(list, container-color, transparent),
+
+  // Navlist
+  navlist-spacing: utils.module-val(list, navlist-spacing, spacing.variable(xxsmall)),
+  navlist-margin: utils.module-val(list, navlist-margin, spacing.variable(xxsmall) spacing.variable(xsmall)),
+  navlist-height: utils.module-val(list, navlist-height, 40px),
+  navlist-padding: utils.module-val(list, navlist-padding, 0 spacing.variable(xsmall)),
+  navlist-shape: utils.module-val(list, navlist-shape, shape.variable(medium)),
+  navlist-font-size: utils.module-val(list, navlist-font-size, typography.font-size-relative('0875')),
+  navlist-font-weight: utils.module-val(list, navlist-font-weight, 500),
 ) !default;
 
 @function get($key) {

--- a/src/lib/list/list-item/_core.scss
+++ b/src/lib/list/list-item/_core.scss
@@ -16,7 +16,7 @@
   box-sizing: border-box;
   outline: none;
   text-decoration: none;
-  background-color: #{token(background-color)};
+  background-color: #{token(background)};
   border-radius: #{token(shape)};
   -webkit-tap-highlight-color: transparent;
   height: #{token(height)};
@@ -35,9 +35,9 @@
   @include typography.ellipse;
 
   box-sizing: border-box;
-  font-size: #{token(supporting-text-font-size)};
-  font-weight: #{token(supporting-text-font-weight)};
-  line-height: #{token(supporting-text-line-height)};
+  font-size: #{token(text-font-size)};
+  font-weight: #{token(text-font-weight)};
+  line-height: #{token(text-line-height)};
   flex: 1;
 }
 
@@ -70,16 +70,16 @@
   color: #{token(selected-color)};
 }
 
-@mixin supporting-text {
+@mixin text {
   @include typography.style(body1);
   @include typography.ellipse;
 
-  color: #{token(supporting-text-color)};
+  color: #{token(text-color)};
   display: block;
 }
 
-@mixin supporting-text-selected {
-  color: #{token(selected-supporting-text-color)};
+@mixin text-selected {
+  color: #{token(selected-text-color)};
 }
 
 @mixin two-line {
@@ -136,7 +136,7 @@
 }
 
 @mixin leading-trailing-base {
-  color: #{token(supporting-text-color)};
+  color: #{token(text-color)};
   display: inline-flex;
   flex-shrink: 0;
   align-items: center;
@@ -165,7 +165,7 @@
   line-height: normal;
 }
 
-@mixin supporting-text-wrap {
+@mixin text-wrap {
   @include text-container-wrap;
 }
 

--- a/src/lib/list/list-item/list-item.scss
+++ b/src/lib/list/list-item/list-item.scss
@@ -136,17 +136,17 @@ a.forge-list-item {
   @include text-container;
 }
 
-// Supporting text slotted elements
+// Text slotted elements
 slot[name=secondary-text],
 slot[name=subtitle],
 slot[name=tertiary-text],
 slot[name=tertiary-title] {
   &::slotted(*) {
-    @include supporting-text;
+    @include text;
   }
 
   :host([selected]) &::slotted(*) {
-    @include supporting-text-selected;
+    @include text-selected;
   }
 }
 
@@ -190,7 +190,7 @@ slot[name=tertiary-title] {
   slot[name=tertiary-text],
   slot[name=tertiary-title] {
     &::slotted(*) {
-      @include supporting-text-wrap;
+      @include text-wrap;
     }
   }
 }

--- a/src/lib/list/list-item/list-item.ts
+++ b/src/lib/list/list-item/list-item.ts
@@ -97,7 +97,7 @@ declare global {
  * @csspart focus-indicator - The forwarded focus indicator's internal indicator element.
  * @csspart state-layer - The forwarded state layer's internal surface element.
  * 
- * @cssproperty --forge-list-item-background-color - The background color.
+ * @cssproperty --forge-list-item-background - The background color.
  * @cssproperty --forge-list-item-shape - The shape of the list item.
  * @cssproperty --forge-list-item-padding - The padding inside of the container element.
  * @cssproperty --forge-list-item-wrap-padding - The padding inside of the container element when `wrap` is enabled.
@@ -107,13 +107,15 @@ declare global {
  * @cssproperty --forge-list-item-indent - The margin inline state when in the indented state.
  * @cssproperty --forge-list-item-cursor - The cursor when interactive.
  * @cssproperty --forge-list-item-gap - The gap between the slotted content.
- * @cssproperty --forge-list-item-supporting-text-color - The text color of the supporting text.
- * @cssproperty --forge-list-item-supporting-line-height - The line height of the supporting text.
+ * @cssproperty --forge-list-item-text-color - The text color of the text.
+ * @cssproperty --forge-list-item-text-font-size - The font size of the text.
+ * @cssproperty --forge-list-item-text-font-weight - The font weight of the text.
+ * @cssproperty --forge-list-item-text-line-height - The line height of the text.
  * @cssproperty --forge-list-item-selected-color - The color when in the selected state.
  * @cssproperty --forge-list-item-opacity - The opacity of the background color when in the disabled state.
  * @cssproperty --forge-list-item-selected-leading-color - The color of the leading content when in the selected state.
  * @cssproperty --forge-list-item-selected-trailing-color - The color of the trailing content when in the selected state.
- * @cssproperty --forge-list-item-selected-supporting-text-color - The color of the supporting text when in the selected state.
+ * @cssproperty --forge-list-item-selected-text-color - The color of the text when in the selected state.
  * @cssproperty --forge-list-item-disabled-opacity - The opacity of the element when in the disabled state.
  * @cssproperty --forge-list-item-disabled-cursor - The cursor when in the disabled state.
  * @cssproperty --forge-list-item-one-line-height - The line height when in the one/single line state.

--- a/src/lib/list/list/list.scss
+++ b/src/lib/list/list/list.scss
@@ -5,6 +5,20 @@
 // Host
 //
 
+$_host-tokens: [
+  navlist-spacing
+  navlist-margin
+  navlist-height
+  navlist-padding
+  navlist-shape
+  navlist-font-size
+  navlist-font-weight
+];
+
+:host {
+  @include tokens($includes: $_host-tokens);
+}
+
 :host {
   display: block;
 }
@@ -14,13 +28,15 @@
 }
 
 :host([navlist]) {
+  margin-block: #{token(navlist-spacing)};
+
   @include list-item.provide-theme((
-    height: 40px,
-    margin: 4px 8px,
-    padding: 0 8px,
-    shape: 4px,
-    supporting-text-font-size: 0.875rem,
-    supporting-text-font-weight: 500
+    height: #{token(navlist-height)},
+    margin: #{token(navlist-margin)},
+    padding: #{token(navlist-padding)},
+    shape: #{token(navlist-shape)},
+    text-font-size: #{token(navlist-font-size)},
+    text-font-weight: #{token(navlist-font-weight)},
   ));
 }
 
@@ -29,7 +45,7 @@
 //
 
 .forge-list {
-  @include tokens;
+  @include tokens($excludes: $_host-tokens);
 }
 
 .forge-list {


### PR DESCRIPTION
- Added default `margin-block` to `<forge-list navlist>`
- Removed "supporting" from the tokens and mixins related to the slotted text content for brevity