### PR TITLE
fix(select): fix missing `aria-controls` attribute to use temporary element

### DIFF
--- a/src/lib/select/option/option.ts
+++ b/src/lib/select/option/option.ts
@@ -47,12 +47,6 @@ export class OptionComponent extends BaseComponent implements IOptionComponent {
     this._foundation = new OptionFoundation(new OptionAdapter(this));
   }
 
-  public initializedCallback(): void {
-    if (!this.hasAttribute('role')) {
-      this.setAttribute('role', 'option');
-    }
-  }
-
   public attributeChangedCallback(name: string, oldValue: string, newValue: string): void {
     switch (name) {
       case OPTION_CONSTANTS.attributes.VALUE:

--- a/src/lib/select/select/select-adapter.ts
+++ b/src/lib/select/select/select-adapter.ts
@@ -1,4 +1,4 @@
-import { getShadowElement, toggleAttribute } from '@tylertech/forge-core';
+import { getShadowElement, randomChars, toggleAttribute } from '@tylertech/forge-core';
 import { ISelectComponent } from './select';
 import { SELECT_CONSTANTS } from './select-constants';
 import { IBaseSelectAdapter, BaseSelectAdapter } from '../core';
@@ -40,6 +40,7 @@ export class SelectAdapter extends BaseSelectAdapter<ISelectComponent> implement
     this._component.setAttribute('role', 'combobox');
     this._component.setAttribute('aria-haspopup', 'true');
     this._component.setAttribute('aria-expanded', 'false');
+    this.setAriaControls();
 
     if (this.fieldElement.required) {
       this.setHostAttribute('aria-required', 'true');
@@ -93,7 +94,7 @@ export class SelectAdapter extends BaseSelectAdapter<ISelectComponent> implement
   public close(): Promise<void> {
     this._component.setAttribute('aria-expanded', 'false');
     this._component.removeAttribute('aria-activedescendant');
-    this._component.removeAttribute('aria-controls');
+    this.setAriaControls();
     this._fieldElement.popoverExpanded = false;
     return super.close();
   }
@@ -129,5 +130,18 @@ export class SelectAdapter extends BaseSelectAdapter<ISelectComponent> implement
 
   public removeTargetListener(type: string, listener: (evt: Event) => void): void {
     this._component.removeEventListener(type, listener);
+  }
+
+  public setAriaControls(): void {
+    let placeholderDiv = this._component.querySelector('[data-forge-aria-controls-placeholder]');
+    if (placeholderDiv) {
+      this._component.setAttribute('aria-controls', placeholderDiv.id);
+      return;
+    }
+    placeholderDiv = document.createElement('div');
+    placeholderDiv.id = `forge-select-dropdown-temp-${randomChars(10)}`;
+    placeholderDiv.setAttribute('data-forge-aria-controls-placeholder', '');
+    this._component.setAttribute('aria-controls', placeholderDiv.id);
+    this._component.appendChild(placeholderDiv);
   }
 }


### PR DESCRIPTION
This is a temporary workaround to fix accessibility audits due to the dynamic nature of the dropdown in the current implementation.

A new select component is being designed for a future release that will take advantage of the new inline dropdown pattern which will properly take care of this issue and we can deprecate this legacy component at that time.