### PR TITLE
fix(tab-bar): move ARIA attributes to internal scroll container for tab bar

### DIFF
--- a/src/lib/tabs/tab-bar/tab-bar-adapter.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-adapter.ts
@@ -57,8 +57,8 @@ export class TabBarAdapter extends BaseAdapter<ITabBarComponent> implements ITab
   }
 
   public initialize(): void {
-    this._forwardObserver = forwardAttributes(this._component, TAB_BAR_CONSTANTS.forwardedAttributes, (name, value) => {
-      toggleAttribute(this._scrollContainer, !!value, name, value ?? undefined);
+    this._forwardObserver = forwardAttributes(this._component, Object.keys(TAB_BAR_CONSTANTS.forwardedAttributes), (name, value) => {
+      toggleAttribute(this._scrollContainer, !!value, TAB_BAR_CONSTANTS.forwardedAttributes[name], value ?? undefined);
     });
   }
 

--- a/src/lib/tabs/tab-bar/tab-bar-adapter.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-adapter.ts
@@ -8,7 +8,6 @@ import { ITabBarComponent } from './tab-bar';
 import { TAB_BAR_CONSTANTS } from './tab-bar-constants';
 
 export interface ITabBarAdapter extends IBaseAdapter {
-  initializeAccessibility(): void;
   initializeContainerSizeObserver(listener: () => void): void;
   destroyContainerSizeObserver(): void;
   initializeScrollObserver(listener: EventListener): void;
@@ -53,12 +52,6 @@ export class TabBarAdapter extends BaseAdapter<ITabBarComponent> implements ITab
     this._scrollContainer = getShadowElement(this._component, TAB_BAR_CONSTANTS.selectors.SCROLL_CONTAINER);
   }
 
-  public initializeAccessibility(): void {
-    if (!this._component.hasAttribute('role')) {
-      this._component.setAttribute('role', 'tablist');
-    }
-  }
-
   public initializeContainerSizeObserver(listener: () => void): void {
     this._resizeObserver = new ResizeObserver(() => listener());
     this._resizeObserver.observe(this._component);
@@ -78,7 +71,7 @@ export class TabBarAdapter extends BaseAdapter<ITabBarComponent> implements ITab
   }
 
   public setVertical(value: boolean): void {
-    toggleAttribute(this._component, !!value, 'aria-orientation', 'vertical');
+    toggleAttribute(this._scrollContainer, !!value, 'aria-orientation', 'vertical');
   }
 
   public setScrollBackwardButtonListener(listener: EventListener): void {

--- a/src/lib/tabs/tab-bar/tab-bar-adapter.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-adapter.ts
@@ -6,8 +6,11 @@ import { ITabComponent } from '../tab/tab';
 import { TAB_CONSTANTS } from '../tab/tab-constants';
 import { ITabBarComponent } from './tab-bar';
 import { TAB_BAR_CONSTANTS } from './tab-bar-constants';
+import { forwardAttributes } from '../../core/utils/reflect-utils';
 
 export interface ITabBarAdapter extends IBaseAdapter {
+  initialize(): void;
+  destroy(): void;
   initializeContainerSizeObserver(listener: () => void): void;
   destroyContainerSizeObserver(): void;
   initializeScrollObserver(listener: EventListener): void;
@@ -43,6 +46,7 @@ export class TabBarAdapter extends BaseAdapter<ITabBarComponent> implements ITab
   private _resizeObserver: ResizeObserver | undefined;
   private _backwardScrollButton: IIconButtonComponent | undefined;
   private _forwardScrollButton: IIconButtonComponent | undefined;
+  private _forwardObserver?: MutationObserver;
 
   constructor(component: ITabBarComponent) {
     super(component);
@@ -50,6 +54,17 @@ export class TabBarAdapter extends BaseAdapter<ITabBarComponent> implements ITab
     this._defaultSlotElement = getShadowElement(this._component, TAB_BAR_CONSTANTS.selectors.DEFAULT_SLOT) as HTMLSlotElement;
     this._rootElement = getShadowElement(this._component, TAB_BAR_CONSTANTS.selectors.ROOT);
     this._scrollContainer = getShadowElement(this._component, TAB_BAR_CONSTANTS.selectors.SCROLL_CONTAINER);
+  }
+
+  public initialize(): void {
+    this._forwardObserver = forwardAttributes(this._component, TAB_BAR_CONSTANTS.forwardedAttributes, (name, value) => {
+      toggleAttribute(this._scrollContainer, !!value, name, value ?? undefined);
+    });
+  }
+
+  public destroy(): void {
+    this._forwardObserver?.disconnect();
+    this._forwardObserver = undefined;
   }
 
   public initializeContainerSizeObserver(listener: () => void): void {

--- a/src/lib/tabs/tab-bar/tab-bar-constants.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-constants.ts
@@ -18,7 +18,9 @@ const attributes = {
   ...observedAttributes
 };
 
-const forwardedAttributes = ['aria-label'];
+const forwardedAttributes = {
+  'data-aria-label': 'aria-label'
+};
 
 const selectors = {
   ROOT: '.forge-tab-bar',

--- a/src/lib/tabs/tab-bar/tab-bar-constants.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-constants.ts
@@ -18,6 +18,8 @@ const attributes = {
   ...observedAttributes
 };
 
+const forwardedAttributes = ['aria-label'];
+
 const selectors = {
   ROOT: '.forge-tab-bar',
   SCROLL_CONTAINER: '.scroll-container',
@@ -40,6 +42,7 @@ export const TAB_BAR_CONSTANTS = {
   elementName,
   observedAttributes,
   attributes,
+  forwardedAttributes,
   events,
   selectors,
   classes,

--- a/src/lib/tabs/tab-bar/tab-bar-core.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-core.ts
@@ -55,7 +55,6 @@ export class TabBarCore implements ITabBarCore {
   }
 
   public initialize(): void {
-    this._adapter.initializeAccessibility();
     this._adapter.addSlotListener(this._tabsChangedListener);
     this._adapter.addHostListener(TAB_CONSTANTS.events.SELECT, this._tabSelectedListener);
     this._adapter.addHostListener('keydown', this._keydownListener);

--- a/src/lib/tabs/tab-bar/tab-bar-core.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-core.ts
@@ -55,6 +55,7 @@ export class TabBarCore implements ITabBarCore {
   }
 
   public initialize(): void {
+    this._adapter.initialize();
     this._adapter.addSlotListener(this._tabsChangedListener);
     this._adapter.addHostListener(TAB_CONSTANTS.events.SELECT, this._tabSelectedListener);
     this._adapter.addHostListener('keydown', this._keydownListener);
@@ -71,6 +72,7 @@ export class TabBarCore implements ITabBarCore {
   }
 
   public destroy(): void {
+    this._adapter.destroy();
     this._adapter.destroyContainerSizeObserver();
     this._adapter.destroyScrollObserver(this._scrollListener);
     this._isInitialized = false;

--- a/src/lib/tabs/tab-bar/tab-bar.html
+++ b/src/lib/tabs/tab-bar/tab-bar.html
@@ -1,6 +1,6 @@
 <template>
   <div class="forge-tab-bar" part="container">
-    <div class="scroll-container" part="scroll-container">
+    <div role="tablist" class="scroll-container" part="scroll-container">
       <slot></slot>
     </div>
   </div>

--- a/src/lib/tabs/tab-bar/tab-bar.ts
+++ b/src/lib/tabs/tab-bar/tab-bar.ts
@@ -65,6 +65,7 @@ declare global {
  * @attribute {boolean} [secondary=false] - Controls whether the tabs are styled as secondary tab navigation.
  * @attribute {boolean} [auto-activate=false] - Controls whether the tabs are automatically activated when receiving focus.
  * @attribute {boolean} [scroll-buttons=false] - Controls whether scroll buttons are displayed when the tabs overflow their container.
+ * @attribute {string} [data-aria-label] - The ARIA label to forward to the internal tablist element.
  *
  * @event {CustomEvent<ITabBarChangeEventData>} forge-tab-bar-change - Dispatches when the active tab changes.
  *

--- a/src/lib/tabs/tabs.test.ts
+++ b/src/lib/tabs/tabs.test.ts
@@ -30,7 +30,7 @@ describe('Tabs', () => {
 
     expect(scrollContainerEl.hasAttribute('aria-label')).to.be.false;
 
-    el.setAttribute('aria-label', 'Test');
+    el.setAttribute('data-aria-label', 'Test');
     await elementUpdated(el);
 
     expect(scrollContainerEl.getAttribute('aria-label')).to.equal('Test');

--- a/src/lib/tabs/tabs.test.ts
+++ b/src/lib/tabs/tabs.test.ts
@@ -24,6 +24,19 @@ describe('Tabs', () => {
     await expect(el).to.be.accessible();
   });
 
+  it('should forward aria-label to internal tablist element', async () => {
+    const el = await createFixture();
+    const scrollContainerEl = getShadowElement(el, TAB_BAR_CONSTANTS.selectors.SCROLL_CONTAINER);
+
+    expect(scrollContainerEl.hasAttribute('aria-label')).to.be.false;
+
+    el.setAttribute('aria-label', 'Test');
+    await elementUpdated(el);
+
+    expect(scrollContainerEl.getAttribute('aria-label')).to.equal('Test');
+    await expect(el).to.be.accessible();
+  });
+
   it('should set default active tab', async () => {
     const el = await createFixture({ activeTab: 1 });
     const ctx = new TabsHarness(el);

--- a/src/lib/tabs/tabs.test.ts
+++ b/src/lib/tabs/tabs.test.ts
@@ -535,9 +535,7 @@ describe('Tabs', () => {
       el.style.width = '1px';
       await elementUpdated(el);
 
-      // TODO: fix nested scroll buttons within tab role
-      // await expect(el).to.be.accessible();
-
+      await expect(el).to.be.accessible();
       expect(el.scrollButtons).to.be.true;
       expect(ctx.hasScrollButtons).to.be.true;
       expect(ctx.backwardScrollButton).to.be.ok;

--- a/src/stories/components/tabs/Tabs.stories.ts
+++ b/src/stories/components/tabs/Tabs.stories.ts
@@ -39,6 +39,7 @@ const meta = {
 
     return html`
       <forge-tab-bar
+        data-aria-label="Demo tabs"
         .disabled=${args.disabled}
         .activeTab=${args.activeTab}
         .vertical=${args.vertical}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Moves the `role="tablist"` from the `<forge-tab-bar>` to the internal scroll container element that `<forge-tab>` elements slot into. This keeps the scroll buttons outside of the tablist element.

## Additional information
This will fail an audit with Arc, but it's due to a bug in their audit.
