### PR TITLE
feat(list-item): add `deactivateRipple()` method to allow for manually removing the "pressed" ripple state if needed

### DIFF
--- a/src/lib/list/list-item/list-item-foundation.ts
+++ b/src/lib/list/list-item/list-item-foundation.ts
@@ -17,6 +17,7 @@ export interface IListItemFoundation extends ICustomElementFoundation {
   dense: boolean;
   wrap: boolean;
   setFocus(): void;
+  deactivateRipple(): void;
 }
 
 /**
@@ -83,6 +84,10 @@ export class ListItemFoundation implements IListItemFoundation {
       this._destroyUserInteractionListener();
       this._destroyUserInteractionListener = undefined;
     }
+  }
+
+  public deactivateRipple(): void {
+    this._rippleInstance?.deactivate();
   }
 
   private _onKeydown(evt: KeyboardEvent): void {

--- a/src/lib/list/list-item/list-item.ts
+++ b/src/lib/list/list-item/list-item.ts
@@ -25,6 +25,7 @@ export interface IListItemComponent extends IBaseComponent {
   indented: boolean;
   wrap: boolean;
   focus(): void;
+  deactivateRipple(): void;
 }
 
 declare global {
@@ -214,5 +215,9 @@ export class ListItemComponent extends BaseComponent implements IListItemCompone
   /** Sets focus to this list item. */
   public override focus(): void {
     this._foundation.setFocus();
+  }
+
+  public deactivateRipple(): void {
+    this._foundation.deactivateRipple();
   }
 }

--- a/src/stories/src/components/list/list.mdx
+++ b/src/stories/src/components/list/list.mdx
@@ -241,6 +241,12 @@ Gets/sets whether the list item content is wrapped or not.
 
 ## Methods
 
+<MethodDef name="deactivateRipple(): void">
+
+Forces the ripple state layter to deactivate.
+
+</MethodDef>
+
 <MethodDef name="focus(): void">
 
 Sets focus to this list item.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
A new method called `decativateRipple()` is now available on the `<forge-list-item>` elements. Developers can use this to manually remove the state layer on the ripple element.

## Additional information
This was added to help alleviate issues when using drag events to move elements around. The pressed state was activating on the ripple and sticking after the drag operation was completed.
