### PR TITLE
feat(base-button): remove internal `<a>` support and APIs and instead allow for slotted `<a>` elements and update each button-like element to support slotted anchor styling/functionality

### DIFF
--- a/src/dev/pages/button/button.ejs
+++ b/src/dev/pages/button/button.ejs
@@ -32,37 +32,37 @@
     <div class="vert">
       <forge-button>
         <a href="javascript: console.log('Anchor button clicked');">
-          Text button
+          Anchor button
           <forge-icon name="open_in_new"></forge-icon>
         </a>
       </forge-button>
       <forge-button variant="outlined">
         <a href="javascript: console.log('Anchor button clicked');">
-          Text button
+          Anchor button
           <forge-icon name="open_in_new"></forge-icon>
         </a>
       </forge-button>
       <forge-button variant="tonal">
         <a href="javascript: console.log('Anchor button clicked');">
-          Text button
+          Anchor button
           <forge-icon name="open_in_new"></forge-icon>
         </a>
       </forge-button>
       <forge-button variant="filled">
         <a href="javascript: console.log('Anchor button clicked');">
-          Text button
+          Anchor button
           <forge-icon name="open_in_new"></forge-icon>
         </a>
       </forge-button>
       <forge-button variant="raised">
         <a href="javascript: console.log('Anchor button clicked');">
-          Text button
+          Anchor button
           <forge-icon name="open_in_new"></forge-icon>
         </a>
       </forge-button>
       <forge-button variant="link">
         <a href="javascript: console.log('Anchor button clicked');">
-          Text button
+          Anchor button
           <forge-icon name="open_in_new"></forge-icon>
         </a>
       </forge-button>

--- a/src/dev/pages/button/button.ejs
+++ b/src/dev/pages/button/button.ejs
@@ -29,10 +29,44 @@
 
   <section>
     <h3 class="forge-typography--heading2">Anchor</h3>
-    <forge-button variant="outlined" href="javascript: alert('Anchor link button works!');">
-      w/Anchor link
-      <forge-icon slot="end" name="open_in_new"></forge-icon>
-    </forge-button>
+    <div class="vert">
+      <forge-button>
+        <a href="javascript: console.log('Anchor button clicked');">
+          Text button
+          <forge-icon name="open_in_new"></forge-icon>
+        </a>
+      </forge-button>
+      <forge-button variant="outlined">
+        <a href="javascript: console.log('Anchor button clicked');">
+          Text button
+          <forge-icon name="open_in_new"></forge-icon>
+        </a>
+      </forge-button>
+      <forge-button variant="tonal">
+        <a href="javascript: console.log('Anchor button clicked');">
+          Text button
+          <forge-icon name="open_in_new"></forge-icon>
+        </a>
+      </forge-button>
+      <forge-button variant="filled">
+        <a href="javascript: console.log('Anchor button clicked');">
+          Text button
+          <forge-icon name="open_in_new"></forge-icon>
+        </a>
+      </forge-button>
+      <forge-button variant="raised">
+        <a href="javascript: console.log('Anchor button clicked');">
+          Text button
+          <forge-icon name="open_in_new"></forge-icon>
+        </a>
+      </forge-button>
+      <forge-button variant="link">
+        <a href="javascript: console.log('Anchor button clicked');">
+          Text button
+          <forge-icon name="open_in_new"></forge-icon>
+        </a>
+      </forge-button>
+    </div>
   </section>
 
   <section>

--- a/src/dev/pages/button/button.html
+++ b/src/dev/pages/button/button.html
@@ -7,11 +7,9 @@ include('./src/partials/page.ejs', {
       { type: 'switch', label: 'Disabled', id: 'opt-disabled' },
       { type: 'switch', label: 'Dense', id: 'opt-dense' },
       { type: 'switch', label: 'Pill', id: 'opt-pill' },
-      { type: 'switch', label: 'Anchor', id: 'opt-anchor' },
       { type: 'switch', label: 'Full width', id: 'opt-full-width' },
       { type: 'switch', label: 'Popover icon', id: 'opt-popover-icon' },
       { type: 'switch', label: 'Form prevent default', id: 'opt-form-prevent' },
-      { type: 'switch', label: 'Anchor prevent default', id: 'opt-href-prevent' },
       {
         type: 'select',
         label: 'Theme',

--- a/src/dev/pages/button/button.ts
+++ b/src/dev/pages/button/button.ts
@@ -14,7 +14,6 @@ import './button.scss';
 IconRegistry.define([tylIconForgeLogo, tylIconFavorite, tylIconOpenInNew]);
 
 const formPreventToggle = document.querySelector('#opt-form-prevent') as ISwitchComponent;
-const hrefPreventToggle = document.querySelector('#opt-href-prevent') as ISwitchComponent;
 
 const submitBtn = document.querySelector('#submit-btn') as HTMLButtonElement;
 submitBtn.addEventListener('click', evt => {
@@ -35,14 +34,6 @@ resetBtn.addEventListener('click', evt => {
 const testForm = document.querySelector('#test-btn-form') as HTMLFormElement;
 testForm.addEventListener('submit', evt => {
   console.log('Form submitted!', evt.submitter);
-});
-
-const hrefBtn = document.querySelector('forge-button[href]') as HTMLAnchorElement;
-hrefBtn.addEventListener('click', evt => {
-  if (hrefPreventToggle.on) {
-    evt.preventDefault();
-  }
-  console.log('href button click', evt);
 });
 
 const popoverBtn = document.querySelector('#popover-button') as HTMLButtonElement;
@@ -78,11 +69,6 @@ denseToggle.addEventListener('forge-switch-change', ({ detail: selected }) => {
 const pillToggle = document.querySelector('#opt-pill') as ISwitchComponent;
 pillToggle.addEventListener('forge-switch-change', ({ detail: selected }) => {
   allButtons.forEach(btn => btn.pill = selected);
-});
-
-const anchorToggle = document.querySelector('#opt-anchor') as ISwitchComponent;
-anchorToggle.addEventListener('forge-switch-change', ({ detail: selected }) => {
-  allButtons.filter(b => !b.href).forEach(btn => btn.anchor = selected);
 });
 
 const fullWidthToggle = document.querySelector('#opt-full-width') as ISwitchComponent;

--- a/src/dev/pages/fab/fab.ejs
+++ b/src/dev/pages/fab/fab.ejs
@@ -18,8 +18,10 @@
       <forge-icon slot="end" name="add"></forge-icon>
     </forge-fab>
 
-    <forge-fab href="javascript: alert('FAB with anchor link!')" aria-label="Test FAB with anchor link">
-      <forge-icon name="open_in_new"></forge-icon>
+    <forge-fab>
+      <a href="javascript: alert('FAB with anchor link!')" aria-label="Test FAB with anchor link">
+        <forge-icon name="open_in_new"></forge-icon>
+      </a>
     </forge-fab>
   </div>
 </div>

--- a/src/dev/pages/icon-button/icon-button.ejs
+++ b/src/dev/pages/icon-button/icon-button.ejs
@@ -56,8 +56,10 @@
 
   <section>
     <h3 class="forge-typography--heading2">w/Anchor link</h3>
-    <forge-icon-button href="javascript: alert('Anchor link icon button works!');" aria-label="Anchor link icon button">
-      <forge-icon name="open_in_new"></forge-icon>
+    <forge-icon-button>
+      <a href="javascript: alert('Anchor link icon button works!');" aria-label="Anchor link icon button">
+        <forge-icon name="open_in_new"></forge-icon>
+      </a>
     </forge-icon-button>
   </section>
 

--- a/src/dev/pages/typography/typography.ejs
+++ b/src/dev/pages/typography/typography.ejs
@@ -2,7 +2,7 @@
   <div class="forge-typography--heading2">Heading</div>
   <div class="forge-typography--subheading1">Subheading</div>
   <p>
-    Lorem ipsum dolor sit amet <a href="javascript: alert('Automatic link styling!')">consectetur</a> adipisicing elit. Odio vero dolore aspernatur veritatis cupiditate accusantium totam odit nihil officiis perspiciatis molestiae, cum sed ad quae dolorum. Veritatis omnis nobis repellat?
+    Lorem ipsum dolor sit amet <a class="forge-anchor" href="javascript: alert('Automatic link styling!')">consectetur</a> adipisicing elit. Odio vero dolore aspernatur veritatis cupiditate accusantium totam odit nihil officiis perspiciatis molestiae, cum sed ad quae dolorum. Veritatis omnis nobis repellat?
   </p>
 </div>
 

--- a/src/dev/src/components.json
+++ b/src/dev/src/components.json
@@ -24,7 +24,7 @@
   { "label": "Expansion panel", "path": "/pages/expansion-panel/expansion-panel.html" },
   { "label": "Field", "path": "/pages/field/field.html", "tags": ["form"] },
   { "label": "File picker", "path": "/pages/file-picker/file-picker.html", "tags": ["form"] },
-  { "label": "Floating action button", "path": "/pages/fab/fab.html" },
+  { "label": "Floating action button", "path": "/pages/fab/fab.html", "tags": ["fab"] },
   { "label": "Focus indicator", "path": "/pages/focus-indicator/focus-indicator.html" },
   { "label": "Icon", "path": "/pages/icon/icon.html" },
   { "label": "Icon button", "path": "/pages/icon-button/icon-button.html" },

--- a/src/lib/button/_core.scss
+++ b/src/lib/button/_core.scss
@@ -75,11 +75,18 @@
 @mixin anchor-base {
   position: absolute;
   inset: 0;
-  text-decoration: none;
-}
 
-@mixin text {
-  @include override(focus-indicator-offset, text-focus-indicator-offset);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: #{token(spacing)};
+
+  color: #{token(color)};
+
+  outline: none;
+  border-radius: #{token(shape)};
+
+  text-decoration: none !important; // Forge provides default styles for <a> elements so we need to override it
 }
 
 @mixin filled {

--- a/src/lib/button/_core.scss
+++ b/src/lib/button/_core.scss
@@ -86,7 +86,7 @@
   outline: none;
   border-radius: #{token(shape)};
 
-  text-decoration: none !important; // Forge provides default styles for <a> elements so we need to override it
+  text-decoration: none;
 }
 
 @mixin filled {

--- a/src/lib/button/base/base-button-constants.ts
+++ b/src/lib/button/base/base-button-constants.ts
@@ -2,11 +2,6 @@ const observedAttributes = {
   TYPE: 'type',
   DISABLED: 'disabled',
   POPOVER_ICON: 'popover-icon',
-  ANCHOR: 'anchor',
-  HREF: 'href',
-  TARGET: 'target',
-  DOWNLOAD: 'download',
-  REL: 'rel',
   DENSE: 'dense',
   TABINDEX: 'tabindex'
 } as const;
@@ -17,11 +12,13 @@ const attributes = {
 
 const classes = {
   ROOT: 'forge-button',
-  POPOVER_ICON: 'forge-button__popover-icon'
+  POPOVER_ICON: 'forge-button__popover-icon',
+  WITH_ANCHOR: 'with-anchor'
 } as const;
 
 const selectors = {
   ROOT:'[part=root]',
+  DEFAULT_SLOT: 'slot:not([name])',
   END_SLOT: 'slot[name=end]'
 } as const;
 

--- a/src/lib/button/base/base-button-foundation.ts
+++ b/src/lib/button/base/base-button-foundation.ts
@@ -8,11 +8,6 @@ export interface IBaseButtonFoundation extends ICustomElementFoundation {
   type: ButtonType;
   disabled: boolean;
   popoverIcon: boolean;
-  anchor: boolean;
-  href: string;
-  target: string;
-  download: string;
-  rel: string;
   dense: boolean;
   click(options: ButtonClickOptions): void;
   focus(options?: ExperimentalFocusOptions): void;
@@ -22,36 +17,17 @@ export abstract class BaseButtonFoundation<T extends IBaseButtonAdapter> impleme
   private _type: ButtonType = 'button'; // We default our buttons to the "button" type instead of "submit" as that is more common
   private _disabled = false;
   private _popoverIcon = false;
-  private _anchor = false;
-  private _href = '';
-  private _target = '';
-  private _download = '';
-  private _rel = '';
   private _dense = false;
 
-  private _clickListener: EventListener;
-  private _keydownListener: EventListener;
-  private _anchorFocusListener: EventListener;
+  private _clickListener: EventListener = this._onClick.bind(this);
+  private _keydownListener: EventListener = this._onKeydown.bind(this);
+  private _slotChangeListener: EventListener = () => this._detectSlottedAnchor();
 
-  constructor(protected _adapter: T) {
-    this._clickListener = (evt: MouseEvent) => this._onClick(evt);
-    this._keydownListener = (evt: KeyboardEvent) => this._onKeydown(evt);
-    this._anchorFocusListener = () => this._adapter.focusHost(); // Always ensure our host is focused when the anchor is focused
-    this._adapter.addHostListener('keydown', this._keydownListener);
-  }
-
+  constructor(protected _adapter: T) {}
+  
   public initialize(): void {
-    this._adapter.initialize();
-
-    if (this._anchor) {
-      // When we're in anchor mode, we swap to us an `<a>` internally as the root. Since the `<a>`
-      // element is interactive by default, we can remove our click listener since the anchor will
-      // take over the default interaction handling
-      this._adapter.addAnchorEventListener('focus', this._anchorFocusListener);
-    } else {
-      // When we're in button mode, we need to handle the click event on the host element
-      this._adapter.addHostListener('click', this._clickListener);
-    }
+    this._detectSlottedAnchor();
+    this._adapter.addDefaultSlotChangeListener(this._slotChangeListener);
   }
 
   /**
@@ -62,11 +38,7 @@ export abstract class BaseButtonFoundation<T extends IBaseButtonAdapter> impleme
       return;
     }
 
-    if (this._anchor) {
-      this._adapter.clickAnchor();
-    } else {
-      this._adapter.clickHost();
-    }
+    this._adapter.clickHost();
 
     if (animateStateLayer) {
       this._adapter.animateStateLayer();
@@ -116,9 +88,8 @@ export abstract class BaseButtonFoundation<T extends IBaseButtonAdapter> impleme
    * Handle keydown events on the host element to manually trigger click events.
    */
   private async _onKeydown(evt: KeyboardEvent): Promise<void> {
-    // Handle the special case for the space key (when not an anchor) to avoid
-    // scrolling when triggered
-    if (evt.key === ' ' && !this._anchor) {
+    // Handle the special case for the space key to avoid scrolling when triggered
+    if (evt.key === ' ') {
       evt.preventDefault();
       this.click();
       return;
@@ -132,33 +103,20 @@ export abstract class BaseButtonFoundation<T extends IBaseButtonAdapter> impleme
     }
     
     if (evt.key === 'Enter') {
-      if (this._anchor) {
-        this._adapter.clickAnchor();
-      } else {
-        this.click();
-      }
+      this.click();
     }
   }
 
-  private _toggleAnchor(): void {
-    if (this._anchor) {
-      this._adapter.initializeAnchor();
-      this._manageAnchorListeners();
-      this.disabled = false; // Anchor elements are always enabled
-    } else {
-      this._adapter.removeAnchor();
-      this._manageAnchorListeners();
-    }
-  }
-
-  private _manageAnchorListeners(): void {
-    if (this._anchor) {
+  private _detectSlottedAnchor(): void {
+    if (this._adapter.hasSlottedAnchor) {
+      this.disabled = false;
       this._adapter.removeHostListener('click', this._clickListener);
-      this._adapter.addAnchorEventListener('focus', this._anchorFocusListener);
+      this._adapter.removeHostListener('keydown', this._keydownListener);
     } else {
       this._adapter.addHostListener('click', this._clickListener);
-      this._adapter.removeAnchorEventListener('focus', this._anchorFocusListener);
+      this._adapter.addHostListener('keydown', this._keydownListener);
     }
+    this._adapter.initialize();
   }
 
   public get type(): ButtonType {
@@ -181,8 +139,7 @@ export abstract class BaseButtonFoundation<T extends IBaseButtonAdapter> impleme
       return;
     }
 
-    // When we're in anchor mode we need to ensure that the anchor is always enabled
-    if (this._anchor) {
+    if (this._adapter.hasSlottedAnchor) {
       value = false;
     }
 
@@ -200,70 +157,6 @@ export abstract class BaseButtonFoundation<T extends IBaseButtonAdapter> impleme
       this._popoverIcon = value;
       this._adapter.toggleDefaultPopoverIcon(this._popoverIcon);
       this._adapter.toggleHostAttribute(BASE_BUTTON_CONSTANTS.attributes.POPOVER_ICON, value);
-    }
-  }
-
-  /**
-   * Anchor properties
-   */
-
-  public get anchor(): boolean {
-    return this._anchor;
-  }
-  public set anchor(value: boolean) {
-    value = Boolean(value);
-    if (this._anchor !== value) {
-      this._anchor = value;
-      this._toggleAnchor();
-      this._adapter.toggleHostAttribute(BASE_BUTTON_CONSTANTS.attributes.ANCHOR, value);
-    }
-  }
-
-  public get href(): string {
-    return this._href;
-  }
-  public set href(value: string) {
-    value = (value ?? '').trim();
-    if (this._href !== value) {
-      this._href = value;
-      this.anchor = this._href.length > 0;
-      if (this._anchor) {
-        this._adapter.setAnchorProperty('href', this._href);
-      }
-      this._adapter.toggleHostAttribute(BASE_BUTTON_CONSTANTS.attributes.HREF, !!this._href, this._href);
-    }
-  }
-
-  public get target(): string {
-    return this._target;
-  }
-  public set target(value: string) {
-    if (this._target !== value) {
-      this._target = value ?? '_self';
-      this._adapter.setAnchorProperty('target', value);
-      this._adapter.toggleHostAttribute(BASE_BUTTON_CONSTANTS.attributes.TARGET, !!this._target, this._target);
-    }
-  }
-
-  public get download(): string {
-    return this._download;
-  }
-  public set download(value: string) {
-    if (this._download !== value) {
-      this._download = value;
-      this._adapter.setAnchorProperty('download', this._download);
-      this._adapter.toggleHostAttribute(BASE_BUTTON_CONSTANTS.attributes.DOWNLOAD, !!this._download, this._download);
-    }
-  }
-
-  public get rel(): string {
-    return this._rel;
-  }
-  public set rel(value: string) {
-    if (this._rel !== value) {
-      this._rel = value;
-      this._adapter.setAnchorProperty('rel', this._rel);
-      this._adapter.toggleHostAttribute(BASE_BUTTON_CONSTANTS.attributes.REL, !!this._rel, this._rel);
     }
   }
 

--- a/src/lib/button/base/base-button.ts
+++ b/src/lib/button/base/base-button.ts
@@ -1,7 +1,6 @@
 import { coerceBoolean, FoundationProperty } from '@tylertech/forge-core';
 import { tylIconArrowDropDown } from '@tylertech/tyler-icons/standard';
 import { IconRegistry } from '../../icon/icon-registry';
-import { WithFocusable, IWithFocusable } from '../../core/mixins/focus/with-focusable';
 import { BaseComponent } from '../../core/base/base-component';
 import { ExperimentalFocusOptions, internals, setDefaultAria } from '../../constants';
 import { IBaseButtonAdapter } from './base-button-adapter';
@@ -11,23 +10,18 @@ import { WithLabelAwareness, IWithLabelAwareness } from '../../core/mixins/label
 import { IWithElementInternals, WithElementInternals } from '../../core/mixins/internals/with-element-internals';
 import { IWithDefaultAria, WithDefaultAria } from '../../core/mixins/internals/with-default-aria';
 
-export interface IBaseButton extends IWithFocusable, IWithLabelAwareness, IWithElementInternals, IWithDefaultAria {
+export interface IBaseButton extends IWithLabelAwareness, IWithElementInternals, IWithDefaultAria {
   type: ButtonType;
   disabled: boolean;
   popoverIcon: boolean;
   name: string;
   value: string;
   dense: boolean;
-  anchor: boolean;
-  href: string;
-  target: string;
-  download: string;
-  rel: string;
   form: HTMLFormElement | null;
   focus(options?: ExperimentalFocusOptions): void;
 }
 
-export abstract class BaseButton<T extends BaseButtonFoundation<IBaseButtonAdapter>> extends WithDefaultAria(WithElementInternals(WithLabelAwareness(WithFocusable(BaseComponent)))) implements IBaseButton {
+export abstract class BaseButton<T extends BaseButtonFoundation<IBaseButtonAdapter>> extends WithDefaultAria(WithElementInternals(WithLabelAwareness(BaseComponent))) implements IBaseButton {
   public static get observedAttributes(): string[] {
     return Object.values(BASE_BUTTON_CONSTANTS.observedAttributes);
   }
@@ -41,12 +35,11 @@ export abstract class BaseButton<T extends BaseButtonFoundation<IBaseButtonAdapt
     IconRegistry.define(tylIconArrowDropDown);
   }
 
-  public override connectedCallback(): void {
-    super.connectedCallback();
+  public connectedCallback(): void {
     this._foundation.initialize();
   }
 
-  public override attributeChangedCallback(name: string, oldValue: string, newValue: string): void {
+  public attributeChangedCallback(name: string, oldValue: string, newValue: string): void {
     switch (name) {
       case BASE_BUTTON_CONSTANTS.observedAttributes.TYPE:
         this.type = newValue as ButtonType;
@@ -57,26 +50,10 @@ export abstract class BaseButton<T extends BaseButtonFoundation<IBaseButtonAdapt
       case BASE_BUTTON_CONSTANTS.observedAttributes.POPOVER_ICON:
         this.popoverIcon = coerceBoolean(newValue);
         return;
-      case BASE_BUTTON_CONSTANTS.observedAttributes.ANCHOR:
-        this.anchor = coerceBoolean(newValue);
-        return;
-      case BASE_BUTTON_CONSTANTS.observedAttributes.HREF:
-        this.href = newValue;
-        return;
-      case BASE_BUTTON_CONSTANTS.observedAttributes.TARGET:
-        this.target = newValue;
-        return;
-      case BASE_BUTTON_CONSTANTS.observedAttributes.DOWNLOAD:
-        this.download = newValue;
-        return;
-      case BASE_BUTTON_CONSTANTS.observedAttributes.REL:
-        this.rel = newValue;
-        return;
       case BASE_BUTTON_CONSTANTS.observedAttributes.DENSE:
         this.dense = coerceBoolean(newValue);
         return;
     }
-    super.attributeChangedCallback(name, oldValue, newValue);
   }
 
   public labelClickedCallback(): void {
@@ -113,21 +90,6 @@ export abstract class BaseButton<T extends BaseButtonFoundation<IBaseButtonAdapt
 
   @FoundationProperty()
   public declare popoverIcon: boolean;
-
-  @FoundationProperty()
-  public declare anchor: boolean;
-
-  @FoundationProperty()
-  public declare href: string;
-
-  @FoundationProperty()
-  public declare target: string;
-
-  @FoundationProperty()
-  public declare download: string;
-
-  @FoundationProperty()
-  public declare rel: string;
 
   @FoundationProperty()
   public declare dense: boolean;

--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -3,6 +3,7 @@
 @use '../state-layer';
 @use '../focus-indicator';
 @use '../circular-progress';
+@use '../icon';
 
 //
 // Host
@@ -38,13 +39,38 @@ $host-tokens: [display disabled-cursor];
   }
 }
 
-a {
+//
+// Anchor
+//
+
+::slotted(a) {
   @include anchor-base;
+
+  @include icon.provide-theme((
+    font-size: #{token(icon-size)}
+  ))
 }
 
-forge-state-layer {
-  @include state-layer.provide-theme(( color: #{token(color)} ));
+:host([variant=link]) {
+  ::slotted(a) {
+    position: relative;
+    inset: auto;
+  }
 }
+
+//
+// State layer
+//
+
+forge-state-layer {
+  @include state-layer.provide-theme((
+    color: #{token(color)}
+  ));
+}
+
+//
+// Focus indicator
+//
 
 forge-focus-indicator {
   @include focus-indicator.provide-theme((
@@ -89,19 +115,15 @@ forge-focus-indicator {
 // Variants
 //
 
-:host(:is(:not([variant], [variant=text]))) {
-  .forge-button {
-    @include text;
-  }
-}
-
 :host(:is([variant=filled],[variant=raised])) {
   .forge-button {
     @include filled;
   }
 
   forge-state-layer {
-    @include state-layer.provide-theme(( color: #{token(filled-color)} ));
+    @include state-layer.provide-theme((
+      color: #{token(filled-color)}
+    ));
   }
 }
 
@@ -117,7 +139,9 @@ forge-focus-indicator {
   }
 
   forge-state-layer {
-    @include state-layer.provide-theme(( color: #{token(tonal-color)} ));
+    @include state-layer.provide-theme((
+      color: #{token(tonal-color)}
+    ));
   }
 }
 
@@ -162,7 +186,9 @@ forge-focus-indicator {
   }
 
   forge-focus-indicator {
-    @include focus-indicator.provide-theme(( shape: #{token(pill-shape)} ));
+    @include focus-indicator.provide-theme((
+      shape: #{token(pill-shape)}
+    ));
   }
 }
 

--- a/src/lib/core/styles/typography/index.scss
+++ b/src/lib/core/styles/typography/index.scss
@@ -90,25 +90,51 @@
 /// Create a selector for default anchor link styles
 ///
 @mixin anchor {
+  .forge-anchor,
   .forge-hyperlink,
-  .forge-typography--link,
-  :not(forge-list-item) > a:not([forge-ignore]) {
-    text-decoration: var(--forge-typography-link-text-decoration, underline);
-    color: theme.variable(primary);
-    cursor: pointer;
+  .forge-typography--link {
+    @include anchor-base;
 
     &:visited {
-      color: theme.variable(primary);
+      @include anchor-visited;
     }
 
     &:hover {
-      text-decoration: none;
+      @include anchor-hover;
     }
 
     &:active {
-      opacity: theme.emphasis(high);
+      @include anchor-active;
+    }
+
+    &-plain {
+      @include anchor-plain;
     }
   }
+}
+
+@mixin anchor-base {
+  text-decoration: var(--forge-typography-link-text-decoration, underline);
+  color: theme.variable(primary);
+  cursor: pointer;
+}
+
+@mixin anchor-visited {
+  color: theme.variable(primary);
+}
+
+@mixin anchor-hover {
+  text-decoration: none;
+}
+
+@mixin anchor-active {
+  opacity: theme.emphasis(high);
+}
+
+@mixin anchor-plain {
+  text-decoration: none;
+  color: inherit;
+  outline: none;
 }
 
 ///

--- a/src/lib/deprecated/button/deprecated-button.scss
+++ b/src/lib/deprecated/button/deprecated-button.scss
@@ -50,12 +50,6 @@ forge-focus-indicator {
 // Types
 //
 
-:host(:is(:not([type],[type*=text]))) {
-  ::slotted(:is(button,a)) {
-    @include text;
-  }
-}
-
 :host(:is([type*=unelevated],[type*=raised])) {
   ::slotted(:is(button,a)) {
     @include filled;

--- a/src/lib/floating-action-button/_core.scss
+++ b/src/lib/floating-action-button/_core.scss
@@ -86,7 +86,7 @@
 
   color: #{token(color)};
 
-  text-decoration: none !important; // Forge provides default styles for <a> elements so we need to override it
+  text-decoration: none;
 }
 
 @mixin density-small {

--- a/src/lib/floating-action-button/_core.scss
+++ b/src/lib/floating-action-button/_core.scss
@@ -55,7 +55,8 @@
 }
 
 @mixin extended {
-  padding-inline: #{token(extended-padding)};
+  @include override(padding, extended-padding);
+  
   min-width: #{token(extended-min-width)};
 }
 
@@ -72,9 +73,20 @@
 }
 
 @mixin anchor-base {
-  position: absolute;
-  inset: 0;
-  text-decoration: none;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  border-radius: #{token(shape)};
+  padding-inline: #{token(padding)};
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: #{token(gap)};
+
+  color: #{token(color)};
+
+  text-decoration: none !important; // Forge provides default styles for <a> elements so we need to override it
 }
 
 @mixin density-small {

--- a/src/lib/floating-action-button/floating-action-button.scss
+++ b/src/lib/floating-action-button/floating-action-button.scss
@@ -37,7 +37,15 @@ $host-tokens: [display disabled-cursor];
   }
 }
 
-a {
+//
+// Anchor
+//
+
+.with-anchor {
+  padding-inline: 0;
+}
+
+::slotted(a) {
   @include anchor-base;
 }
 

--- a/src/lib/icon-button/_core.scss
+++ b/src/lib/icon-button/_core.scss
@@ -61,7 +61,7 @@
 
   color: #{token(icon-color)};
 
-  text-decoration: none !important; // Forge provides default styles for <a> elements so we need to override it
+  text-decoration: none;
 }
 
 @mixin host-disabled {

--- a/src/lib/icon-button/_core.scss
+++ b/src/lib/icon-button/_core.scss
@@ -48,9 +48,20 @@
 }
 
 @mixin anchor-base {
-  position: absolute;
-  inset: 0;
-  text-decoration: none;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  border-radius: #{token(shape)};
+  padding-inline: #{token(padding)};
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: #{token(gap)};
+
+  color: #{token(icon-color)};
+
+  text-decoration: none !important; // Forge provides default styles for <a> elements so we need to override it
 }
 
 @mixin host-disabled {

--- a/src/lib/icon-button/icon-button.scss
+++ b/src/lib/icon-button/icon-button.scss
@@ -39,7 +39,11 @@ $host-tokens: [display disabled-cursor];
   }
 }
 
-a {
+//
+// Anchor
+//
+
+::slotted(a) {
   @include anchor-base;
 }
 

--- a/src/lib/state-layer/state-layer-foundation.ts
+++ b/src/lib/state-layer/state-layer-foundation.ts
@@ -262,6 +262,7 @@ export class StateLayerFoundation implements IStateLayerFoundation {
     }
 
     this._adapter.setTargetElement(el);
+    this._adapter.addTargetListener('click', this._clickListener);
 
     // If we are not already deferring attaching the listeners, then do that now
     if (!this._deferred) {
@@ -286,6 +287,7 @@ export class StateLayerFoundation implements IStateLayerFoundation {
         }
 
         this._adapter.trySetTarget(value);
+        this._adapter.addTargetListener('click', this._clickListener);
 
         if (!this._deferred) {
           this._deferInitialization();


### PR DESCRIPTION
- Removes anchor-related APIs from the base button functionality such as `href`, `target`, `rel`, `download`, and `anchor` properties.
- Updates base button logic to instead detect slotted `<a>` elements
- Slotted `<a>` do **not** work work with start/end slots, the `<a>` must be the only child, and the button will apply a flex layout to the slotted `<a>`
- Update semantics and interactions when slotting anchors
- Removed globally applied `<a>` styles in favor of opt-in classes