### PR TITLE
feat: readopt constructed stylesheets

### DIFF
--- a/src/lib/bottom-sheet/bottom-sheet.ts
+++ b/src/lib/bottom-sheet/bottom-sheet.ts
@@ -1,5 +1,5 @@
-import { attachShadowTemplate, customElement, coreProperty, ICustomElement, coerceBoolean } from '@tylertech/forge-core';
-import { BaseComponent } from '../core/base/base-component';
+import { attachShadowTemplate, customElement, coreProperty, coerceBoolean } from '@tylertech/forge-core';
+import { BaseComponent, IBaseComponent } from '../core/base/base-component';
 import { WithDefaultAria } from '../core/mixins/internals/with-default-aria';
 import { WithElementInternals } from '../core/mixins/internals/with-element-internals';
 import { DialogComponent } from '../dialog/dialog';
@@ -10,7 +10,7 @@ import { BottomSheetCore } from './bottom-sheet-core';
 import template from './bottom-sheet.html';
 import styles from './bottom-sheet.scss';
 
-export interface IBottomSheetComponent extends ICustomElement {
+export interface IBottomSheetComponent extends IBaseComponent {
   mode: BottomSheetMode;
   persistent: boolean;
   open: boolean;

--- a/src/lib/button-area/button-area.ts
+++ b/src/lib/button-area/button-area.ts
@@ -1,14 +1,15 @@
-import { customElement, attachShadowTemplate, ICustomElement, coreProperty, coerceBoolean } from '@tylertech/forge-core';
+import { customElement, attachShadowTemplate, coreProperty, coerceBoolean } from '@tylertech/forge-core';
 import { ButtonAreaAdapter } from './button-area-adapter';
 import { ButtonAreaCore } from './button-area-core';
 import { BUTTON_AREA_CONSTANTS } from './button-area-constants';
 import { FocusIndicatorComponent } from '../focus-indicator';
 import { StateLayerComponent } from '../state-layer';
+import { BaseComponent, IBaseComponent } from '../core/base/base-component';
 
 import template from './button-area.html';
 import styles from './button-area.scss';
 
-export interface IButtonAreaComponent extends ICustomElement {
+export interface IButtonAreaComponent extends IBaseComponent {
   disabled: boolean;
 }
 
@@ -47,7 +48,7 @@ declare global {
   name: BUTTON_AREA_CONSTANTS.elementName,
   dependencies: [FocusIndicatorComponent, StateLayerComponent]
 })
-export class ButtonAreaComponent extends HTMLElement implements IButtonAreaComponent {
+export class ButtonAreaComponent extends BaseComponent implements IButtonAreaComponent {
   public static get observedAttributes(): string[] {
     return [BUTTON_AREA_CONSTANTS.attributes.DISABLED];
   }

--- a/src/lib/calendar/calendar-menu/calendar-menu.ts
+++ b/src/lib/calendar/calendar-menu/calendar-menu.ts
@@ -1,15 +1,16 @@
-import { customElement, attachShadowTemplate, ICustomElement, coreProperty, coerceBoolean, elementParents } from '@tylertech/forge-core';
+import { customElement, attachShadowTemplate, coreProperty, coerceBoolean, elementParents } from '@tylertech/forge-core';
 import { FocusIndicatorComponent } from '../../focus-indicator/focus-indicator';
 import { StateLayerComponent } from '../../state-layer/state-layer';
 
 import { CalendarMenuAdapter } from './calendar-menu-adapter';
 import { CalendarDirection, CalendarMenuAnimationType, CALENDAR_MENU_CONSTANTS, ICalendarMenuOption } from './calendar-menu-constants';
 import { CalendarMenuCore } from './calendar-menu-core';
+import { BaseComponent, IBaseComponent } from '../../core/base/base-component';
 
 import template from './calendar-menu.html';
 import styles from './calendar-menu.scss';
 
-export interface ICalendarMenuComponent extends ICustomElement {
+export interface ICalendarMenuComponent extends IBaseComponent {
   animationType: CalendarMenuAnimationType;
   preventFocus: boolean;
   animateIn(options: ICalendarMenuOption[], direction: CalendarDirection, setFocus?: boolean): void;
@@ -42,7 +43,7 @@ declare global {
   name: CALENDAR_MENU_CONSTANTS.elementName,
   dependencies: [StateLayerComponent, FocusIndicatorComponent]
 })
-export class CalendarMenuComponent extends HTMLElement implements ICalendarMenuComponent {
+export class CalendarMenuComponent extends BaseComponent implements ICalendarMenuComponent {
   public static get observedAttributes(): string[] {
     return [CALENDAR_MENU_CONSTANTS.attributes.ANIMATION_TYPE, CALENDAR_MENU_CONSTANTS.attributes.PREVENT_FOCUS];
   }

--- a/src/lib/calendar/calendar.ts
+++ b/src/lib/calendar/calendar.ts
@@ -1,4 +1,4 @@
-import { customElement, attachShadowTemplate, ICustomElement, coreProperty, coerceNumber, coerceBoolean, elementParents } from '@tylertech/forge-core';
+import { customElement, attachShadowTemplate, coreProperty, coerceNumber, coerceBoolean, elementParents } from '@tylertech/forge-core';
 import { tylIconAdd, tylIconArrowDropDown, tylIconKeyboardArrowLeft, tylIconKeyboardArrowRight, tylIconLens } from '@tylertech/tyler-icons/standard';
 
 import { CalendarAdapter } from './calendar-adapter';
@@ -27,11 +27,12 @@ import { ICalendarBase } from './core/calendar-base';
 import { CalendarMenuAnimationType, CalendarMenuComponent } from './calendar-menu';
 import { StateLayerComponent } from '../state-layer';
 import { FocusIndicatorComponent } from '../focus-indicator';
+import { BaseComponent, IBaseComponent } from '../core/base/base-component';
 
 import template from './calendar.html';
 import styles from './calendar.scss';
 
-export interface ICalendarComponent extends ICalendarBase, ICustomElement {
+export interface ICalendarComponent extends ICalendarBase, IBaseComponent {
   mode: CalendarMode;
   view: CalendarView;
   preventFocus: boolean;
@@ -139,7 +140,7 @@ declare global {
   name: CALENDAR_CONSTANTS.elementName,
   dependencies: [ButtonComponent, CalendarMenuComponent, IconButtonComponent, IconComponent, TooltipComponent, StateLayerComponent, FocusIndicatorComponent]
 })
-export class CalendarComponent extends HTMLElement implements ICalendarComponent {
+export class CalendarComponent extends BaseComponent implements ICalendarComponent {
   public static get observedAttributes(): string[] {
     return [
       CALENDAR_CONSTANTS.attributes.ALLOW_SINGLE_DATE_RANGE,

--- a/src/lib/core/base/base-component.ts
+++ b/src/lib/core/base/base-component.ts
@@ -1,9 +1,20 @@
+import { readoptStyles } from '@tylertech/forge-core';
+
 export interface IBaseComponent extends HTMLElement {
   initializedCallback?(): void;
   connectedCallback?(): void;
   disconnectedCallback?(): void;
   attributeChangedCallback?(name: string, oldValue: string, newValue: string): void;
-  adoptedCallback?(): void;
+  adoptedCallback(): void;
 }
 
-export abstract class BaseComponent extends HTMLElement implements IBaseComponent {}
+export abstract class BaseComponent extends HTMLElement implements IBaseComponent {
+  public adoptedCallback(): void {
+    // Attempt to readopt constructed CSSStyleSheet instances to the shadow root to ensure that
+    // they are created against the new document because CSSStyleSheet instances cannot be shared
+    // across documents.
+    if (this.shadowRoot) {
+      readoptStyles(this);
+    }
+  }
+}

--- a/src/lib/select/option/option.ts
+++ b/src/lib/select/option/option.ts
@@ -1,12 +1,12 @@
-import { coerceBoolean, customElement, coreProperty, ICustomElement } from '@tylertech/forge-core';
+import { coerceBoolean, customElement, coreProperty } from '@tylertech/forge-core';
 import { IIconComponent } from '../../icon';
-import { BaseComponent } from '../../core/base/base-component';
+import { BaseComponent, IBaseComponent } from '../../core/base/base-component';
 import { IBaseListDropdownOption, ListDropdownIconType } from '../../list-dropdown/list-dropdown-constants';
 import { OptionAdapter } from './option-adapter';
 import { OPTION_CONSTANTS } from './option-constants';
 import { OptionCore } from './option-core';
 
-export interface IOptionComponent extends ICustomElement, Required<IBaseListDropdownOption> {}
+export interface IOptionComponent extends IBaseComponent, Required<IBaseListDropdownOption> {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/lib/stack/stack.ts
+++ b/src/lib/stack/stack.ts
@@ -1,13 +1,13 @@
-import { customElement, attachShadowTemplate, ICustomElement, coerceBoolean, coreProperty } from '@tylertech/forge-core';
+import { customElement, attachShadowTemplate, coerceBoolean, coreProperty } from '@tylertech/forge-core';
 import { StackAdapter } from './stack-adapter';
 import { StackCore } from './stack-core';
 import { STACK_CONSTANTS, StackAlignment } from './stack-constants';
-import { BaseComponent } from '../core/base/base-component';
+import { BaseComponent, IBaseComponent } from '../core/base/base-component';
 
 import template from './stack.html';
 import styles from './stack.scss';
 
-export interface IStackComponent extends ICustomElement {
+export interface IStackComponent extends IBaseComponent {
   inline: boolean;
   wrap: boolean;
   stretch: boolean;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Adds an `adoptedCallback()` implementation to the `BaseComponent` class that attempts to readopt `CSSStyleSheet` instances on custom elements that have a shadow root instance at the time of them being adopted by another `document`.

This ensures that the `CSSStyleSheet` instances are recreated in the document that is rendering the element since `CSSStyleSheet` instances cannot be access across different documents than where they were created.
