### PR TITLE
fix(forge-step): correct select event name for proper typing

### DIFF
--- a/.github/workflows/auto-pr-check.yml
+++ b/.github/workflows/auto-pr-check.yml
@@ -2,10 +2,7 @@ name: Pull Request Validation
 
 on:
   pull_request_target:
-    branches:
-      - main
     types: [opened, synchronize, reopened, labeled, unlabeled]
-  workflow_dispatch:
 
 jobs:
   release:

--- a/src/dev/pages/stepper/stepper.ts
+++ b/src/dev/pages/stepper/stepper.ts
@@ -6,9 +6,9 @@ import './stepper.scss';
 const stepper = document.querySelector('#demo-stepper') as IStepperComponent;
 stepper.selectedIndex = 2;
 
-stepper.addEventListener('forge-step-selected', ({ detail }) => {
+stepper.addEventListener('forge-step-select', ({ detail }) => {
   stepper.selectedIndex = detail;
-  console.log('[forge-step-selected]: ', detail);
+  console.log('[forge-step-select]: ', detail);
 });
 
 const steps: IStepConfiguration[] = [

--- a/src/lib/stepper/step/step.ts
+++ b/src/lib/stepper/step/step.ts
@@ -29,7 +29,7 @@ declare global {
   }
 
   interface HTMLElementEventMap {
-    'forge-step-selected': CustomEvent<number>;
+    'forge-step-select': CustomEvent<number>;
     'forge-step-expanded-content-focusin': CustomEvent<IStepComponent>;
     'forge-step-expanded-content-focusout': CustomEvent<IStepComponent>;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: n/a
- Docs have been added/updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?
Fix the event name registered to HTMLElementEventMap so that `forge-step-select` events are properly typed.

## Additional information
Event name is correct in Forge 3.0, though the dev page addEventListener is still incorrect.
