### PR TITLE
feat: emit all tokens in global stylesheet

### DIFF
--- a/src/dev/pages/drawer/drawer.scss
+++ b/src/dev/pages/drawer/drawer.scss
@@ -1,4 +1,4 @@
 .drawer-demo {
-  border: 1px solid var(--forge-theme-border-color);
-  background-color: var(--mdc-theme-background);
+  border: 1px solid var(--forge-theme-outline);
+  background-color: var(--forge-theme-surface-dim);
 }

--- a/src/dev/pages/focus-indicator/focus-indicator.scss
+++ b/src/dev/pages/focus-indicator/focus-indicator.scss
@@ -25,7 +25,7 @@
   justify-content: center;
   align-items: center;
   text-align: center;
-  border: 1px solid var(--forge-theme-border-color);
+  border: 1px solid var(--forge-theme-outline);
 
   --forge-focus-indicator-shape: 10px;
   --forge-focus-indicator-inward-offset: 4px;

--- a/src/dev/pages/list/list.scss
+++ b/src/dev/pages/list/list.scss
@@ -1,4 +1,4 @@
 .list-demo {
   max-width: 600px;
-  border: 1px solid var(--forge-theme-border-color);
+  border: 1px solid var(--forge-theme-outline);
 }

--- a/src/dev/pages/overlay/overlay.scss
+++ b/src/dev/pages/overlay/overlay.scss
@@ -1,11 +1,11 @@
 .clipping-container {
   height: 500px;
-  border: 1px solid var(--forge-theme-border-color);
+  border: 1px solid var(--forge-theme-outline);
   overflow: auto;
 
   &.force-containment {
     transform: translate3d(0, 0, 0);
-    border: 2px dashed var(--mdc-theme-error);
+    border: 2px dashed var(--forge-theme-error);
   }
 
   &.use-small-container {

--- a/src/dev/pages/popover/popover.scss
+++ b/src/dev/pages/popover/popover.scss
@@ -1,11 +1,11 @@
 .clipping-container {
   height: 550px;
-  border: 1px solid var(--forge-theme-border-color);
+  border: 1px solid var(--forge-theme-outline);
   overflow: auto;
 
   &.force-containment {
     transform: translate3d(0, 0, 0);
-    border: 2px dashed var(--mdc-theme-error);
+    border: 2px dashed var(--forge-theme-error);
   }
 
   &.use-small-container {

--- a/src/dev/pages/scaffold/scaffold.scss
+++ b/src/dev/pages/scaffold/scaffold.scss
@@ -1,11 +1,11 @@
 .demo-container {
   height: 750px;
-  border: 1px solid var(--forge-theme-border-color);
+  border: 1px solid var(--forge-theme-outline);
 }
 
 .placeholder-container {
   margin: 16px;
-  border: 2px dashed var(--forge-theme-border-color);
+  border: 2px dashed var(--forge-theme-outline);
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/dev/pages/skeleton/skeleton.ejs
+++ b/src/dev/pages/skeleton/skeleton.ejs
@@ -66,7 +66,7 @@
             <forge-skeleton list-item></forge-skeleton>
           </div>
         </forge-drawer>
-        <div slot="body" style="padding: 16px; background-color: var(--mdc-theme-background);">
+        <div slot="body" style="padding: 16px; background-color: var(--forge-theme-surface-dim);">
           <forge-card style="--forge-card-padding: 16px; margin-bottom: 16px;">
             <forge-skeleton avatar></forge-skeleton>
             <forge-skeleton text></forge-skeleton>

--- a/src/dev/pages/state-layer/state-layer.scss
+++ b/src/dev/pages/state-layer/state-layer.scss
@@ -5,7 +5,7 @@
   outline: none;
   height: 200px;
   width: 200px;
-  border: 1px solid var(--forge-theme-border-color);
+  border: 1px solid var(--forge-theme-outline);
   border-radius: 4px;
   display: flex;
   justify-content: center;

--- a/src/dev/pages/table/table.scss
+++ b/src/dev/pages/table/table.scss
@@ -1,6 +1,6 @@
 .forge-table-expandable-row {
   margin: 16px;
-  border: 4px dashed var(--forge-theme-border-color);
+  border: 4px dashed var(--forge-theme-outline);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/dev/pages/tabs/tabs.scss
+++ b/src/dev/pages/tabs/tabs.scss
@@ -8,7 +8,7 @@
   width: 100%;
   justify-content: center;
   align-items: center;
-  border: 2px dashed var(--forge-theme-border-color);
+  border: 2px dashed var(--forge-theme-outline);
 }
 
 .tabs-demo {

--- a/src/dev/pages/toolbar/toolbar.scss
+++ b/src/dev/pages/toolbar/toolbar.scss
@@ -1,5 +1,5 @@
 .placeholder-container {
-  border: 2px dashed var(--forge-theme-border-color);
+  border: 2px dashed var(--forge-theme-outline);
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/dev/pages/view-switcher/view-switcher.scss
+++ b/src/dev/pages/view-switcher/view-switcher.scss
@@ -6,5 +6,5 @@
   font-size: 1.5rem;
   margin-top: 16px;
   text-transform: uppercase;
-  border: 4px dashed var(--forge-theme-border-color);
+  border: 4px dashed var(--forge-theme-outline);
 }

--- a/src/dev/src/styles/_list.scss
+++ b/src/dev/src/styles/_list.scss
@@ -4,6 +4,6 @@
   &:visited,
   &:hover {
     text-decoration: none;
-    color: var(--mdc-theme-text-primary-on-background);
+    color: var(--forge-theme-text-high);
   }
 }

--- a/src/lib/app-bar/search/app-bar-search.ts
+++ b/src/lib/app-bar/search/app-bar-search.ts
@@ -45,9 +45,9 @@ declare global {
  * @csspart global-icon - The global icon <forge-icon> element.
  * @csspart actions-container - The action container element around the slot.
  * 
- * @cssproperty --mdc-theme-on-primary - Controls the border-color of the container outline, the font-color, and icon color.
- * @cssproperty --mdc-theme-on-surface - Controls the font color of the buttons.
- * @cssproperty --mdc-theme-text-secondary-on-background - Controls the placeholder font color.
+ * @cssproperty --forge-theme-on-primary - Controls the border-color of the container outline, the font-color, and icon color.
+ * @cssproperty --forge-theme-on-surface - Controls the font color of the buttons.
+ * @cssproperty --forge-theme-text-medium - Controls the placeholder font color.
  * @cssproperty --forge-app-bar-search-theme-background - Controls the background-color of the container.
  * @cssproperty --forge-app-bar-search-theme-background-focused - Controls the focused background-color of the container.
  * @cssproperty --forge-app-bar-search-theme-hover-opacity - Controls the hover opacity of the outline.

--- a/src/lib/build.json
+++ b/src/lib/build.json
@@ -4,6 +4,7 @@
   "stylesheets": [
     "./forge.scss",
     "./forge-dark.scss",
-    "./forge-core.scss"
+    "./forge-core.scss",
+    "./forge-tokens.scss"
   ]
 }

--- a/src/lib/core/styles/animation/index.scss
+++ b/src/lib/core/styles/animation/index.scss
@@ -2,10 +2,32 @@
 @use '../utils';
 @use '../tokens/animation/tokens';
 
+///
+/// Emits custom property declarations for all animation theme tokens.
+/// 
+@mixin properties {
+  @each $token-name, $token-value in tokens.$tokens {
+    @include utils.declare-var(animation, $token-name, $token-value);
+  }
+}
+
+///
+/// Gets a CSS custom property declaration for a specific animation token with its token value as the fallback value.
+/// 
+/// Example:
+/// ```scss
+/// .my-class {
+///   animation-duration: #{animation.variable(duration-short4)}; // => animation-duration: var(--forge-animation-duration-short4, 200ms);
+/// }
+/// ```
+/// 
 @function variable($key, $prefix: config.$prefix) {
   @return utils.variable(animation, tokens.$tokens, $key, $prefix);
 }
 
+///
+/// Generates CSS custom property declarations for the provided animation tokens.
+/// 
 @function provide($tokens, $prefix: config.$prefix) {
   @return utils.provide(tokens.$tokens, $tokens, animation, $prefix);
 }

--- a/src/lib/core/styles/border/index.scss
+++ b/src/lib/core/styles/border/index.scss
@@ -19,7 +19,7 @@
 /// Example:
 /// ```scss
 /// .my-class {
-///   @include border.style(standard); // => border: var(--forge-border-standard, 1px solid var(--forge-theme-border-color));
+///   @include border.style(standard); // => border: var(--forge-border-standard, 1px solid var(--forge-theme-outline));
 /// }
 /// ```
 /// 

--- a/src/lib/core/styles/border/index.scss
+++ b/src/lib/core/styles/border/index.scss
@@ -5,6 +5,15 @@
 @use '../utils';
 
 ///
+/// Emits custom property declarations for all border theme tokens.
+/// 
+@mixin properties {
+  @each $token-name, $token-value in tokens.$tokens {
+    @include utils.declare-var(border, $token-name, $token-value);
+  }
+}
+
+///
 /// Gets a CSS custom property declaration for a specific border token with its token value as the fallback value.
 /// 
 /// Example:

--- a/src/lib/core/styles/elevation/index.scss
+++ b/src/lib/core/styles/elevation/index.scss
@@ -1,49 +1,42 @@
 @use 'sass:map';
 @use 'sass:math';
 @use 'sass:meta';
+@use 'sass:string';
 @use '../utils';
 @use '../core/config';
 @use '../tokens/elevation/tokens';
 
 ///
-/// Generates a `box-shadow` style value for the provided elevation z-value.
+/// Emits custom property declarations for all default theme tokens.
 /// 
-@function _calc-box-shadow($z-value, $color, $opacity-boost) {
-  @if meta.type-of($z-value) != number or not math.is-unitless($z-value) {
-    @error "$z-value must be a unitless number, but received '#{$z-value}'";
+@mixin properties {
+  @each $token-name, $token-value in tokens.$tokens {
+    @include utils.declare-var(elevation, $token-name, $token-value);
   }
-
-  @if $z-value < 0 or $z-value > 24 {
-    @error "$z-value must be between 0 and 24, but received '#{$z-value}'";
-  }
-
-  $umbra-z-value: map.get(tokens.$umbra-map, $z-value);
-  $penumbra-z-value: map.get(tokens.$penumbra-map, $z-value);
-  $ambient-z-value: map.get(tokens.$ambient-map, $z-value);
-
-  $umbra-color: rgba($color, tokens.$umbra-opacity + $opacity-boost);
-  $penumbra-color: rgba($color, tokens.$penumbra-opacity + $opacity-boost);
-  $ambient-color: rgba($color, tokens.$ambient-opacity + $opacity-boost);
-
-  @return (
-    #{'#{$umbra-z-value} #{$umbra-color}'},
-    #{'#{$penumbra-z-value} #{$penumbra-color}'},
-    #{$ambient-z-value} $ambient-color
-  );
 }
+
+///
+/// Emits custom property declarations for all z-index theme tokens.
+/// 
+@mixin z-index-properties {
+  @each $token-name, $token-value in tokens.$z-index-tokens {
+    @include utils.declare-var(z-index, $token-name, $token-value);
+  }
+}
+
 
 ///
 /// Returns a an elevation value specified by the provided elevation z-value.
 /// 
-@function value($z-value, $color: tokens.$baseline-color, $opacity-boost: 0) {
-  @return _calc-box-shadow($z-value, $color, $opacity-boost);
+@function value($level) {
+  @return string.unquote(tokens.get($level));
 }
 
 ///
 /// Sets a `box-shadow` style specified by the provided elevation z-value.
 /// 
-@mixin box-shadow($z-value, $color: tokens.$baseline-color, $opacity-boost: 0) {
-  box-shadow: #{_calc-box-shadow($z-value, $color, $opacity-boost)};
+@mixin box-shadow($level) {
+  box-shadow: #{value($level)};
 }
 
 ///
@@ -52,7 +45,7 @@
 /// All z-index values are set as CSS custom properties, so they can be overridden globally.
 /// 
 @mixin z-index($level) {
-  $value: map.get(tokens.$z-index-map, $level);
+  $value: map.get(tokens.$z-index-tokens, $level);
   z-index: var(--#{config.$prefix}-z-index-#{$level}, #{$value});
 }
 
@@ -62,5 +55,5 @@
 /// @param {Number} $level - The z-index level to return.
 ///
 @function z-index-variable($level) {
-  @return utils.variable(z-index, tokens.$z-index-map, $level);
+  @return utils.variable(z-index, tokens.$z-index-tokens, $level);
 }

--- a/src/lib/core/styles/shape/index.scss
+++ b/src/lib/core/styles/shape/index.scss
@@ -4,6 +4,15 @@
 @use '../utils';
 
 ///
+/// Emits custom property declarations for all shape theme tokens.
+/// 
+@mixin properties {
+  @each $token-name, $token-value in tokens.$tokens {
+    @include utils.declare-var(shape, $token-name, $token-value);
+  }
+}
+
+///
 /// Creates a `border-radius` style using the provided radius token.
 /// 
 @mixin radius($radius) {

--- a/src/lib/core/styles/spacing/index.scss
+++ b/src/lib/core/styles/spacing/index.scss
@@ -4,6 +4,15 @@
 @use '../utils';
 
 ///
+/// Emits custom property declarations for all spacing theme tokens.
+/// 
+@mixin properties {
+  @each $token-name, $token-value in tokens.$tokens {
+    @include utils.declare-var(spacing, $token-name, $token-value);
+  }
+}
+
+///
 /// Gets a spacing token value.
 /// 
 @function value($key) {

--- a/src/lib/core/styles/theme/index.scss
+++ b/src/lib/core/styles/theme/index.scss
@@ -12,7 +12,7 @@
 /// 
 @mixin properties {
   @each $token-name, $token-value in tokens.$tokens {
-    --#{config.$prefix}-theme-#{$token-name}: #{$token-value};
+    @include utils.declare-var(theme, $token-name, $token-value);
   }
 }
 
@@ -21,7 +21,7 @@
 /// 
 @mixin properties-dark {
   @each $token-name, $token-value in tokens.$tokens-dark {
-    --#{config.$prefix}-theme-#{$token-name}: #{$token-value};
+    @include utils.declare-var(theme, $token-name, $token-value);
   }
 }
 

--- a/src/lib/core/styles/tokens/elevation/_tokens.scss
+++ b/src/lib/core/styles/tokens/elevation/_tokens.scss
@@ -1,6 +1,8 @@
+@use 'sass:map';
+
 /// Layering values to define z-index ranges for common groups of UI elements
 /// to ensure floating elements overlay correctly.
-$z-index-map: (
+$z-index-tokens: (
   surface: 1,
   header: 4,
   backdrop: 7,
@@ -11,90 +13,39 @@ $z-index-map: (
 ) !default;
 
 $baseline-color: black !default;
-$umbra-opacity: 0.2 !default;
-$penumbra-opacity: 0.14 !default;
-$ambient-opacity: 0.12 !default;
+$umbra-color: rgba($baseline-color, 0.2) !default;
+$penumbra-color: rgba($baseline-color, 0.14) !default;
+$ambient-color: rgba($baseline-color, 0.12) !default;
 
-$umbra-map: (
-  0: '0px 0px 0px 0px',
-  1: '0px 2px 1px -1px',
-  2: '0px 3px 1px -2px',
-  3: '0px 3px 3px -2px',
-  4: '0px 2px 4px -1px',
-  5: '0px 3px 5px -1px',
-  6: '0px 3px 5px -1px',
-  7: '0px 4px 5px -2px',
-  8: '0px 5px 5px -3px',
-  9: '0px 5px 6px -3px',
-  10: '0px 6px 6px -3px',
-  11: '0px 6px 7px -4px',
-  12: '0px 7px 8px -4px',
-  13: '0px 7px 8px -4px',
-  14: '0px 7px 9px -4px',
-  15: '0px 8px 9px -5px',
-  16: '0px 8px 10px -5px',
-  17: '0px 8px 11px -5px',
-  18: '0px 9px 11px -5px',
-  19: '0px 9px 12px -6px',
-  20: '0px 10px 13px -6px',
-  21: '0px 10px 13px -6px',
-  22: '0px 10px 14px -6px',
-  23: '0px 11px 14px -7px',
-  24: '0px 11px 15px -7px',
+$tokens: (
+  0: '0px 0px 0px 0px #{$umbra-color}, 0px 0px 0px 0px #{$penumbra-color}, 0px 0px 0px 0px #{$ambient-color}',
+  1: '0px 2px 1px -1px #{$umbra-color}, 0px 1px 1px 0px #{$penumbra-color}, 0px 1px 3px 0px #{$ambient-color}',
+  2: '0px 3px 1px -2px #{$umbra-color}, 0px 2px 2px 0px #{$penumbra-color}, 0px 1px 5px 0px #{$ambient-color}',
+  3: '0px 3px 3px -2px #{$umbra-color}, 0px 3px 4px 0px #{$penumbra-color}, 0px 1px 8px 0px #{$ambient-color}',
+  4: '0px 2px 4px -1px #{$umbra-color}, 0px 4px 5px 0px #{$penumbra-color}, 0px 1px 10px 0px #{$ambient-color}',
+  5: '0px 3px 5px -1px #{$umbra-color}, 0px 5px 8px 0px #{$penumbra-color}, 0px 1px 14px 0px #{$ambient-color}',
+  6: '0px 3px 5px -1px #{$umbra-color}, 0px 6px 10px 0px #{$penumbra-color}, 0px 1px 18px 0px #{$ambient-color}',
+  7: '0px 4px 5px -2px #{$umbra-color}, 0px 7px 10px 1px #{$penumbra-color}, 0px 2px 16px 1px #{$ambient-color}',
+  8: '0px 5px 5px -3px #{$umbra-color}, 0px 8px 10px 1px #{$penumbra-color}, 0px 3px 14px 2px #{$ambient-color}',
+  9: '0px 5px 6px -3px #{$umbra-color}, 0px 9px 12px 1px #{$penumbra-color}, 0px 3px 16px 2px #{$ambient-color}',
+  10: '0px 6px 6px -3px #{$umbra-color}, 0px 10px 14px 1px #{$penumbra-color}, 0px 4px 18px 3px #{$ambient-color}',
+  11: '0px 6px 7px -4px #{$umbra-color}, 0px 11px 15px 1px #{$penumbra-color}, 0px 4px 20px 3px #{$ambient-color}',
+  12: '0px 7px 8px -4px #{$umbra-color}, 0px 12px 17px 2px #{$penumbra-color}, 0px 5px 22px 4px #{$ambient-color}',
+  13: '0px 7px 8px -4px #{$umbra-color}, 0px 13px 19px 2px #{$penumbra-color}, 0px 5px 24px 4px #{$ambient-color}',
+  14: '0px 7px 9px -4px #{$umbra-color}, 0px 14px 21px 2px #{$penumbra-color}, 0px 5px 26px 4px #{$ambient-color}',
+  15: '0px 8px 9px -5px #{$umbra-color}, 0px 15px 22px 2px #{$penumbra-color}, 0px 6px 28px 5px #{$ambient-color}',
+  16: '0px 8px 10px -5px #{$umbra-color}, 0px 16px 24px 2px #{$penumbra-color}, 0px 6px 30px 5px #{$ambient-color}',
+  17: '0px 8px 11px -5px #{$umbra-color}, 0px 17px 26px 2px #{$penumbra-color}, 0px 6px 32px 5px #{$ambient-color}',
+  18: '0px 9px 11px -5px #{$umbra-color}, 0px 18px 28px 2px #{$penumbra-color}, 0px 7px 34px 6px #{$ambient-color}',
+  19: '0px 9px 12px -6px #{$umbra-color}, 0px 19px 29px 2px #{$penumbra-color}, 0px 7px 36px 6px #{$ambient-color}',
+  20: '0px 10px 13px -6px #{$umbra-color}, 0px 20px 31px 3px #{$penumbra-color}, 0px 8px 38px 7px #{$ambient-color}',
+  21: '0px 10px 13px -6px #{$umbra-color}, 0px 21px 33px 3px #{$penumbra-color}, 0px 8px 40px 7px #{$ambient-color}',
+  22: '0px 10px 14px -6px #{$umbra-color}, 0px 22px 35px 3px #{$penumbra-color}, 0px 8px 42px 7px #{$ambient-color}',
+  23: '0px 11px 14px -7px #{$umbra-color}, 0px 23px 36px 3px #{$penumbra-color}, 0px 9px 44px 8px #{$ambient-color}',
+  24: '0px 11px 15px -7px #{$umbra-color}, 0px 24px 38px 3px #{$penumbra-color}, 0px 9px 46px 8px #{$ambient-color}',
 ) !default;
 
-$penumbra-map: (
-  0: '0px 0px 0px 0px',
-  1: '0px 1px 1px 0px',
-  2: '0px 2px 2px 0px',
-  3: '0px 3px 4px 0px',
-  4: '0px 4px 5px 0px',
-  5: '0px 5px 8px 0px',
-  6: '0px 6px 10px 0px',
-  7: '0px 7px 10px 1px',
-  8: '0px 8px 10px 1px',
-  9: '0px 9px 12px 1px',
-  10: '0px 10px 14px 1px',
-  11: '0px 11px 15px 1px',
-  12: '0px 12px 17px 2px',
-  13: '0px 13px 19px 2px',
-  14: '0px 14px 21px 2px',
-  15: '0px 15px 22px 2px',
-  16: '0px 16px 24px 2px',
-  17: '0px 17px 26px 2px',
-  18: '0px 18px 28px 2px',
-  19: '0px 19px 29px 2px',
-  20: '0px 20px 31px 3px',
-  21: '0px 21px 33px 3px',
-  22: '0px 22px 35px 3px',
-  23: '0px 23px 36px 3px',
-  24: '0px 24px 38px 3px',
-) !default;
+@function get($key) {
+  @return map.get($tokens, $key);
+}
 
-$ambient-map: (
-  0: '0px 0px 0px 0px',
-  1: '0px 1px 3px 0px',
-  2: '0px 1px 5px 0px',
-  3: '0px 1px 8px 0px',
-  4: '0px 1px 10px 0px',
-  5: '0px 1px 14px 0px',
-  6: '0px 1px 18px 0px',
-  7: '0px 2px 16px 1px',
-  8: '0px 3px 14px 2px',
-  9: '0px 3px 16px 2px',
-  10: '0px 4px 18px 3px',
-  11: '0px 4px 20px 3px',
-  12: '0px 5px 22px 4px',
-  13: '0px 5px 24px 4px',
-  14: '0px 5px 26px 4px',
-  15: '0px 6px 28px 5px',
-  16: '0px 6px 30px 5px',
-  17: '0px 6px 32px 5px',
-  18: '0px 7px 34px 6px',
-  19: '0px 7px 36px 6px',
-  20: '0px 8px 38px 7px',
-  21: '0px 8px 40px 7px',
-  22: '0px 8px 42px 7px',
-  23: '0px 9px 44px 8px',
-  24: '0px 9px 46px 8px',
-) !default;

--- a/src/lib/core/styles/tokens/theme/_tokens.core.scss
+++ b/src/lib/core/styles/tokens/theme/_tokens.core.scss
@@ -1,40 +1,70 @@
 @use 'sass:map';
-@use '../../utils';
-@use './token-utils';
-@use './tokens.surface' as surface;
 @use '../color-palette';
 
-///
-/// Computes the status theme colors.
-/// 
-/// @param {Map} $colors - The status colors map.
-/// @param {Map} $surface-theme - The base surface theme
-/// @return {Map} - The computed status theme
-/// 
-@function get-status-theme($colors, $surface-theme) {
-  $surface: map.get($surface-theme, surface);
-
-  $primary-theme: token-utils.get-color-theme('primary', map.get($colors, primary), $surface);
-  $secondary-theme: token-utils.get-color-theme('secondary', map.get($colors, secondary), $surface);
-  $tertiary-theme: token-utils.get-color-theme('tertiary', map.get($colors, tertiary), $surface);
-
-  @return utils.flatten(
-    $primary-theme,
-    $secondary-theme,
-    $tertiary-theme
-  );
-}
-
 // Light
-$tokens: get-status-theme((
+$tokens: (
   primary: color-palette.$indigo-500,
+  primary-container-minimum: #f7f8fc,
+  primary-container-low: color-palette.$indigo-50,
+  primary-container: #d1d5ed,
+  primary-container-high: #b6bde3,
+  on-primary: color-palette.$white,
+  on-primary-container-minimum: #222c62,
+  on-primary-container-low: #222c62,
+  on-primary-container: #222c62,
+  on-primary-container-high: color-palette.$black,
   secondary: color-palette.$amber-500,
-  tertiary: color-palette.$indigo-a400
-), surface.$tokens);
+  secondary-container-minimum: #fffdf5,
+  secondary-container-low: color-palette.$amber-50,
+  secondary-container: #fff0c3,
+  secondary-container-high: #ffe7a1,
+  on-secondary: color-palette.$black,
+  on-secondary-container-minimum: #8a6804,
+  on-secondary-container-low: #8a6804,
+  on-secondary-container: #8a6804,
+  on-secondary-container-high: color-palette.$black,
+  tertiary: color-palette.$indigo-a400,
+  tertiary-container-minimum: #f7f8ff,
+  tertiary-container-low: #e8ebff,
+  tertiary-container: #d0d7ff,
+  tertiary-container-high: #b5c0ff,
+  on-tertiary: color-palette.$white,
+  on-tertiary-container-minimum: #213189,
+  on-tertiary-container-low: #213189,
+  on-tertiary-container: #213189,
+  on-tertiary-container-high: color-palette.$black,
+);
 
 // Dark
-$tokens-dark: get-status-theme((
+$tokens-dark: (
   primary: color-palette.$indigo-a100,
+  primary-container-minimum: #303134,
+  primary-container-low: #383a45,
+  primary-container: #43475f,
+  primary-container-high: #50577c,
+  on-primary: color-palette.$black,
+  on-primary-container-minimum: #c1cbff,
+  on-primary-container-low: #c1cbff,
+  on-primary-container: #c1cbff,
+  on-primary-container-high: color-palette.$white,
   secondary: color-palette.$amber-200,
-  tertiary: color-palette.$amber-200
-), surface.$tokens-dark);
+  secondary-container-minimum: #34332f,
+  secondary-container-low: #454236,
+  secondary-container: #5f5741,
+  secondary-container-high: #7c704d,
+  on-secondary: color-palette.$black,
+  on-secondary-container-minimum: #ffeebc,
+  on-secondary-container-low: #ffeebc,
+  on-secondary-container: #ffeebc,
+  on-secondary-container-high: color-palette.$white,
+  tertiary: color-palette.$amber-200,
+  tertiary-container-minimum: #34332f,
+  tertiary-container-low: #454236,
+  tertiary-container: #5f5741,
+  tertiary-container-high: #7c704d,
+  on-tertiary: color-palette.$black,
+  on-tertiary-container-minimum: #ffeebc,
+  on-tertiary-container-low: #ffeebc,
+  on-tertiary-container: #ffeebc,
+  on-tertiary-container-high: color-palette.$white,
+);

--- a/src/lib/core/styles/tokens/theme/_tokens.scss
+++ b/src/lib/core/styles/tokens/theme/_tokens.scss
@@ -1,6 +1,5 @@
 @use 'sass:map';
 @use '../../utils';
-@use '../../theme/utils' as theme-utils;
 @use './tokens.brand' as brand;
 @use './tokens.core' as core;
 @use './tokens.surface' as surface;

--- a/src/lib/core/styles/tokens/theme/_tokens.status.scss
+++ b/src/lib/core/styles/tokens/theme/_tokens.status.scss
@@ -1,44 +1,90 @@
 @use 'sass:map';
-@use '../../utils';
-@use './token-utils';
-@use './tokens.surface' as surface;
 @use '../color-palette';
 
-///
-/// Computes the status theme colors.
-/// 
-/// @param {Map} $colors - The status colors map.
-/// @param {Map} $surface-theme - The base surface theme
-/// @return {Map} - The computed status theme
-///
-@function get-status-theme($colors, $surface-theme) {
-  $surface: map.get($surface-theme, surface);
-
-  $success-theme: token-utils.get-color-theme('success', map.get($colors, success), $surface);
-  $error-theme: token-utils.get-color-theme('error', map.get($colors, error), $surface);
-  $warning-theme: token-utils.get-color-theme('warning', map.get($colors, warning), $surface);
-  $info-theme: token-utils.get-color-theme('info', map.get($colors, info), $surface);
-
-  @return utils.flatten(
-    $success-theme,
-    $error-theme,
-    $warning-theme,
-    $info-theme
-  );
-}
-
 // Light
-$tokens: get-status-theme((
+$tokens: (
   success: color-palette.$green-800,
+  success-container-minimum: #f7faf7,
+  success-container-low: #e6efe6,
+  success-container: #cde0ce,
+  success-container-high: #b0ceb1,
+  on-success: color-palette.$white,
+  on-success-container-minimum: #19441b,
+  on-success-container-low: #19441b,
+  on-success-container: #19441b,
+  on-success-container-high: color-palette.$black,
   error: color-palette.$crimson-900,
+  error-container-minimum: #fcf5f6,
+  error-container-low: #f6e0e4,
+  error-container: #ecc2c9,
+  error-container-high: #e19eaa,
+  on-error: color-palette.$white,
+  on-error-container-minimum: #5f0011,
+  on-error-container-low: #5f0011,
+  on-error-container: #5f0011,
+  on-error-container-high: color-palette.$black,
   warning: color-palette.$burnt-orange-800,
-  info: color-palette.$blue-800
-), surface.$tokens);
+  warning-container-minimum: #fdf8f5,
+  warning-container-low: #f9e9e0,
+  warning-container: #f4d3c2,
+  warning-container-high: #eeba9e,
+  on-warning: color-palette.$white,
+  on-warning-container-minimum: #712700,
+  on-warning-container-low: #712700,
+  on-warning-container: #712700,
+  on-warning-container-high: color-palette.$black,
+  info: color-palette.$blue-800,
+  info-container-minimum: #f6f9fc,
+  info-container-low: #e3edf7,
+  info-container: #c7daf0,
+  info-container-high: #a6c4e7,
+  on-info: color-palette.$white,
+  on-info-container-minimum: #0b3768,
+  on-info-container-low: #0b3768,
+  on-info-container: #0b3768,
+  on-info-container-high: color-palette.$black,
+);
 
 // Dark
-$tokens-dark: get-status-theme((
+$tokens-dark: (
   success: color-palette.$dollar-bill-600,
-  error: color-palette.$ruddy-pink-200,
+  success-container-minimum: #30312e,
+  success-container-low: #373c32,
+  success-container: #424c38,
+  success-container-high: #4e5f40,
+  on-success: color-palette.$black,
+  on-success-container-minimum: #bed5a9,
+  on-success-container-low: #bed5a9,
+  on-success-container: #bed5a9,
+  on-success-container-high: color-palette.$white,
+  error: color-palette.$ruddy-pink-500,
+  error-container-minimum: #342f30,
+  error-container-low: #433639,
+  error-container: #5a4145,
+  error-container-high: #754d54,
+  on-error: color-palette.$black,
+  on-error-container-minimum: #f5bcc6,
+  on-error-container-low: #f5bcc6,
+  on-error-container: #f5bcc6,
+  on-error-container-high: color-palette.$white,
   warning: color-palette.$apricot-200,
+  warning-container-minimum: #34312f,
+  warning-container-low: #443c36,
+  warning-container: #5d4c3f,
+  warning-container-high: #7a5f4a,
+  on-warning: color-palette.$black,
+  on-warning-container-minimum: #fbd5b8,
+  on-warning-container-low: #fbd5b8,
+  on-warning-container: #fbd5b8,
+  on-warning-container-high: color-palette.$white,
   info: color-palette.$blue-800,
-), surface.$tokens-dark);
+  info-container-minimum: #2b2e32,
+  info-container-low: #29333e,
+  info-container: #263a50,
+  info-container-high: #234264,
+  on-info: color-palette.$white,
+  on-info-container-minimum: #81acdd,
+  on-info-container-low: #81acdd,
+  on-info-container: #81acdd,
+  on-info-container-high: color-palette.$white,
+);

--- a/src/lib/core/styles/tokens/theme/_tokens.surface.scss
+++ b/src/lib/core/styles/tokens/theme/_tokens.surface.scss
@@ -1,63 +1,45 @@
 @use 'sass:map';
-@use '../../theme/utils' as theme-utils;
-@use '../../theme/color-utils';
 @use '../../elevation';
-@use './color-emphasis';
 @use '../color-palette';
 
-///
-/// Computes the surface theme colors.
-/// 
-/// @param {Map} $theme - The surface theme map.
-/// @return {Map} - The computed surface theme map
-/// 
-@function get-surface-theme($theme) {
-  $surface: map.get($theme, surface);
-  $on-surface: theme-utils.contrast($surface);
-  $surface-tone: color-utils.tone($surface);
-  $surface-inverse: theme-utils.hexify($on-surface, $surface, color-emphasis.value(inverse));
-
-  $surface-container: theme-utils.hexify($on-surface, $surface, color-emphasis.value(lower));
-  $surface-container-minimum: theme-utils.hexify($on-surface, $surface, color-emphasis.value(minimum));
-  $surface-container-low: theme-utils.hexify($on-surface, $surface, color-emphasis.value(lowest));
-  $surface-container-medium: theme-utils.hexify($on-surface, $surface, color-emphasis.value(if($surface-tone == 'light', low, medium-low)));
-  $surface-container-high: theme-utils.hexify($on-surface, $surface, color-emphasis.value(if($surface-tone == 'light', medium-low, medium)));
-
-  @return (
-    surface: $surface,
-    surface-inverse: $surface-inverse,
-    surface-container: $surface-container,
-    surface-container-minimum: $surface-container-minimum,
-    surface-container-low: $surface-container-low,
-    surface-container-medium: $surface-container-medium,
-    surface-container-high: $surface-container-high,
-    surface-dim: map.get($theme, surface-dim),
-    surface-bright: map.get($theme, surface-bright),
-    surface-bright-shadow: map.get($theme, surface-bright-shadow),
-    on-surface: $on-surface,
-    on-surface-inverse: theme-utils.contrast($surface-inverse),
-    on-surface-container: theme-utils.contrast($surface-container),
-    on-surface-container-minimum: theme-utils.contrast($surface-container-minimum),
-    on-surface-container-low: theme-utils.contrast($surface-container-low),
-    on-surface-container-medium: theme-utils.contrast($surface-container-medium),
-    on-surface-container-high: theme-utils.contrast($surface-container-high)
-  );
-}
-
 // Light
-$tokens: get-surface-theme((
+$tokens: (
   surface: color-palette.$neutral-50,
+  surface-inverse: #333333,
+  surface-container: color-palette.$grey-300,
+  surface-container-minimum: color-palette.$grey-100,
+  surface-container-low: #ebebeb,
+  surface-container-medium: #c2c2c2,
+  surface-container-high: color-palette.$grey-500,
+  surface-dim: color-palette.$grey-50,
   surface-bright: color-palette.$neutral-50,
   surface-bright-shadow: elevation.value(2),
-  surface-dim: color-palette.$grey-50
-));
+  on-surface: color-palette.$black,
+  on-surface-inverse: color-palette.$white,
+  on-surface-container: color-palette.$black,
+  on-surface-container-minimum: color-palette.$black,
+  on-surface-container-low: color-palette.$black,
+  on-surface-container-medium: color-palette.$black,
+  on-surface-container-high: color-palette.$black
+);
 
 // Dark
-$surface-dark: color-palette.$neutral-900;
-$on-surface-dark: theme-utils.contrast($surface-dark);
-$tokens-dark: get-surface-theme((
+$tokens-dark: (
   surface: color-palette.$neutral-900,
-  surface-bright: theme-utils.hexify($on-surface-dark, $surface-dark, color-emphasis.value(minimum)),
+  surface-inverse: #d5d5d5,
+  surface-container: #454545,
+  surface-container-minimum: #343434,
+  surface-container-low: #3d3d3d,
+  surface-container-medium: #7c7c7c,
+  surface-container-high: color-palette.$grey-500,
+  surface-dim: color-palette.$grey-900,
+  surface-bright: color-palette.$neutral-50,
   surface-bright-shadow: elevation.value(16),
-  surface-dim: color-palette.$grey-900
-));
+  on-surface: color-palette.$white,
+  on-surface-inverse: color-palette.$black,
+  on-surface-container: color-palette.$white,
+  on-surface-container-minimum: color-palette.$white,
+  on-surface-container-low: color-palette.$white,
+  on-surface-container-medium: color-palette.$white,
+  on-surface-container-high: color-palette.$black
+);

--- a/src/lib/core/styles/tokens/theme/_tokens.surface.scss
+++ b/src/lib/core/styles/tokens/theme/_tokens.surface.scss
@@ -33,7 +33,7 @@ $tokens-dark: (
   surface-container-medium: #7c7c7c,
   surface-container-high: color-palette.$grey-500,
   surface-dim: color-palette.$grey-900,
-  surface-bright: color-palette.$neutral-50,
+  surface-bright: #343434,
   surface-bright-shadow: elevation.value(16),
   on-surface: color-palette.$white,
   on-surface-inverse: color-palette.$black,

--- a/src/lib/core/styles/tokens/theme/_tokens.text.scss
+++ b/src/lib/core/styles/tokens/theme/_tokens.text.scss
@@ -1,33 +1,27 @@
 @use 'sass:map';
-@use '../../theme/utils' as theme-utils;
 @use './color-emphasis';
 @use './tokens.surface' as surface;
 
-///
-/// Computes the text theme colors.
-/// 
-/// @param {Color} $surface-theme - The base surface theme
-/// @return {Map} - The computed text theme
-/// 
-@function get-text-theme($surface-theme) {
-  $surface: map.get($surface-theme, surface);
-  $text: theme-utils.contrast($surface);
-  $text-inverse: theme-utils.contrast($text);
-
-  @return (
-    text-high: theme-utils.emphasized($text, color-emphasis.value(highest)),
-    text-high-inverse: theme-utils.emphasized($text-inverse, color-emphasis.value(highest)),
-    text-medium: theme-utils.emphasized($text, color-emphasis.value(medium-high)),
-    text-medium-inverse: theme-utils.emphasized($text-inverse, color-emphasis.value(medium-high)),
-    text-low: theme-utils.emphasized($text, color-emphasis.value(medium-low)),
-    text-low-inverse: theme-utils.emphasized($text-inverse, color-emphasis.value(medium-low)),
-    text-lowest: theme-utils.emphasized($text, color-emphasis.value(lower)),
-    text-lowest-inverse: theme-utils.emphasized($text-inverse, color-emphasis.value(lower)),
-  );
-}
-
 // Light
-$tokens: get-text-theme(surface.$tokens);
+$tokens: (
+  text-high: rgba(#000, color-emphasis.value(highest)),
+  text-high-inverse: rgba(#fff, color-emphasis.value(highest)),
+  text-medium: rgba(#000, color-emphasis.value(medium-high)),
+  text-medium-inverse: rgba(#fff, color-emphasis.value(medium-high)),
+  text-low: rgba(#000, color-emphasis.value(medium-low)),
+  text-low-inverse: rgba(#fff, color-emphasis.value(medium-low)),
+  text-lowest: rgba(#000, color-emphasis.value(lower)),
+  text-lowest-inverse: rgba(#fff, color-emphasis.value(lower)),
+);
 
 // Dark
-$tokens-dark: get-text-theme(surface.$tokens-dark);
+$tokens-dark: (
+  text-high: rgba(#fff, color-emphasis.value(highest)),
+  text-high-inverse: rgba(#000, color-emphasis.value(highest)),
+  text-medium: rgba(#fff, color-emphasis.value(medium-high)),
+  text-medium-inverse: rgba(#000, color-emphasis.value(medium-high)),
+  text-low: rgba(#fff, color-emphasis.value(medium-low)),
+  text-low-inverse: rgba(#000, color-emphasis.value(medium-low)),
+  text-lowest: rgba(#fff, color-emphasis.value(lower)),
+  text-lowest-inverse: rgba(#000, color-emphasis.value(lower)),
+);

--- a/src/lib/core/styles/tokens/theme/_tokens.utilities.scss
+++ b/src/lib/core/styles/tokens/theme/_tokens.utilities.scss
@@ -1,28 +1,18 @@
 @use 'sass:map';
-@use '../../theme/utils' as theme-utils;
-@use './color-emphasis';
-@use './tokens.surface' as surface;
-
-///
-/// Computes the utilities theme colors.
-/// 
-/// @param {Color} $surface-theme - The base surface theme
-/// @return {Map} - The computed utilities theme 
-///
-@function get-utilities-theme($surface-theme) {
-  $surface: map.get($surface-theme, surface);
-  $on-surface: map.get($surface-theme, on-surface);
-
-  @return (
-    outline-high: theme-utils.hexify($on-surface, $surface, color-emphasis.value(highest)),
-    outline-medium: theme-utils.hexify($on-surface, $surface, color-emphasis.value(medium)),
-    outline-low: theme-utils.hexify($on-surface, $surface, color-emphasis.value(medium-low)),
-    outline: theme-utils.hexify($on-surface, $surface, color-emphasis.value(lower))
-  );
-}
+@use '../color-palette';
 
 // Light
-$tokens: get-utilities-theme(surface.$tokens);
+$tokens: (
+  outline-high: color-palette.$grey-900,
+  outline-medium: color-palette.$grey-600,
+  outline-low: color-palette.$grey-500,
+  outline: color-palette.$grey-300
+);
 
 // Dark
-$tokens-dark: get-utilities-theme(surface.$tokens-dark);
+$tokens-dark: (
+  outline-high: #e4e4e4,
+  outline-medium: color-palette.$grey-500,
+  outline-low: color-palette.$grey-600,
+  outline: color-palette.$grey-800
+);

--- a/src/lib/forge-tokens.scss
+++ b/src/lib/forge-tokens.scss
@@ -1,0 +1,35 @@
+@use './core/styles/animation';
+@use './core/styles/border';
+@use './core/styles/elevation';
+@use './core/styles/shape';
+@use './core/styles/spacing';
+
+// Animation
+:root {
+  @include animation.properties;
+}
+
+// Border
+:root {
+  @include border.properties;
+}
+
+// Elevation
+:root {
+  @include elevation.properties;
+}
+
+// z-index layering
+:root {
+  @include elevation.z-index-properties;
+}
+
+// Shape
+:root {
+  @include shape.properties;
+}
+
+// Spacing
+:root {
+  @include spacing.properties;
+}

--- a/src/lib/forge.scss
+++ b/src/lib/forge.scss
@@ -1,2 +1,3 @@
+@use './forge-tokens';
 @use './theme/forge-theme';
 @use './typography/forge-typography';

--- a/src/stories/preview-head.html
+++ b/src/stories/preview-head.html
@@ -42,7 +42,7 @@
     background-color: var(--forge-docs-core-code-background);
     white-space: pre;
     padding: 2px 4px;
-    border: 1px solid var(--forge-theme-border-color);
+    border: 1px solid var(--forge-theme-outline);
     border-radius: 4px;
     color: var(--mdc-theme-text-primary-on-background);
   }

--- a/src/stories/src/components/button/button.mdx
+++ b/src/stories/src/components/button/button.mdx
@@ -66,7 +66,7 @@ Gets/sets the button type. Valid values: `raised`, `unelevated`, `outlined`, `de
 | :---------------------------------------| :----------------
 | `--mdc-theme-primary`                   | Sets the background color
 | `--mdc-theme-on-primary`                | Sets the font color.
-| `--forge-theme-border-color`            | Sets the border color.
+| `--forge-theme-outline`            | Sets the border color.
 | `--mdc-theme-text-disabled-on-light`    | Sets the disabled color.
 
 </PageSection>

--- a/src/stories/src/components/calendar/calendar.mdx
+++ b/src/stories/src/components/calendar/calendar.mdx
@@ -435,7 +435,7 @@ If `setFocus` is `true` the date will receive focus.
 | `--forge-calendar-menu-max-height`        | Controls the max height of a the menu when displayed as a grid.
 | `--mdc-theme-primary`                     | Controls the primary theme color used throughout the component.
 | `--mdc-theme-on-primary`                  | Controls the on-primary theme color used throughout the component.
-| `--forge-theme-border-color`              | Controls the border-color theme color used throughout the component.
+| `--forge-theme-outline`              | Controls the border-color theme color used throughout the component.
 | `--mdc-theme-text-disabled-on-light`      | Controls the disabled color used for day cells.
 
 ### Events

--- a/src/stories/src/components/card/card.mdx
+++ b/src/stories/src/components/card/card.mdx
@@ -111,7 +111,7 @@ Controls whether the card has elevation applied.
 | `--forge-card-overflow`           | Controls the `overflow` style of the card element.
 | `--forge-card-height`             | Sets the `height` of the card element.
 | `--forge-card-width`              | Sets the `width` of the card element.
-| `--forge-theme-border-color`      | Sets the border color of the card element when not raised.
+| `--forge-theme-outline`      | Sets the border color of the card element when not raised.
 
 </PageSection>
 

--- a/src/stories/src/components/chips/chips.mdx
+++ b/src/stories/src/components/chips/chips.mdx
@@ -221,7 +221,7 @@ Controls the invalid state.
 | `--forge-chip-min-height`                  | Sets the `min-height` of the element. Default varies based on type and density.
 | `--mdc-theme-primary`                      | Sets the primary theme throughout the component
 | `--mdc-theme-on-primary`                   | Sets the contrasting color of the primary theme through the component.
-| `--forge-theme-border-color`               | Sets the border color.
+| `--forge-theme-outline`               | Sets the border color.
 | `--mdc-theme-error`                        | Sets the delete color.
 | `--mdc-theme-text-primary-on-dark`         | Sets the selected font color.
 | `--mdc-theme-text-primary-on-background`   | Sets the focus and hover font color.

--- a/src/stories/src/components/divider/divider.mdx
+++ b/src/stories/src/components/divider/divider.mdx
@@ -53,7 +53,7 @@ Causes the component to render vertically.
 
 | Name                                       | Description
 | :------------------------------------------| :---------------
-| `--forge-theme-border-color`               | Controls the color of the divider line.
+| `--forge-theme-outline`               | Controls the color of the divider line.
 | `--forge-divider-width`                    | Sets the stroke width of the divider line. Default is `1px`.
 | `--forge-divider-margin`                   | Controls the `margin` style that is applied to the internal root element.
 

--- a/src/stories/src/components/drawer/drawer.mdx
+++ b/src/stories/src/components/drawer/drawer.mdx
@@ -153,7 +153,7 @@ Controls the hover mode on the mini drawer. Allowing the mini drawer to expand w
 | Name                                           | Values
 | :----------------------------------------------| :-----------------
 | `--mdc-theme-surface`                          | Controls the background-color of the drawer content.
-| `--forge-theme-border-color`                   | Controls the built-in border color.
+| `--forge-theme-outline`                   | Controls the built-in border color.
 | `--forge-drawer-width`                         | Controls the width of the drawer. Recommended widths: 256 or 320px.
 | `--forge-drawer-mini-width`                    | Controls the width of the mini drawer when resting.
 | `--forge-drawer-mini-width-hover`              | Controls the width of the mini drawer when hovering.

--- a/src/stories/src/components/drawer/drawer.stories.tsx
+++ b/src/stories/src/components/drawer/drawer.stories.tsx
@@ -24,7 +24,7 @@ export const Drawer: Story<IDrawerProps> = ({
   const scaffoldStyles = {
     '--forge-scaffold-height': '500px',
     '--forge-scaffold-width': '100%',
-    borderBottom: '1px solid var(--forge-theme-border-color)'
+    borderBottom: '1px solid var(--forge-theme-outline)'
   };
 
   return (
@@ -57,7 +57,7 @@ export const Modal: Story<IDrawerProps> = ({
   const scaffoldStyles = {
     '--forge-scaffold-height': '500px',
     '--forge-scaffold-width': '100%',
-    borderBottom: '1px solid var(--forge-theme-border-color)'
+    borderBottom: '1px solid var(--forge-theme-outline)'
   };
 
   return (
@@ -95,7 +95,7 @@ export const Mini: Story<IMiniDrawerProps> = ({
   const scaffoldStyles = {
     '--forge-scaffold-height': '500px',
     '--forge-scaffold-width': '100%',
-    borderBottom: '1px solid var(--forge-theme-border-color)',
+    borderBottom: '1px solid var(--forge-theme-outline)',
     backgroundColor: 'var(--mdc-theme-background)'
   };
 

--- a/src/stories/src/components/file-picker/file-picker.mdx
+++ b/src/stories/src/components/file-picker/file-picker.mdx
@@ -132,7 +132,7 @@ Gets and sets whether the file picker is borderless.
 | :---------------------------------------------------| :-----------------------
 | `--mdc-theme-primary`                               | Controls the primary color of the default variant.
 | `--mdc-theme-background`                            | Controls the background color of the default variant.
-| `--forge-theme-border-color`                        | Controls the border color of the default variant.
+| `--forge-theme-outline`                        | Controls the border color of the default variant.
 | `--mdc-theme-text-primary-on-background`            | Controls the primary typography title.
 | `--forge-file-picker-height`                        | Controls the height of the default variant container.
 | `--forge-file-picker-width`                         | Controls the width of the default variant container.

--- a/src/stories/src/components/split-view/split-view.mdx
+++ b/src/stories/src/components/split-view/split-view.mdx
@@ -323,7 +323,7 @@ Resizes panels within the split view to avoid overflow.
 | Name                                     | Description
 | :--------------------------------------- | :----------------
 | `--forge-split-view-handle-width`        | Controls the width of the resize handle.
-| `--forge-theme-border-color`             | Controls the background color of the resize handle.
+| `--forge-theme-outline`             | Controls the background color of the resize handle.
 | `--mdc-theme-text-secondary-on-light`    | Controls the color of the resize handle icon.
 
 </PageSection>

--- a/src/stories/src/components/stepper/stepper.mdx
+++ b/src/stories/src/components/stepper/stepper.mdx
@@ -265,7 +265,7 @@ Sets the tab index on the step
 | `--mdc-theme-error`                                                     | Controls the color of the error state.
 | `--mdc-theme-on-primary`                                                | Controls the color of the step icon when selected.
 | `--mdc-theme-on-error`                                                  | Controls the color of the step icon when in an error state.
-| `--forge-theme-border-color`                                            | Controls the border-color of the step line.
+| `--forge-theme-outline`                                            | Controls the border-color of the step line.
 | `--mdc-theme-icon-color`                                                | Controls the font color of the expanded icon.
 | `--mdc-theme-form-field-text-disabled-on-background`                    | Controls the disabled color throughout the component.
 | `--forge-step-expansion-panel-border-left-width`                        | Controls the left border width of the expansion panel.

--- a/src/stories/src/components/table/table.mdx
+++ b/src/stories/src/components/table/table.mdx
@@ -420,7 +420,7 @@ export class TableExampleComponent implements OnInit {
 | `--forge-table-theme-row-active-background`             | Controls the active background color of a body row.
 | `--forge-table-theme-row-selected-active-background`    | Controls the selected active background color of a body row.
 | `--forge-z-index-surface`                               | Controls the z-index of a fixed head cell.
-| `--forge-theme-border-color`                            | Controls the border-color of the table.
+| `--forge-theme-outline`                            | Controls the border-color of the table.
 | `--mdc-theme-primary`                                   | Controls the border-color of the resize handle.
 | `--mdc-theme-surface`                                   | Controls the background-color of the table.
 | `--mdc-theme-on-surface`                                | Controls the font-color of the table.

--- a/src/stories/src/components/toolbar/toolbar.mdx
+++ b/src/stories/src/components/toolbar/toolbar.mdx
@@ -95,7 +95,7 @@ Forces the internal container to use `height: auto` for dynamic content that doe
 | Name                                          | Description
 | :---------------------------------------------| :----------------
 | `--mdc-theme-surface`                         | Controls the background-color of the toolbar.
-| `--forge-theme-border-color`                  | Controls the border-color of the toolbar.
+| `--forge-theme-outline`                  | Controls the border-color of the toolbar.
 | `--forge-toolbar-height`                      | Controls the height.
 | `--forge-toolbar-min-height`                  | Controls the minimum height.
 | `--forge-toolbar-padding`                     | Controls the left and right padding using the `padding-inline` style.

--- a/src/stories/src/core/theme-color-grid.tsx
+++ b/src/stories/src/core/theme-color-grid.tsx
@@ -48,7 +48,7 @@ const colors = {
   },
 
   // Forge-specific
-  '--forge-theme-border-color': {
+  '--forge-theme-outline': {
     value: '#e0e0e0'
   },
   '--forge-theme-danger': {
@@ -125,7 +125,7 @@ const ThemeColorGrid: FC = () => (
               <code className="forge-docs-core__inline-code">{value}</code>
             </td>
             <td className="forge-table-cell forge-table-body__cell">
-              <div style={{ backgroundColor: `var(${theme}, ${value})`, height: '24px', width: '24px', borderRadius: '4px', border: '1px solid var(--forge-theme-border-color)' }}></div>
+              <div style={{ backgroundColor: `var(${theme}, ${value})`, height: '24px', width: '24px', borderRadius: '4px', border: '1px solid var(--forge-theme-outline)' }}></div>
             </td>
           </tr>
         );

--- a/src/stories/src/guides/css-custom-properties.stories.mdx
+++ b/src/stories/src/guides/css-custom-properties.stories.mdx
@@ -39,7 +39,7 @@ For in-depth information on theming, please see the [theming guide](?path=/docs/
 | `--mdc-theme-on-primary`                              | The theme color for usage on top of the primary theme color.
 | `--mdc-theme-on-secondary`                            | The theme color for usage on top of the secondary theme color.
 | `--forge-theme-on-tertiary`                           | The theme color for usage on top of the tertiary theme color.
-| `--forge-theme-border-color`                          | The theme color for borders and dividers.
+| `--forge-theme-outline`                          | The theme color for borders and dividers.
 | `--forge-theme-icon-color`                            | The theme color for icons.
 | `--forge-theme-danger`                                | The theme color error states.
 | `--forge-theme-warning`                               | The theme color warning states.


### PR DESCRIPTION
- Replaced computed tokens with static values
- Referenced the color palette where possible for theme colors
- Separated out utility tokens into their own `forge-tokens.css` stylesheet
- Added all tokens the default global `forge.css` stylesheet