### PR TITLE
fix(menu): fixed a bug where pressing the tab key would select the active option

### DIFF
--- a/src/lib/menu/menu-foundation.ts
+++ b/src/lib/menu/menu-foundation.ts
@@ -173,11 +173,6 @@ export class MenuFoundation extends CascadingListDropdownAwareFoundation<IMenuOp
     }
 
     switch (evt.code) {
-      case 'Tab':
-        if (this._open) {
-          this._selectActiveOption();
-        }
-        break;
       case 'Escape':
         if (this._open) {
           evt.preventDefault();

--- a/src/stories/src/components/menu/menu.mdx
+++ b/src/stories/src/components/menu/menu.mdx
@@ -155,7 +155,6 @@ Sets the first option in the menu to be active.
 | Name                                | Description
 | :-----------------------------------| :----------------
 | **Menu open**                       |
-| `tab`                               | Selects the focued menu item.
 | `space / escape`                    | Closes the menu.
 | `enter / arrow right`               | Opens and closes child menu of the focused menu item.
 | `arrow left`                        | **Mode is Cascade:** Closes the menu.

--- a/src/test/spec/menu/menu.spec.ts
+++ b/src/test/spec/menu/menu.spec.ts
@@ -542,7 +542,7 @@ describe('MenuComponent', function(this: ITestContext) {
         expect(this.context.component.open).toBeFalse();
       });
 
-      it('should select active item when tab key is pressed while dropdown is open', async function(this: ITestContext) {
+      it('should not select active item when tab key is pressed while dropdown is open', async function(this: ITestContext) {
         this.context = setupTestContext();
         const options = generateMenuOptions(7);
         this.context.component.options = options;
@@ -559,7 +559,7 @@ describe('MenuComponent', function(this: ITestContext) {
         toggleElement.dispatchEvent(new KeyboardEvent('keydown', { code: 'Tab' }));
         await tick();
 
-        expect(selectSpy).toHaveBeenCalledOnceWith(jasmine.objectContaining({ detail: { index: 0, value: options[0].value }}));
+        expect(selectSpy).not.toHaveBeenCalled();
       });
 
       it('should highlight first option when opened via down arrow key', async function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Pressing the `Tab` key while the menu is open will no longer select the active option.
