### PR TITLE
fix(radio): set aria-required on radio group element instead of individual radios

### DIFF
--- a/src/lib/radio/core/radio-group-manager.ts
+++ b/src/lib/radio/core/radio-group-manager.ts
@@ -1,7 +1,6 @@
 import { getValidationMessage, internals, isFocusable, setDefaultAria } from '../../constants';
 import { task } from '../../core/utils/event-utils';
 import { IRadioComponent, RADIO_CONSTANTS, tryCheck } from '../radio';
-import { RADIO_GROUP_CONSTANTS } from '../radio-group';
 
 /**
  * A class for coordinating the states of radio components within a radio group.

--- a/src/lib/radio/core/radio-group-manager.ts
+++ b/src/lib/radio/core/radio-group-manager.ts
@@ -1,6 +1,7 @@
-import { getValidationMessage, internals, isFocusable } from '../../constants';
+import { getValidationMessage, internals, isFocusable, setDefaultAria } from '../../constants';
 import { task } from '../../core/utils/event-utils';
 import { IRadioComponent, RADIO_CONSTANTS, tryCheck } from '../radio';
+import { RADIO_GROUP_CONSTANTS } from '../radio-group';
 
 /**
  * A class for coordinating the states of radio components within a radio group.
@@ -73,6 +74,38 @@ export class RadioGroupManager {
       radio[internals].setValidity({ valueMissing: invalid }, validationMessage);
     });
   }
+
+  /**
+   * Sets the required state of a radio group element.
+   * 
+   * @param el A radio component within the group.
+   */
+  public static setRadioGroupRequired(el: IRadioComponent): void {
+    const groupElement = RadioGroupManager.getRadioGroupElement(el);
+
+    if (!groupElement) {
+      return;
+    }
+
+    const group = RadioGroupManager.getRadioGroup(el);
+    const required = Array.from(group).some(radio => radio.required);
+
+    if (groupElement?.tagName === 'forge-radio-group') {
+      groupElement[setDefaultAria]({ ariaRequired: required ? 'true' : 'false' });
+    } else {
+      groupElement.setAttribute('aria-required', required ? 'true' : 'false');
+    }
+  }
+
+  /**
+   * Gets the radio group element containing the given radio component or null if there is none.
+   * 
+   * @param el A radio component within the group.
+   * @returns The radio group element containing the given radio component or null if there is none.
+   */
+  public static getRadioGroupElement(el: IRadioComponent): HTMLElement | null {
+    return el.closest(`:is(fieldset, [role=radiogroup], forge-radio-group)`);
+  };
 
   /**
    * Sets the selected radio in a radio group.

--- a/src/lib/radio/radio-group/radio-group-adapter.ts
+++ b/src/lib/radio/radio-group/radio-group-adapter.ts
@@ -7,6 +7,7 @@ import { IRadioGroupComponent } from './radio-group';
 export interface IRadioGroupAdapter extends IBaseAdapter {
   attachLabel(label: LabelComponent): void;
   setDisabled(value: boolean): void;
+  trySetRequired(): void;
 }
 
 export class RadioGroupAdapter extends BaseAdapter<IRadioGroupComponent> implements IRadioGroupAdapter {
@@ -22,6 +23,11 @@ export class RadioGroupAdapter extends BaseAdapter<IRadioGroupComponent> impleme
   public setDisabled(value: boolean): void {
     this._component[setDefaultAria]({ ariaDisabled: value ? 'true' : null });
     this._disableRadios(value);
+  }
+
+  public trySetRequired(): void {
+    const required = Array.from(this._component.querySelectorAll(RADIO_CONSTANTS.elementName)).some(radio => radio.required);
+    this._component[setDefaultAria]({ ariaRequired: required ? 'true' : null });
   }
 
   private _disableRadios(value: boolean): void {

--- a/src/lib/radio/radio-group/radio-group-foundation.ts
+++ b/src/lib/radio/radio-group/radio-group-foundation.ts
@@ -18,6 +18,7 @@ export class RadioGroupFoundation implements IRadioGroupFoundation {
 
   public initialize(): void {
     this._adapter.addHostListener(LABEL_CONSTANTS.events.CONNECTED, this._labelConnectedListener);
+    this._adapter.trySetRequired();
   }
 
   private _handleLabelConnected(evt: Event): void {

--- a/src/lib/radio/radio-group/radio-group.test.ts
+++ b/src/lib/radio/radio-group/radio-group.test.ts
@@ -173,5 +173,41 @@ describe('Radio group', () => {
         expect(radio.disabled).to.be.true;
       });
     });
+
+    it('should set required when a descendant radio is required', async () => {
+      const el = await fixture<IRadioGroupComponent>(html`
+        <forge-radio-group>
+          <forge-radio required></forge-radio>
+          <forge-radio></forge-radio>
+        </forge-radio-group>
+      `);
+
+      expect(el.ariaRequired).to.equal('true');
+    });
+
+    it('should not set required when no descendant radios are required', async () => {
+      const el = await fixture<IRadioGroupComponent>(html`
+        <forge-radio-group>
+          <forge-radio></forge-radio>
+          <forge-radio></forge-radio>
+        </forge-radio-group>
+      `);
+
+      expect(el.ariaRequired).to.be.null;
+    });
+
+    it('should set required to false when a change to descendant radios results in none being required', async () => {
+      const el = await fixture<IRadioGroupComponent>(html`
+        <forge-radio-group>
+          <forge-radio required></forge-radio>
+          <forge-radio></forge-radio>
+        </forge-radio-group>
+      `);
+
+      const radio = el.querySelector(RADIO_CONSTANTS.elementName) as IRadioComponent;
+      radio.required = false;
+
+      expect(el.ariaRequired).to.equal('false');
+    });
   });
 });

--- a/src/lib/radio/radio-group/radio-group.test.ts
+++ b/src/lib/radio/radio-group/radio-group.test.ts
@@ -177,30 +177,32 @@ describe('Radio group', () => {
     it('should set required when a descendant radio is required', async () => {
       const el = await fixture<IRadioGroupComponent>(html`
         <forge-radio-group>
-          <forge-radio required></forge-radio>
-          <forge-radio></forge-radio>
+          <forge-radio required>One</forge-radio>
+          <forge-radio>Two</forge-radio>
         </forge-radio-group>
       `);
 
       expect(el.ariaRequired).to.equal('true');
+      await expect(el).to.be.accessible();
     });
 
     it('should not set required when no descendant radios are required', async () => {
       const el = await fixture<IRadioGroupComponent>(html`
         <forge-radio-group>
-          <forge-radio></forge-radio>
-          <forge-radio></forge-radio>
+          <forge-radio>One</forge-radio>
+          <forge-radio>Two</forge-radio>
         </forge-radio-group>
       `);
 
       expect(el.ariaRequired).to.be.null;
+      await expect(el).to.be.accessible();
     });
 
     it('should set required to false when a change to descendant radios results in none being required', async () => {
       const el = await fixture<IRadioGroupComponent>(html`
         <forge-radio-group>
-          <forge-radio required></forge-radio>
-          <forge-radio></forge-radio>
+          <forge-radio required>One</forge-radio>
+          <forge-radio>Two</forge-radio>
         </forge-radio-group>
       `);
 
@@ -208,6 +210,7 @@ describe('Radio group', () => {
       radio.required = false;
 
       expect(el.ariaRequired).to.equal('false');
+      await expect(el).to.be.accessible();
     });
   });
 });

--- a/src/lib/radio/radio/radio-adapter.ts
+++ b/src/lib/radio/radio/radio-adapter.ts
@@ -66,11 +66,9 @@ export class RadioAdapter extends BaseAdapter<IRadioComponent> implements IRadio
     return true;
   }
 
-  public setRequired(value: boolean): void {
-    this._component[setDefaultAria]({
-      ariaRequired: value ? 'true' : 'false'
-    }, { setAttribute: true });
+  public setRequired(): void {
     RadioGroupManager.setRadioGroupValidity(this._component);
+    RadioGroupManager.setRadioGroupRequired(this._component);
   }
 
   public setReadonly(value: boolean): void {

--- a/src/lib/radio/radio/radio-foundation.ts
+++ b/src/lib/radio/radio/radio-foundation.ts
@@ -201,8 +201,8 @@ export class RadioFoundation implements IRadioFoundation {
   public set required(value: boolean) {
     if (this._required !== value) {
       this._required = value;
-      this._adapter.setRequired(this._required);
       this._adapter.toggleHostAttribute(RADIO_CONSTANTS.attributes.REQUIRED, this._required);
+      this._adapter.setRequired(this._required);
     }
   }
 

--- a/src/lib/radio/radio/radio.ts
+++ b/src/lib/radio/radio/radio.ts
@@ -127,8 +127,7 @@ export class RadioComponent extends WithFormAssociation(WithLabelAwareness(WithF
     this[setDefaultAria]({
       role: 'radio',
       ariaChecked: this.checked ? 'true' : 'false',
-      ariaDisabled: this.disabled ? 'true' : 'false',
-      ariaRequired: this.required ? 'true' : 'false'
+      ariaDisabled: this.disabled ? 'true' : 'false'
     });
     RadioGroupManager.syncRadioFocusableState(this);
     this._foundation.initialize();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
A radio no longer sets `aria-required` on itself. Instead, when the state of `required` changes the required status of each radio in the group is evaluated and `aria-required` set on the closest `fieldset`, element with `role=radiogroup`, or `forge-radio-group`. The Forge radio group component attempts the same logic when it's added to the DOM.
