### PR TITLE
fix(table): fixed a bug where the table sort icon rotation could get out sync

### DIFF
--- a/src/lib/table/table-foundation.ts
+++ b/src/lib/table/table-foundation.ts
@@ -1160,7 +1160,16 @@ export class TableFoundation implements ITableFoundation {
 
   private _refreshTableSort(): void {
     this._sortedColumnIndex = this._visibleColumnConfigurations.findIndex(c => c.initialSort);
-    this._sortDirection = this._sortedColumnIndex >= 0 ? (this._visibleColumnConfigurations[this._sortedColumnIndex].sortDirection as SortDirection) : undefined;
+
+    // We only update the sort direction if it was not already set
+    if (this._sortDirection === undefined) {
+      const sortedColumn = this._visibleColumnConfigurations[this._sortedColumnIndex];
+      if (sortedColumn.initialSort === true && sortedColumn.sortDirection) {
+        this._sortDirection =  sortedColumn.sortDirection;
+      } else if (typeof sortedColumn.initialSort === 'object' && sortedColumn.initialSort.direction) {
+        this._sortDirection = sortedColumn.initialSort.direction;
+      }
+    }
 
     if (this._multiColumnSort) {
       const sortedColumns: ISortedItem[] = [];

--- a/src/lib/table/table-foundation.ts
+++ b/src/lib/table/table-foundation.ts
@@ -1162,7 +1162,7 @@ export class TableFoundation implements ITableFoundation {
     this._sortedColumnIndex = this._visibleColumnConfigurations.findIndex(c => c.initialSort);
 
     // We only update the sort direction if it was not already set
-    if (this._sortDirection === undefined) {
+    if (this._sortedColumnIndex >= 0 && this._sortDirection === undefined) {
       const sortedColumn = this._visibleColumnConfigurations[this._sortedColumnIndex];
       if (sortedColumn.initialSort === true && sortedColumn.sortDirection) {
         this._sortDirection =  sortedColumn.sortDirection;

--- a/src/stories/src/components/table/table.mdx
+++ b/src/stories/src/components/table/table.mdx
@@ -44,7 +44,7 @@ import { SomeCustomComponentDelegate } from './my-custom-component-delegates';
 
 table.columnConfigurations = [
   { property: 'name', header: 'Person name', filter: true, filterDelegate: new TextFieldComponentDelegate({ options: { placeholder: 'Filter name...' } }) },
-  { property: 'color', header: 'Favorite color', filter: true, filterDelegate: new SelectComponentDelegate({ options: { placeholder: 'Filter color...' } }) },
+  { property: 'color', header: 'Favorite color', filter: true, filterDelegate: new SelectComponentDelegate({ props: { placeholder: 'Filter color...' } }) },
   { property: 'age', header: 'Person age', filter: true, filterDelegate: new SomeCustomComponentDelegate() }
 ];
 ```


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Fixes #557 

## Describe the new behavior?
This was caused by the column configurations being reset and not respecting the current state of the sort direction, and instead resetting to the "initial sort" defined by the column configurations. The table will now only update the sort direction when it has not already been set.
