### PR TITLE
fix(button): fix to properly wire up raised variant-specific tokens

### DIFF
--- a/src/lib/button/_core.scss
+++ b/src/lib/button/_core.scss
@@ -102,6 +102,8 @@
 }
 
 @mixin raised {
+  @include override(background, raised-background);
+  @include override(color, raised-color);
   @include override(shadow, raised-shadow);
 
   &:hover {
@@ -164,6 +166,8 @@
 }
 
 @mixin raised-disabled {
+  @include override(background, raised-disabled-background);
+  @include override(color, raised-disabled-color);
   @include override(shadow, raised-disabled-shadow);
 }
 

--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -100,9 +100,15 @@ forge-focus-indicator {
     }
   }
 
-  :host([theme='#{$theme}']:is([variant='filled'], [variant='raised'])) {
+  :host([theme='#{$theme}'][variant='filled']) {
     .forge-button {
       @include override(filled-color, theme.variable(on-#{$theme}), value);
+    }
+  }
+
+  :host([theme='#{$theme}'][variant='raised']) {
+    .forge-button {
+      @include override(raised-color, theme.variable(on-#{$theme}), value);
     }
   }
 
@@ -125,7 +131,7 @@ forge-focus-indicator {
 // Variants
 //
 
-:host(:is([variant='filled'], [variant='raised'])) {
+:host([variant='filled']) {
   .forge-button {
     @include filled;
   }
@@ -142,6 +148,14 @@ forge-focus-indicator {
 :host([variant='raised']) {
   .forge-button {
     @include raised;
+  }
+
+  forge-state-layer {
+    @include state-layer.provide-theme(
+      (
+        color: #{token(raised-color)}
+      )
+    );
   }
 }
 
@@ -231,7 +245,7 @@ forge-focus-indicator {
   }
 }
 
-:host(:not([anchor]):is([variant='filled'], [variant='raised'])[disabled]) {
+:host(:not([anchor])[variant='filled'][disabled]) {
   .forge-button {
     @include filled-disabled;
   }

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -94,6 +94,10 @@ declare global {
  * @cssproperty --forge-button-hover-shadow - The shadow of the button on hover.
  * @cssproperty --forge-button-active-shadow - The shadow of the button on active state.
  * @cssproperty --forge-button-cursor - The cursor type of the button.
+ * @cssproperty --forge-button-filled-background - The background color of the filled button.
+ * @cssproperty --forge-button-filled-disabled-background - The background color of the disabled filled button.
+ * @cssproperty --forge-button-filled-color - The text color of the filled button.
+ * @cssproperty --forge-button-filled-disabled-color - The text color of the disabled filled button.
  * @cssproperty --forge-button-raised-background - The background color of the raised button.
  * @cssproperty --forge-button-raised-disabled-background - The background color of the disabled raised button.
  * @cssproperty --forge-button-raised-color - The text color of the raised button.
@@ -102,8 +106,6 @@ declare global {
  * @cssproperty --forge-button-raised-hover-shadow - The shadow of the raised button on hover.
  * @cssproperty --forge-button-raised-active-shadow - The shadow of the raised button on active state.
  * @cssproperty --forge-button-raised-disabled-shadow - The shadow of the disabled raised button.
- * @cssproperty --forge-button-raised-transition-duration - The transition duration of the raised button.
- * @cssproperty --forge-button-raised-transition-timing - The transition timing of the raised button.
  * @cssproperty --forge-button-flat-background - The background color of the flat button.
  * @cssproperty --forge-button-flat-disabled-background - The background color of the disabled flat button.
  * @cssproperty --forge-button-flat-color - The text color of the flat button.

--- a/src/lib/core/styles/tokens/button/_tokens.scss
+++ b/src/lib/core/styles/tokens/button/_tokens.scss
@@ -58,6 +58,10 @@ $tokens: (
   filled-color: utils.module-val(button, filled-color, theme.variable(on-primary)),
   filled-disabled-color: utils.module-ref(button, filled-disabled-color, disabled-text-color),
   // Raised
+  raised-background: utils.module-ref(button, raised-background, primary-color),
+  raised-disabled-background: utils.module-ref(button, raised-disabled-background, disabled-color),
+  raised-color: utils.module-val(button, raised-color, theme.variable(on-primary)),
+  raised-disabled-color: utils.module-ref(button, raised-disabled-color, disabled-text-color),
   raised-shadow: utils.module-val(button, raised-shadow, elevation.value(2)),
   raised-hover-shadow: utils.module-val(button, raised-hover-shadow, elevation.value(4)),
   raised-active-shadow: utils.module-val(button, raised-active-shadow, elevation.value(8)),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Updated the button tokens to use variant-specific tokens for the "raised" variant instead of inheriting the "filled" tokens to reduce confusion and make it consistent with the other variants.

Additionally, fixed some CSS variable typos in the API docs.