### PR TITLE
fix(text-field): remove legacy `<label>` & `<input>` DOM order manipulation

### DIFF
--- a/src/dev/pages/autocomplete/autocomplete.ejs
+++ b/src/dev/pages/autocomplete/autocomplete.ejs
@@ -2,8 +2,8 @@
   <form autocomplete="off">
     <forge-autocomplete id="autocomplete">
       <forge-text-field>
-        <input type="text" id="autocomplete-input" aria-label="Choose state" />
         <label for="autocomplete-input">Choose state</label>
+        <input type="text" id="autocomplete-input" aria-label="Choose state" />
         <forge-icon-button slot="trailing" dense density-level="2">
           <button type="button" data-forge-autocomplete-clear>
             <forge-icon name="close"></forge-icon>

--- a/src/dev/pages/date-range-picker/date-range-picker.ejs
+++ b/src/dev/pages/date-range-picker/date-range-picker.ejs
@@ -1,9 +1,9 @@
 <div class="vert">
   <forge-date-range-picker id="demo-date-range-picker">
     <forge-text-field>
+      <label for="input-date-range-picker-01">Date</label>
       <input type="text" id="input-date-range-picker-01" autocomplete="off" placeholder="">
       <input type="text" id="input-date-range-picker-02" autocomplete="off" placeholder="">
-      <label for="input-date-range-picker-01">Date</label>
       <span slot="helper-text">Enter a date range</span>
     </forge-text-field>
   </forge-date-range-picker>

--- a/src/dev/pages/keyboard-shortcut/keyboard-shortcut.ejs
+++ b/src/dev/pages/keyboard-shortcut/keyboard-shortcut.ejs
@@ -8,8 +8,8 @@
 
   <div>
     <forge-text-field>
-      <input type="text" id="keyboard-shortcut-text-field" />
       <label for="keyboard-shortcut-text-field">Shortcut target</label>
+      <input type="text" id="keyboard-shortcut-text-field" />
     </forge-text-field>
     <forge-keyboard-shortcut id="text-field-shortcut"></forge-keyboard-shortcut>
   </div>

--- a/src/dev/pages/time-picker/time-picker.ejs
+++ b/src/dev/pages/time-picker/time-picker.ejs
@@ -1,8 +1,8 @@
 <div class="vert">
   <forge-time-picker id="time-picker">
     <forge-text-field>
-      <input type="text" id="time-picker-input" />
       <label for="time-picker-input">Choose time</label>
+      <input type="text" id="time-picker-input" />
     </forge-text-field>
   </forge-time-picker>
 

--- a/src/dev/src/partials/controls/text-field.ejs
+++ b/src/dev/src/partials/controls/text-field.ejs
@@ -1,9 +1,9 @@
 <forge-text-field>
+  <% if (control.label) { %>
+    <label for="<%= control.id %>"><%= control.label %></label>
+  <% } %>
   <input
     type="<%= control.inputType ?? 'text' %>"
     id="<%= control.id %>"
     value="<%= control.defaultValue ?? undefined %>" />
-  <% if (control.label) { %>
-    <label for="<%= control.id %>"><%= control.label %></label>
-  <% } %>
 </forge-text-field>

--- a/src/dev/src/partials/controls/time-picker.ejs
+++ b/src/dev/src/partials/controls/time-picker.ejs
@@ -1,8 +1,8 @@
 <forge-time-picker id="<%= control.id %>" value="<%= control.defaultValue ?? undefined %>">
   <forge-text-field>
-    <input type="text" />
     <% if (control.label) { %>
-      <label for="<%= control.id %>"><%= control.label %></label>
+      <label for="time-picker-<%= control.id %>"><%= control.label %></label>
     <% } %>
+    <input type="text" id="time-picker-<%= control.id %>" />
   </forge-text-field>
 </forge-time-picker>

--- a/src/lib/field/field-adapter.ts
+++ b/src/lib/field/field-adapter.ts
@@ -51,7 +51,6 @@ export interface IFieldAdapter extends IBaseAdapter {
   // state actions
   initialize(rootSelector: string): void;
   initializeFloatingLabel(): IFloatingLabel;
-  ensureLabelOrder(): void;
   ensureSlottedLabel(): void;
   destroy(): void;
   setValueChangedListener(context: any, listener: (value: any) => void): void;
@@ -99,15 +98,6 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
 
   public ensureSlottedLabel(): void {
     this._labelElement.slot = 'label';
-  }
-
-  public ensureLabelOrder(): void {
-    if (this._labelElement) {
-      const children = Array.from(this._component.children);
-      if (children.length > 1 && children.indexOf(this._labelElement) < children.indexOf(this._inputElement)) {
-        this._component.appendChild(this._labelElement);
-      }
-    }
   }
 
   public addLabelSlotListener(listener: (evt: Event) => void): void {

--- a/src/lib/field/field-foundation.ts
+++ b/src/lib/field/field-foundation.ts
@@ -247,7 +247,6 @@ export class FieldFoundation {
     
     if (this._adapter.hasLabel() && this._density !== 'dense') {
       this._floatingLabel = this._adapter.initializeFloatingLabel();
-      this._adapter.ensureLabelOrder();
       this.floatLabel(this._floatLabelType === 'always' || this._adapter.fieldHasValue() || this._adapter.hasPlaceholder());
       this._adapter.setRootClass(FIELD_CONSTANTS.classes.LABEL);
     } else {

--- a/src/lib/text-field/text-field-adapter.ts
+++ b/src/lib/text-field/text-field-adapter.ts
@@ -41,15 +41,6 @@ export class TextFieldAdapter extends FieldAdapter implements ITextFieldAdapter 
     });
   }
 
-  public override ensureLabelOrder(): void {
-    if (this._labelElement) {
-      const children = Array.from(this._component.children);
-      if (children.length > 1 && children.indexOf(this._labelElement) < children.indexOf(this._inputElements[0])) {
-        this._component.appendChild(this._labelElement);
-      }
-    }
-  }
-
   public override addInputListener(type: string, listener: (evt: Event) => void): void {
     this._applyToInputs(input => input.addEventListener(type, listener));
   }

--- a/src/stories/src/components/autocomplete/autocomplete.stories.tsx
+++ b/src/stories/src/components/autocomplete/autocomplete.stories.tsx
@@ -46,8 +46,8 @@ export const Default: Story<IAutocompleteProps> = ({
       }}
      style={{width: '600px'}}>
       <ForgeTextField>
-        <input type="text" id="state" />
         <label htmlFor="state">Choose state</label>
+        <input type="text" id="state" />
         <ForgeIconButton dense slot="trailing">
           <button type="button" data-forge-autocomplete-clear aria-label="Clear the selection">
             <forge-icon name="close"></forge-icon>

--- a/src/stories/src/components/autocomplete/code/autocomplete-default.ts
+++ b/src/stories/src/components/autocomplete/code/autocomplete-default.ts
@@ -2,8 +2,8 @@ export const AutocompleteDefaultCodeHtml = () => {
   return `
 <forge-autocomplete>
   <forge-text-field>
-    <input type="text" id="state" />
     <label for="state">Choose state</label>
+    <input type="text" id="state" />
     
     <!-- You can optionally provide a clear button with a data-forge-autocomplete-clear attribute that will be detected automatically. -->
     <forge-icon-button data-forge-autocomplete-clear slot="trailing" dense density="3">

--- a/src/stories/src/components/date-picker/code/date-picker-default.ts
+++ b/src/stories/src/components/date-picker/code/date-picker-default.ts
@@ -2,8 +2,8 @@ export const DatePickerDefaultCodeHtml = () => {
   return `
 <forge-date-picker>
   <forge-text-field>
-    <input type="text" id="input-date-picker"/>
     <label for="input-date-picker">Choose date</label>
+    <input type="text" id="input-date-picker"/>
   </forge-text-field>
 </forge-date-picker>
   `;

--- a/src/stories/src/components/date-picker/date-picker.stories.tsx
+++ b/src/stories/src/components/date-picker/date-picker.stories.tsx
@@ -54,8 +54,8 @@ export const Default: Story<IDatePickerProps> = ({
       locale={locale}
       style={{ maxWidth: '256px' }}>
       <ForgeTextField>
-        <input type="text" id="input-date-picker" />
         <label htmlFor="input-date-picker">Choose date</label>
+        <input type="text" id="input-date-picker" />
       </ForgeTextField>
     </ForgeDatePicker>
   );

--- a/src/stories/src/components/date-range-picker/code/date-range-picker-default.ts
+++ b/src/stories/src/components/date-range-picker/code/date-range-picker-default.ts
@@ -1,9 +1,9 @@
 export const DateRangePickerDefaultCodeHtml = () => `
 <forge-date-range-picker>
   <forge-text-field>
+    <label for="input-date-range-picker-01">Date</label>
     <input type="text" id="input-date-range-picker-01" autocomplete="off" placeholder="mm/dd/yyyy" />
     <input type="text" id="input-date-range-picker-02" autocomplete="off" placeholder="mm/dd/yyyy" />
-    <label for="input-date-range-picker-01">Date</label>
   </forge-text-field>
 </forge-date-range-picker>
 `;

--- a/src/stories/src/components/date-range-picker/date-range-picker.stories.tsx
+++ b/src/stories/src/components/date-range-picker/date-range-picker.stories.tsx
@@ -52,9 +52,9 @@ export const Default: Story<IDateRangePickerProps> = ({
       locale={locale}
       style={{ width: '320px' }}>
       <ForgeTextField>
+        <label htmlFor="input-date-range-picker-01">Date</label>
         <input type="text" id="input-date-range-picker-01" autoComplete="off" placeholder="mm/dd/yyyy" />
         <input type="text" id="input-date-range-picker-02" autoComplete="off" placeholder="mm/dd/yyyy" />
-        <label htmlFor="input-date-range-picker-01">Date</label>
       </ForgeTextField>
     </ForgeDateRangePicker>
   );

--- a/src/stories/src/components/text-field/code/text-field-default.ts
+++ b/src/stories/src/components/text-field/code/text-field-default.ts
@@ -1,6 +1,6 @@
 export const TextFieldDefaultHtml = () => `
 <forge-text-field>
-  <input type="text" id="input-text-01" />
   <label for="input-text-01" slot="label">Text field</label>
+  <input type="text" id="input-text-01" />
 </forge-text-field>
 `;

--- a/src/stories/src/components/text-field/text-field.stories.tsx
+++ b/src/stories/src/components/text-field/text-field.stories.tsx
@@ -43,8 +43,8 @@ export const Default: Story<ITextFieldProps> = ({
       style={{width:  '259px'}}>
       {hasLeading && <ForgeIcon slot="leading" name="event" />}
 
-      <input autoComplete="off" type="text" id="input-text" disabled={disabled} placeholder={hasPlaceholder ? 'Enter first name...' : undefined} />
       {hasLabel && <label htmlFor="input-text" slot="label">{label}</label>}
+      <input autoComplete="off" type="text" id="input-text" disabled={disabled} placeholder={hasPlaceholder ? 'Enter first name...' : undefined} />
 
       {hasTrailing &&
         <ForgeIconButton slot="trailing" dense densityLevel={density === 'dense' ? 6 : 3}>
@@ -91,8 +91,8 @@ export const Textarea: Story<ITextFieldTextareaProps> = ({
   hasHelperText = false
 }) => (
   <ForgeTextField floatLabelType={floatLabelType} invalid={invalid} required={required} style={{width: '512px'}}>
-    <textarea autoComplete="off" id="input-textarea" disabled={disabled} rows={10} placeholder={hasPlaceholder ? 'Enter description...' : undefined}></textarea>
     {hasLabel && <label htmlFor="input-textarea" slot="label">Description</label>}
+    <textarea autoComplete="off" id="input-textarea" disabled={disabled} rows={10} placeholder={hasPlaceholder ? 'Enter description...' : undefined}></textarea>
     {hasHelperText && <span slot="helper-text">Please enter a description</span>}
   </ForgeTextField>
 );

--- a/src/stories/src/components/time-picker/code/time-picker-default.ts
+++ b/src/stories/src/components/time-picker/code/time-picker-default.ts
@@ -1,8 +1,8 @@
 export const TimePickerDefaultHtml = () => `
 <forge-time-picker>
   <forge-text-field>
-    <input type="text" id="time-picker" placeholder="hh:mm AM" />
     <label for="time-picker" slot="label">Time</label>
+    <input type="text" id="time-picker" placeholder="hh:mm AM" />
   </forge-text-field>
 </forge-time-picker>
 `;

--- a/src/stories/src/components/time-picker/time-picker.stories.tsx
+++ b/src/stories/src/components/time-picker/time-picker.stories.tsx
@@ -42,8 +42,8 @@ export const Default: Story<ITimePickerProps> = ({
     showHourOptions={showHourOptions}
     disabled={disabled}>
     <ForgeTextField>
-      <input autoComplete="off" type="text" id="time-picker" placeholder={`hh:mm${allowSeconds ? ':ss' : ''}${use24HourTime ? '' : ' AM'}`} />
       <label htmlFor="time-picker" slot="label">Time</label>
+      <input autoComplete="off" type="text" id="time-picker" placeholder={`hh:mm${allowSeconds ? ':ss' : ''}${use24HourTime ? '' : ' AM'}`} />
     </ForgeTextField>
   </ForgeTimePicker>
 );

--- a/src/stories/src/mock/document-filters.tsx
+++ b/src/stories/src/mock/document-filters.tsx
@@ -127,9 +127,9 @@ export const DocumentPublished: FC = () => (
   <div style={{padding: '16px'}}>
     <ForgeDateRangePicker>
       <ForgeTextField>
+        <label htmlFor="input-date-range-picker-01">Document published</label>
         <input type="text" id="input-date-range-picker-01" autoComplete="off" placeholder="mm/dd/yyyy" />
         <input type="text" id="input-date-range-picker-02" autoComplete="off" placeholder="mm/dd/yyyy" />
-        <label htmlFor="input-date-range-picker-01">Document published</label>
       </ForgeTextField>
     </ForgeDateRangePicker>
   </div>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The `<label>` and `<input>` elements will no longer be moved in the DOM when connected.
