### PR TITLE
[field] fix initialization of internal element references to occur in constructor instead of connectedCallback

### DIFF
--- a/src/lib/chip-field/chip-field-adapter.ts
+++ b/src/lib/chip-field/chip-field-adapter.ts
@@ -28,11 +28,11 @@ export class ChipFieldAdapter extends FieldAdapter implements IChipFieldAdapter 
   protected _inputContainerElement: HTMLElement;
 
   constructor(component: IChipFieldComponent) {
-    super(component);
+    super(component, CHIP_FIELD_CONSTANTS.selectors.ROOT);
   }
 
   public initialize(): void {
-    super.initialize(CHIP_FIELD_CONSTANTS.selectors.ROOT);
+    super.initialize();
     this._memberSlot = getShadowElement(this._component, CHIP_FIELD_CONSTANTS.selectors.MEMBER_SLOT) as HTMLSlotElement;
     this._inputContainerElement = getShadowElement(this._component, CHIP_FIELD_CONSTANTS.selectors.INPUT_CONTAINER) as HTMLElement;
   }

--- a/src/lib/field/field-adapter.ts
+++ b/src/lib/field/field-adapter.ts
@@ -49,7 +49,7 @@ export interface IFieldAdapter extends IBaseAdapter {
   getLabelWidth(fontSize: number, fontFamily: string): number;
 
   // state actions
-  initialize(rootSelector: string): void;
+  initialize(): void;
   initializeFloatingLabel(): IFloatingLabel;
   ensureSlottedLabel(): void;
   destroy(): void;
@@ -72,16 +72,16 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
   protected _inputMutationObserver: MutationObserver;
   protected _valueChangeListeners: Array<() => void> = [];
 
-  constructor(component: IFieldComponent) {
+  constructor(component: IFieldComponent, rootSelector: string) {
     super(component);
-  }
-
-  public initialize(rootSelector: string): void {
     this._rootElement = getShadowElement(this._component, rootSelector);
     this._labelSlot = getShadowElement(this._component, 'slot[name=label]') as HTMLSlotElement;
     this._leadingSlot = getShadowElement(this._component, 'slot[name=leading]') as HTMLSlotElement;
     this._trailingSlot = getShadowElement(this._component, 'slot[name=trailing]') as HTMLSlotElement;
     this._addonEndSlot = getShadowElement(this._component, 'slot[name=addon-end]') as HTMLSlotElement;
+  }
+
+  public initialize(): void {
     this._inputElement = this._component.querySelector('input:not([type=checkbox]):not([type=radio])') as HTMLInputElement;
     this.detectLabel();
   }

--- a/src/lib/field/field-foundation.ts
+++ b/src/lib/field/field-foundation.ts
@@ -45,7 +45,7 @@ export class FieldFoundation {
   //
 
   public initialize(): void {
-    this._adapter.initialize('');
+    this._adapter.initialize();
 
     if (this._adapter.hasLabel()) {
       this._adapter.ensureSlottedLabel();

--- a/src/lib/text-field/text-field-adapter.ts
+++ b/src/lib/text-field/text-field-adapter.ts
@@ -13,11 +13,11 @@ export class TextFieldAdapter extends FieldAdapter implements ITextFieldAdapter 
   protected _inputMutationObserverInstances: MutationObserver[] = [];
 
   constructor(component: ITextFieldComponent) {
-    super(component);
+    super(component, TEXT_FIELD_CONSTANTS.selectors.ROOT);
   }
 
   public initialize(): void {
-    super.initialize(TEXT_FIELD_CONSTANTS.selectors.ROOT);
+    super.initialize();
     this._inputElements = Array.from(this._component.querySelectorAll('input:not([type=checkbox]):not([type=radio]), textarea'));
     if (this._inputElements.length > 1) {
       this._handleMultiInputs();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Moves the initialization of internal element references in the shadow DOM to the constructor of the adapter to ensure that these element references are always available. This fixes a bug where an exception is thrown if the element is removed from the DOM before the element fully initializes because it waits for a child `<input>` asynchronously.
