### PR TITLE
fix(list-item): separate the foreground and background selected state tokens

### DIFF
--- a/src/lib/core/styles/tokens/list/list-item/_tokens.scss
+++ b/src/lib/core/styles/tokens/list/list-item/_tokens.scss
@@ -23,6 +23,7 @@ $tokens: (
   text-line-height: utils.module-val(list-item, text-line-height, typography.scale('1500')),
   // Selected
   selected-color: utils.module-val(list-item, selected-color, theme.variable(primary)),
+  selected-background: utils.module-ref(list-item, selected-background, selected-color),
   selected-opacity: utils.module-val(list-item, selected-opacity, theme.emphasis(lowest)),
   selected-start-color: utils.module-ref(list-item, selected-start-color, selected-color),
   selected-end-color: utils.module-ref(list-item, selected-end-color, selected-color),

--- a/src/lib/list/list-item/_core.scss
+++ b/src/lib/list/list-item/_core.scss
@@ -68,6 +68,7 @@
   @include typography.ellipse;
 
   box-sizing: border-box;
+  isolation: isolate;
 
   font-size: #{token(text-font-size)};
   font-weight: #{token(text-font-weight)};
@@ -85,7 +86,7 @@
     inset: 0;
     border-radius: inherit;
     opacity: #{token(selected-opacity)};
-    background-color: #{token(selected-color)};
+    background-color: #{token(selected-background)};
   }
 }
 

--- a/src/lib/list/list-item/list-item.ts
+++ b/src/lib/list/list-item/list-item.ts
@@ -86,7 +86,8 @@ declare global {
  * @cssproperty --forge-list-item-text-font-size - The font size of the text.
  * @cssproperty --forge-list-item-text-font-weight - The font weight of the text.
  * @cssproperty --forge-list-item-text-line-height - The line height of the text.
- * @cssproperty --forge-list-item-selected-color - The color when in the selected state.
+ * @cssproperty --forge-list-item-selected-color - The foreground color when in the selected state.
+ * @cssproperty --forge-list-item-selected-background - The background color when in the selected state.
  * @cssproperty --forge-list-item-selected-opacity - The opacity of the background color when in the selected state.
  * @cssproperty --forge-list-item-start-selected-color - The color of the start content when in the selected state.
  * @cssproperty --forge-list-item-end-selected-color - The color of the end content when in the selected state.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N/A
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
A new `selected-background` token has been added that reference the `selected-color` token to allow for adjusting the background color and foreground color independently. This will help branding to ensure that these colors can easily be adjusted without `::part` selectors when overrides are needed.

## Additional information
During this change it was also found that the internal list item text-container was rendering below the `::before` pseudo element which was inheriting the opacity. The text-container element has now been moved to its own isolation context.
