### PR TITLE
fix(button): keep native submit or reset button in the dom for implicit form submission

### DIFF
--- a/src/dev/pages/button/button.ejs
+++ b/src/dev/pages/button/button.ejs
@@ -120,6 +120,9 @@
       <forge-text-field style="width: 516px;">
         <input type="text" placeholder="Text input" aria-label="Test form input" autocomplete="off" />
       </forge-text-field>
+      <forge-text-field style="width: 516px;">
+        <input type="text" placeholder="Text input 2" aria-label="Test form input 2" autocomplete="off" />
+      </forge-text-field>
       <div>
         <forge-button id="submit-btn" variant="outlined" type="submit" name="submit-btn" formaction="javascript: alert('<forge-button> submit override action');">Submit</forge-button>
         <forge-button id="reset-btn" variant="outlined" type="reset">Reset</forge-button>

--- a/src/dev/pages/button/button.ts
+++ b/src/dev/pages/button/button.ts
@@ -15,6 +15,11 @@ IconRegistry.define([tylIconForgeLogo, tylIconFavorite, tylIconOpenInNew]);
 
 const formPreventToggle = document.querySelector('#opt-form-prevent') as ISwitchComponent;
 
+const form = document.getElementById('test-btn-form') as HTMLFormElement;
+form.addEventListener('submit', evt => {
+  console.log('form submit', evt);
+});
+
 const submitBtn = document.querySelector('#submit-btn') as HTMLButtonElement;
 submitBtn.addEventListener('click', evt => {
   if (formPreventToggle.on) {

--- a/src/lib/button/base/base-button-core.ts
+++ b/src/lib/button/base/base-button-core.ts
@@ -29,6 +29,9 @@ export abstract class BaseButtonCore<T extends IBaseButtonAdapter<IBaseButton>> 
   public initialize(): void {
     this._detectSlottedAnchor();
     this._adapter.addDefaultSlotChangeListener(this._slotChangeListener);
+    if (this._type !== 'button') {
+      this._adapter.addNativeButton(this._type as 'submit' | 'reset');
+    }
   }
 
   /**
@@ -127,6 +130,12 @@ export abstract class BaseButtonCore<T extends IBaseButtonAdapter<IBaseButton>> 
     if (this._type !== type) {
       this._type = type;
       this._adapter.setHostAttribute(BASE_BUTTON_CONSTANTS.attributes.TYPE, type);
+
+      if (this.type !== 'button') {
+        this._adapter.addNativeButton(type as 'submit' | 'reset');
+      } else {
+        this._adapter.removeNativeButton();
+      }
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
This adds a persistent slotted, hidden `<button type="submit"></button>` or `<button type="reset"></button>` to the base button component to enable implicit form submission, e.g. when a user presses the enter key while a form input is focused.
