### PR TITLE
fix(field): slotted elements can fill entire block size of field

### DIFF
--- a/src/dev/pages/field/field.ts
+++ b/src/dev/pages/field/field.ts
@@ -92,14 +92,20 @@ endSwitch.addEventListener('forge-switch-change', () => {
 accessorySwitch.addEventListener('forge-switch-change', () => {
   if (accessorySwitch.on) {
     fields.forEach(field => {
+      const button = document.createElement('forge-icon-button');
+      button.slot = 'accessory';
+      button.density = 'medium';
+      button.ariaLabel = 'Favorite';
+
       const icon = document.createElement('forge-icon') as IIconComponent;
       icon.name = 'favorite';
-      icon.slot = 'accessory';
-      field.append(icon);
+
+      button.append(icon);
+      field.append(button);
     });
   } else {
     fields.forEach(field => {
-      const icon = field.querySelector('forge-icon[slot=accessory]');
+      const icon = field.querySelector('forge-icon-button[slot=accessory]');
       icon.remove();
     });
   }

--- a/src/lib/field/_core.scss
+++ b/src/lib/field/_core.scss
@@ -78,6 +78,7 @@
   outline-style: #{token(outline-style)};
   outline-width: #{token(outline-width)};
   outline-color: #{token(outline-color, custom)};
+  pointer-events: none;
 }
 
 @mixin container {
@@ -108,6 +109,7 @@
   grid-column: 1 / -1;
   grid-row: 1 / -1;
 
+  border-radius: #{token(shape)};
   inline-size: 100%;
   block-size: 100%;
 
@@ -198,8 +200,9 @@
   grid-area: start;
   align-items: center;
 
+  block-size: 100%;
   max-block-size: 100%;
-  overflow: hidden;
+  min-block-size: 0;
 
   color: #{token(content-color, custom)};
 }
@@ -212,8 +215,9 @@
   grid-area: end;
   align-items: center;
 
+  block-size: 100%;
   max-block-size: 100%;
-  overflow: hidden;
+  min-block-size: 0;
 
   color: #{token(content-color, custom)};
 }
@@ -229,7 +233,7 @@
 
   block-size: 100%;
   max-block-size: 100%;
-  overflow: hidden;
+  min-block-size: 0;
 
   color: #{token(content-color, custom)};
 

--- a/src/lib/field/field.html
+++ b/src/lib/field/field.html
@@ -3,9 +3,6 @@
     <div id="label" class="label" part="label">
       <slot name="label"></slot>
     </div>
-    <div class="outline">
-      <forge-focus-indicator target="input" part="focus-indicator"></forge-focus-indicator>
-    </div>
     <div id="container" class="container">
       <div class="popover-target" aria-hidden="true"></div>
       <div id="surface" class="surface" part="surface"></div>
@@ -35,6 +32,9 @@
       <div class="support-text-end" part="support-text-end">
         <slot name="support-text-end"></slot>
       </div>
+    </div>
+    <div class="outline">
+      <forge-focus-indicator target="input" part="focus-indicator"></forge-focus-indicator>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N/A
- Docs have been added/updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N/A

## Describe the new behavior?
Fixes an issue where absolutely positioned elements of slotted content would cut off before reaching edge of the field.