### PR TITLE
fix(app-bar-notification-button): fixed a bug where the count could incorrectly display when in dot mode if not changed from default

### DIFF
--- a/src/lib/app-bar/notification-button/app-bar-notification-button-core.ts
+++ b/src/lib/app-bar/notification-button/app-bar-notification-button-core.ts
@@ -23,9 +23,7 @@ export class AppBarNotificationButtonCore implements IAppBarNotificationButtonCo
   public initialize(): void {
     this._adapter.initialize();
     this._adapter.setBadgeType(this._dot);
-    if (!this._dot) {
-      this._adapter.setCount(this._count);
-    }
+    this._adapter.setCount(this._dot ? null : this._count);
     this._adapter.setBadgeTheme(this._theme);
     this._adapter.setBadgeVisible(this._showBadge);
     this._adapter.setIcon(this._icon);
@@ -57,7 +55,9 @@ export class AppBarNotificationButtonCore implements IAppBarNotificationButtonCo
     if (this._count !== value) {
       this._count = value;
       if (this._isInitialized) {
-        if (!this._dot) {
+        if (this._dot) {
+          this._adapter.setCount(null);
+        } else {
           this._adapter.setCount(this._count);
         }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The `count` value will now not be displayed if in `dot` mode when a badge is visible.
