### PR TITLE
fix(icon-button): fix to properly default `theme` to "default" to allow for "primary" to be used like other themes

### DIFF
--- a/src/dev/pages/icon-button/icon-button.html
+++ b/src/dev/pages/icon-button/icon-button.html
@@ -32,9 +32,9 @@ include('./src/partials/page.ejs', {
         type: 'select',
         label: 'Theme',
         id: 'opt-theme',
-        defaultValue: '',
+        defaultValue: 'default',
         options: [
-          { label: 'Default', value: '' },
+          { label: 'Default', value: 'default' },
           { label: 'Primary', value: 'primary' },
           { label: 'Secondary', value: 'secondary' },
           { label: 'Tertiary', value: 'tertiary' },

--- a/src/lib/icon-button/icon-button-constants.ts
+++ b/src/lib/icon-button/icon-button-constants.ts
@@ -22,7 +22,7 @@ const events = {
 
 const defaults = {
   DEFAULT_VARIANT: 'icon' as IconButtonVariant,
-  DEFAULT_THEME: 'primary' as IconButtonTheme,
+  DEFAULT_THEME: 'default' as IconButtonTheme,
   DEFAULT_SHAPE: 'circular' as IconButtonShape,
   DEFAULT_DENSITY: 'large' as IconButtonDensity
 };
@@ -36,6 +36,6 @@ export const ICON_BUTTON_CONSTANTS = {
 };
 
 export type IconButtonVariant = 'icon' | 'outlined' | 'tonal' | 'filled' | 'raised';
-export type IconButtonTheme = Theme;
+export type IconButtonTheme = Theme | 'default';
 export type IconButtonShape = 'circular' | 'squared';
 export type IconButtonDensity = Density;

--- a/src/lib/icon-button/icon-button.test.ts
+++ b/src/lib/icon-button/icon-button.test.ts
@@ -62,7 +62,7 @@ describe('Icon Button', () => {
   it('should have default theme', async () => {
     const el = await fixture<IIconButtonComponent>(html`<forge-icon-button>${DEFAULT_ICON}</forge-icon-button>`);
 
-    expect(el.theme).to.equal('primary');
+    expect(el.theme).to.equal('default');
   });
 
   it('should set theme', async () => {
@@ -86,7 +86,7 @@ describe('Icon Button', () => {
 
     el.removeAttribute(ICON_BUTTON_CONSTANTS.attributes.THEME);
 
-    expect(el.theme).to.equal('primary');
+    expect(el.theme).to.equal('default');
     expect(el.hasAttribute(ICON_BUTTON_CONSTANTS.attributes.THEME)).to.be.false;
   });
 

--- a/src/lib/icon-button/icon-button.ts
+++ b/src/lib/icon-button/icon-button.ts
@@ -38,7 +38,7 @@ declare global {
  * @property {boolean} [toggle=false] - Whether or not the icon button can be toggled.
  * @property {boolean} [on=false] - Whether or not the button is on. Only applies when `toggle` is `true`.
  * @property {IconButtonVariant} [variant="icon"] - The variant of the button. Valid values are `text`, `outlined`, `filled`, and `raised`.
- * @property {IconButtonTheme} [theme="primary"] - The theme of the button. Valid values are `primary`, `secondary`, `tertiary`, `success`, `error`, `warning`, `info`.
+ * @property {IconButtonTheme} [theme="default"] - The theme of the button. Valid values are `default`, `primary`, `secondary`, `tertiary`, `success`, `error`, `warning`, `info`.
  * @property {string} [shape="circular"] - The shape of the button. Valid values are `circular` and `squared`.
  * @property {IconButtonDensity} [density="large"] - The density of the button. Valid values are `small`, `medium`, and `large`.
  * @property {string} [type="button"] - The type of button. Defaults to `button`. Valid values are `button`, `submit`, and `reset`.
@@ -56,7 +56,7 @@ declare global {
  * @attribute {boolean} [toggle=false] - Whether or not the icon button can be toggled.
  * @attribute {boolean} [on=false] - Whether or not the button is on. Only applies when `toggle` is `true`.
  * @attribute {IconButtonVariant} [variant="icon"] - The variant of the button. Valid values are `text`, `outlined`, `filled`, and `raised`.
- * @attribute {IconButtonTheme} [theme="primary"] - The theme of the button. Valid values are `primary`, `secondary`, `tertiary`, `success`, `error`, `warning`, `info`.
+ * @attribute {IconButtonTheme} [theme="default"] - The theme of the button. Valid values are `default`, `primary`, `secondary`, `tertiary`, `success`, `error`, `warning`, `info`.
  * @attribute {string} [shape="circular"] - The shape of the button. Valid values are `circular` and `squared`.
  * @attribute {IconButtonDensity} [density="large"] - The density of the button. Valid values are `small`, `medium`, and `large`.
  * @attribute {string} [type="button"] - The type of button. Defaults to `button`. Valid values are `button`, `submit`, and `reset`.

--- a/src/stories/components/button/Button.stories.ts
+++ b/src/stories/components/button/Button.stories.ts
@@ -24,7 +24,7 @@ const meta = {
       tagName: component,
       exclude: ['form', 'name', 'value'],
       controls: {
-        variant: { control: { type: 'select' }, options: ['text', 'outlined', 'filled', 'raised', 'link'] },
+        variant: { control: { type: 'select' }, options: ['text', 'outlined', 'tonal', 'filled', 'raised', 'link'] },
         theme: { control: { type: 'select' }, options: GLOBAL_THEME_OPTIONS }
       }
     }),
@@ -55,6 +55,7 @@ export const Variants: Story = {
     return html`
       <forge-button>Text</forge-button>
       <forge-button variant="outlined">Outlined</forge-button>
+      <forge-button variant="tonal">Tonal</forge-button>
       <forge-button variant="filled">Filled</forge-button>
       <forge-button variant="raised">Raised</forge-button>
       <forge-button variant="link">Link</forge-button>

--- a/src/stories/components/icon-button/IconButton.stories.ts
+++ b/src/stories/components/icon-button/IconButton.stories.ts
@@ -51,7 +51,7 @@ const meta = {
       tagName: component,
       exclude: ['form', 'name', 'value', 'type'],
       controls: {
-        variant: { control: { type: 'select' }, options: ['icon', 'outlined', 'filled', 'raised'] },
+        variant: { control: { type: 'select' }, options: ['icon', 'outlined', 'tonal', 'filled', 'raised'] },
         theme: { control: { type: 'select' }, options: GLOBAL_THEME_OPTIONS },
         shape: { control: { type: 'select' }, options: ['circular', 'squared'] },
         density: { control: { type: 'select' }, options: ['small', 'medium', 'large'] }
@@ -60,7 +60,7 @@ const meta = {
   },
   args: {
     variant: 'icon',
-    theme: 'primary',
+    theme: 'default',
     disabled: false,
     dense: false,
     toggle: false,
@@ -86,6 +86,10 @@ export const Variants: Story = {
       </forge-icon-button>
 
       <forge-icon-button variant="outlined" aria-label="Outlined icon button">
+        <forge-icon name="favorite"></forge-icon>
+      </forge-icon-button>
+
+      <forge-icon-button variant="tonal" aria-label="Tonal icon button">
         <forge-icon name="favorite"></forge-icon>
       </forge-icon-button>
 
@@ -121,25 +125,28 @@ export const Themed: Story = {
   },
   render: ({ variant }) => {
     return html`
-      <forge-icon-button variant=${variant}>
+      <forge-icon-button variant=${variant} aria-label="Default theme icon button">
         <forge-icon name="forge_logo"></forge-icon>
       </forge-icon-button>
-      <forge-icon-button variant=${variant} theme="secondary">
+      <forge-icon-button variant=${variant} theme="primary" aria-label="Primary theme icon button">
         <forge-icon name="forge_logo"></forge-icon>
       </forge-icon-button>
-      <forge-icon-button variant=${variant} theme="tertiary">
+      <forge-icon-button variant=${variant} theme="secondary" aria-label="Secondary theme icon button">
         <forge-icon name="forge_logo"></forge-icon>
       </forge-icon-button>
-      <forge-icon-button variant=${variant} theme="success">
+      <forge-icon-button variant=${variant} theme="tertiary" aria-label="Tertiary theme icon button">
         <forge-icon name="forge_logo"></forge-icon>
       </forge-icon-button>
-      <forge-icon-button variant=${variant} theme="warning">
+      <forge-icon-button variant=${variant} theme="success" aria-label="Success theme icon button">
         <forge-icon name="forge_logo"></forge-icon>
       </forge-icon-button>
-      <forge-icon-button variant=${variant} theme="error">
+      <forge-icon-button variant=${variant} theme="warning" aria-label="Warning theme icon button">
         <forge-icon name="forge_logo"></forge-icon>
       </forge-icon-button>
-      <forge-icon-button variant=${variant} theme="info">
+      <forge-icon-button variant=${variant} theme="error" aria-label="Error theme icon button">
+        <forge-icon name="forge_logo"></forge-icon>
+      </forge-icon-button>
+      <forge-icon-button variant=${variant} theme="info" aria-label="Info theme icon button">
         <forge-icon name="forge_logo"></forge-icon>
       </forge-icon-button>
     `;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The `<forge-icon-button>` previously incorrectly set its default `theme` state to "primary" which doesn't allow for the theme to be truly using the "primary" theme color for the icon like the other built-in theme colors do. This was done because by default icon buttons will use `currentColor` to inherit the color for the icon, but the state layer and focus indicator both use the primary theme.

This change will reduce confusion by setting the default state to "default" instead, which enable the "primary" theme color to naturally just work as expected to fully style it correctly.
