### PR TITLE
fix(app-bar-notification-button): fixed a bug where the badge count could not be unset and updated the logic to not render the count

### DIFF
--- a/src/lib/app-bar/notification-button/app-bar-notification-button-adapter.ts
+++ b/src/lib/app-bar/notification-button/app-bar-notification-button-adapter.ts
@@ -7,7 +7,7 @@ import { ICON_CONSTANTS, IIconComponent } from '../../icon';
 export interface IAppBarNotificationButtonAdapter extends IBaseAdapter {
   initialize(): void;
   setIcon(icon: string): void;
-  setCount(value: number): void;
+  setCount(value: string | number | null | undefined): void;
   setBadgeType(dot: boolean): void;
   setBadgeTheme(theme: string): void;
   setBadgeVisible(isVisible: boolean): void;
@@ -30,8 +30,8 @@ export class AppBarNotificationButtonAdapter extends BaseAdapter<IAppBarNotifica
     this._iconElement = getLightElement(this._component, ICON_CONSTANTS.elementName) as IIconComponent;
   }
 
-  public setCount(value: number): void {
-    this._badgeElement.textContent = value as any;
+  public setCount(value: string | number | undefined | null): void {
+    this._badgeElement.textContent = value != null ? String(value) : '';
   }
 
   public setBadgeType(dot: boolean): void {

--- a/src/lib/app-bar/notification-button/app-bar-notification-button-foundation.ts
+++ b/src/lib/app-bar/notification-button/app-bar-notification-button-foundation.ts
@@ -3,7 +3,7 @@ import { IAppBarNotificationButtonAdapter } from './app-bar-notification-button-
 import { APP_BAR_NOTIFICATION_BUTTON_CONSTANTS } from './app-bar-notification-button-constants';
 
 export interface IAppBarNotificationButtonFoundation extends ICustomElementFoundation {
-  count: number;
+  count: string | number | null | undefined;
   dot: boolean;
   theme: string;
   showBadge: boolean;
@@ -11,7 +11,7 @@ export interface IAppBarNotificationButtonFoundation extends ICustomElementFound
 }
 
 export class AppBarNotificationButtonFoundation implements IAppBarNotificationButtonFoundation {
-  private _count = 0;
+  private _count: string | number | null | undefined = 0;
   private _dot = false;
   private _theme: string;
   private _showBadge = false;
@@ -47,15 +47,17 @@ export class AppBarNotificationButtonFoundation implements IAppBarNotificationBu
     }
   }
 
-  public get count(): number {
+  public get count(): string | number | null | undefined {
     return this._count;
   }
-  public set count(value: number) {
+  public set count(value: string | number | null | undefined) {
     if (this._count !== value) {
       this._count = value;
       if (this._isInitialized) {
-        this._adapter.setCount(this._count);
-        this._adapter.setHostAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.COUNT, this._count as any);
+        if (!this._dot) {
+          this._adapter.setCount(this._count);
+        }
+        this._adapter.toggleHostAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.COUNT, this._count != null, String(this._count));
       }
     }
   }
@@ -69,10 +71,11 @@ export class AppBarNotificationButtonFoundation implements IAppBarNotificationBu
       if (this._isInitialized) {
         this._adapter.setBadgeType(this._dot);
         if (this._dot) {
-          this._adapter.setHostAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.DOT);
+          this._adapter.setCount(null);
         } else {
-          this._adapter.removeHostAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.DOT);
+          this._adapter.setCount(this._count);
         }
+        this._adapter.toggleHostAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.DOT, this._dot);
       }
     }
   }

--- a/src/lib/app-bar/notification-button/app-bar-notification-button-foundation.ts
+++ b/src/lib/app-bar/notification-button/app-bar-notification-button-foundation.ts
@@ -57,7 +57,12 @@ export class AppBarNotificationButtonFoundation implements IAppBarNotificationBu
         if (!this._dot) {
           this._adapter.setCount(this._count);
         }
-        this._adapter.toggleHostAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.COUNT, this._count != null, String(this._count));
+
+        if (typeof this._count === 'string') {
+          this._adapter.setHostAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.COUNT, this._count);
+        } else if (value == null) {
+          this._adapter.removeHostAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.COUNT);
+        }
       }
     }
   }

--- a/src/lib/app-bar/notification-button/app-bar-notification-button.ts
+++ b/src/lib/app-bar/notification-button/app-bar-notification-button.ts
@@ -18,7 +18,7 @@ declare global {
 }
 
 export interface IAppBarNotificationButtonComponent extends IBaseComponent {
-  count: number;
+  count: string | number | null | undefined;
   dot: boolean;
   showBadge: boolean;
   theme: string;
@@ -68,7 +68,7 @@ export class AppBarNotificationButtonComponent extends BaseComponent implements 
   public attributeChangedCallback(name: string, oldValue: string, newValue: string): void {
     switch (name) {
       case APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.COUNT:
-        this.count = coerceNumber(newValue);
+        this.count = newValue;
         break;
       case APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.DOT:
         this.dot = coerceBoolean(newValue);
@@ -86,7 +86,7 @@ export class AppBarNotificationButtonComponent extends BaseComponent implements 
   }
 
   @FoundationProperty()
-  public declare count: number;
+  public declare count: string | number | null | undefined;
 
   @FoundationProperty()
   public declare dot: boolean;

--- a/src/stories/src/components/app-bar-notifications/app-bar-notifications.mdx
+++ b/src/stories/src/components/app-bar-notifications/app-bar-notifications.mdx
@@ -37,7 +37,7 @@ The notification button provides a consistent icon, as well as options to contro
 
 ## Properties/Attributes
 
-<PropertyDef name="count" type="number" defaultValue="0">
+<PropertyDef name="count" type="string | number | null | undefined" defaultValue="0">
 
   Gets/sets the count value of the notification button.
 

--- a/src/test/spec/app-bar/notification-button/app-bar-notification-button.spec.ts
+++ b/src/test/spec/app-bar/notification-button/app-bar-notification-button.spec.ts
@@ -22,39 +22,39 @@ describe('AppBarNotificationButtonComponent', function(this: ITestContext) {
   describe('Badge count', function(this: ITestContext) {
     it('should sync property and attribute count when count property is set', function(this: ITestContext) {
       this.context = setupTestContext();
-      const count = 5;
+      const count = '5';
       this.context.component.count = count;
       expect(this.context.component.count).toBe(count, `Component count property should be set to: ${count}`);
       const attrValue = this.context.component.getAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.COUNT);
       expect(attrValue).not.toBeNull('Component count attribute cannot be null');
-      expect(attrValue ? +attrValue : -1).toBe(count, `Component count attribute should be : ${count}`);
+      expect(attrValue).toBe(count, `Component count attribute should be : ${count}`);
     });
 
     it('should sync property and attribute count when count attribute is set', function(this: ITestContext) {
       this.context = setupTestContext();
-      const count = 5;
+      const count = '5';
       this.context.component.setAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.COUNT, String(count));
       expect(this.context.component.count).toBe(count, `Component count property should be set to: ${count}`);
       const attrValue = this.context.component.getAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.COUNT);
       expect(attrValue).not.toBeNull('Component count attribute cannot be null');
-      expect(attrValue ? +attrValue : -1).toBe(count, `Component count attribute should be : ${count}`);
+      expect(attrValue).toBe(count, `Component count attribute should be : ${count}`);
     });
 
     it('should sync property and attribute count when count property is set and then count attribute is set', function(this: ITestContext) {
       this.context = setupTestContext();
-      let count = 5;
+      let count = '5';
       this.context.component.count = count;
       expect(this.context.component.count).toBe(count, `Component count property should be set to: ${count}`);
       let attrValue = this.context.component.getAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.COUNT);
       expect(attrValue).not.toBeNull('Component count attribute cannot be null');
-      expect(attrValue ? +attrValue : -1).toBe(count, `Component count attribute should be : ${count}`);
+      expect(attrValue).toBe(count, `Component count attribute should be : ${count}`);
 
-      count = 0;
+      count = '0';
       this.context.component.setAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.COUNT, String(count));
       expect(this.context.component.count).toBe(count, `Component count property should be set to: ${count}`);
       attrValue = this.context.component.getAttribute(APP_BAR_NOTIFICATION_BUTTON_CONSTANTS.attributes.COUNT);
       expect(attrValue).not.toBeNull('Component count attribute cannot be null');
-      expect(attrValue ? +attrValue : -1).toBe(count, `Component count attribute should be : ${count}`);
+      expect(attrValue).toBe(count, `Component count attribute should be : ${count}`);
     });
 
     it('should not show badge if count property is set', function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Updated the `count` property to accept more types and properly allow for disabling the count text.
