### PR TITLE
docs: add temporary banner with link to v2.x docs

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -15,4 +15,52 @@
   .sidebar-header img {
     max-width: 100%;
   }
+
+  .forge-docs-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 32px;
+    background-color: #d1d5ed;
+    color: black;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding-inline: 16px;
+  }
+
+  .dark .forge-docs-banner {
+    background-color: #5f5741;
+    color: white;
+  }
+
+  .forge-docs-banner p {
+    margin: 0;
+    text-align: center;
+  }
+
+  div[id=root] {
+    position: fixed;
+    inset: 0;
+    inset-block-start: 32px;
+  }
+
+  div[id=root] > div {
+    height: calc(100dvh - 32px);
+  }
+
+  @media (max-width: 630px) {
+    div[id=root] {
+      inset-block-start: 56px;
+    }
+
+    div[id=root] > div {
+    height: calc(100dvh - 56px);
+  }
+
+    .forge-docs-banner {
+      height: 56px;
+    }
+  }
 </style>

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,5 +1,10 @@
 import { addons } from '@storybook/manager-api';
 
+const banner = document.createElement('div');
+banner.classList.add('forge-docs-banner');
+banner.innerHTML = '<p>You are currently viewing the latest v3.x docs. To view the legacy v2.x docs, click <a href="https://forge.tylerdev.io/version-2" target="_blank" rel="noreferrer noopener">here</a>.</p>';
+document.body.prepend(banner);
+
 addons.setConfig({
   sidebar: {
     showRoots: true,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Adds a temporary custom banner element to the storybook manager app at the top of the page to help users find the legacy v2.x docs more easily for the time being.

**Light theme:**
<img width="1034" alt="image" src="https://github.com/tyler-technologies-oss/forge/assets/2653457/9d11195e-0bab-4596-afdc-38299c070cfc">

**Dark theme:**
<img width="1034" alt="image" src="https://github.com/tyler-technologies-oss/forge/assets/2653457/c21425e3-6eba-41d8-a81a-e43d70e93084">

**Mobile support:**
<img width="516" alt="image" src="https://github.com/tyler-technologies-oss/forge/assets/2653457/cb89da41-3809-46b9-801f-6b46292e0082">
