### PR TITLE
fix(badge): fixed a bug where badge text would not ellipse when overflowing

### DIFF
--- a/src/lib/badge/_mixins.scss
+++ b/src/lib/badge/_mixins.scss
@@ -12,6 +12,10 @@
   .forge-badge {
     @include base;
 
+    &__content {
+      @include content;
+    }
+
     &--elevated {
       @include elevated;
     }
@@ -53,13 +57,16 @@
   gap: 4px;
   transition: transform 200ms ease-in-out;
   transform: scale(0);
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
   pointer-events: none;
   border-radius: 16px;
   padding: 0 8px;
   font-weight: 700;
+}
+
+@mixin content {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 @mixin theme-property($property, $theme, $theme-mod) {

--- a/src/lib/badge/badge.html
+++ b/src/lib/badge/badge.html
@@ -1,7 +1,9 @@
 <template>
   <div class="forge-badge forge-badge--open" part="root">
     <slot name="leading"></slot>
-    <slot></slot>
+    <div class="forge-badge__content">
+      <slot></slot>
+    </div>
     <slot name="trailing"></slot>
   </div>
 </template>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Badge text will now properly ellipse when overflowing.

## Additional information
Fixes #548 
