### PR TITLE
feat(popover): enable `autofocus` attribute when triggered via either keyboard or pointer

### DIFF
--- a/src/lib/popover/popover-adapter.ts
+++ b/src/lib/popover/popover-adapter.ts
@@ -124,12 +124,24 @@ export class PopoverAdapter extends OverlayAwareAdapter<IPopoverComponent> imple
   }
 
   public tryAutofocus(): void {
+    const tryFocus = (): boolean => {
+      if (this._component.open && this._overlayElement.isConnected && !this._component.matches(':focus-within')) {
+        const autofocusElement = this._component.querySelector<HTMLElement>('[autofocus]');
+        if (autofocusElement) {
+          autofocusElement.focus();
+          return true;
+        }
+      }
+      return false;
+    };
+
+    if (tryFocus()) {
+      return;
+    }
+
     window.requestAnimationFrame(() => {
       window.requestAnimationFrame(() => {
-        if (this._component.open && this._overlayElement.isConnected && !this._component.matches(':focus-within')) {
-          const autofocusElement = this._component.querySelector<HTMLElement>('[autofocus]');
-          autofocusElement?.focus();
-        }
+        tryFocus();
       });
     });
   }

--- a/src/lib/popover/popover-foundation.ts
+++ b/src/lib/popover/popover-foundation.ts
@@ -132,7 +132,11 @@ export class PopoverFoundation extends WithLongpressListener(OverlayAwareFoundat
     return true;
   }
 
-  private _openPopover({ dispatchEvents = true, fromKeyboard = false } = {}): void {
+  private _openPopover({ dispatchEvents = true } = {}): void {
+    if (this.open) {
+      return;
+    }
+
     if (dispatchEvents) {
       const evt = this._dispatchBeforetoggleEvent();
       if (evt.defaultPrevented) {
@@ -148,11 +152,7 @@ export class PopoverFoundation extends WithLongpressListener(OverlayAwareFoundat
     }
 
     this._adapter.toggleHostAttribute(POPOVER_CONSTANTS.attributes.OPEN, this.open);
-
-    // We only attempt to set initial focus if the event was triggered by a keyboard interaction
-    if (fromKeyboard) {
-      this._adapter.tryAutofocus();
-    }
+    this._adapter.tryAutofocus();
 
     if (dispatchEvents) {
       this._dispatchToggleEvent();
@@ -160,6 +160,10 @@ export class PopoverFoundation extends WithLongpressListener(OverlayAwareFoundat
   }
 
   private async _closePopover(): Promise<void> {
+    if (!this.open) {
+      return;
+    }
+
     this._previouslyFocusedElement = null;
     DismissibleStack.instance.remove(this._adapter.hostElement);
 
@@ -311,8 +315,7 @@ export class PopoverFoundation extends WithLongpressListener(OverlayAwareFoundat
    */
   private _onAnchorClick(evt: PointerEvent): void {
     if (!this.open) {
-      const fromKeyboard = evt.detail === 0 && !evt.pointerType;
-      this._openPopover({ fromKeyboard });
+      this._openPopover();
     } else {
       this._requestClose('click');
     }
@@ -408,7 +411,7 @@ export class PopoverFoundation extends WithLongpressListener(OverlayAwareFoundat
   private _onAnchorFocus(_evt: FocusEvent): void {
     if (!this._adapter.overlayElement.open) {
       this._adapter.addAnchorListener('focusout', this._anchorBlurListener);
-      this._openPopover({ fromKeyboard: true });
+      this._openPopover();
     }
   }
 

--- a/src/lib/popover/popover.test.ts
+++ b/src/lib/popover/popover.test.ts
@@ -1349,6 +1349,22 @@ describe('Popover', () => {
       expect(document.activeElement).to.be.equal(autofocusEl);
     });
 
+    it('should focus element with autofocus attribute when opened via click', async () => {
+      const harness = await createFixture();
+
+      const autofocusEl = document.createElement('input');
+      autofocusEl.setAttribute('autofocus', '');
+      harness.popoverElement.appendChild(autofocusEl);
+
+      await harness.clickTrigger();
+
+      // We wait two frames internally before attempting to set focus
+      await elementUpdated(harness.popoverElement);
+      await elementUpdated(harness.popoverElement);
+
+      expect(document.activeElement).to.be.equal(autofocusEl);
+    });
+
     it('should place focus back on trigger element when closed via escape key after opened via keyboard', async () => {
       const harness = await createFixture();
 


### PR DESCRIPTION
We were previously only attempting to set focus to an element with the `autofocus` attribute if the popover was triggered via keyboard. This follows the native `popover` expectations. While it shouldn't be overused, there are a lot of design usecases that call for simple form entry in transient popovers and it's desirable to move focus immediately regardless of how the popover was triggered.

We should make a note about this in the docs regarding the accessibility caveats and how it can be confusing to screen reader users.