### PR TITLE
fix(select): temp fix to remove disabled property from form associated mixin for TS2611 until TypeScript fixes accessor union bug

### DIFF
--- a/src/dev/pages/table/table.ts
+++ b/src/dev/pages/table/table.ts
@@ -3,7 +3,6 @@ import '@tylertech/forge/table';
 import '@tylertech/forge/table/forge-table.scss';
 import './table.scss';
 import { TextFieldComponentDelegate } from '@tylertech/forge/text-field';
-import { PositionPlacement } from '@tylertech/forge-core';
 import { tylIconChevronRight, tylIconDelete, tylIconEdit, tylIconMoreVert } from '@tylertech/tyler-icons/standard';
 import { ITableComponent, IColumnConfiguration, SortDirection, ISortedColumn, CellAlign, ITableTemplateBuilderResult, ITableSortMultipleEventData } from '@tylertech/forge/table';
 import { ButtonComponentDelegate } from '@tylertech/forge/button';
@@ -288,7 +287,7 @@ function getMenuColumnTemplate(rowIndex: number): HTMLElement {
   button.appendChild(icon);
 
   const menu = document.createElement('forge-menu');
-  menu.placement = 'bottom-right' as PositionPlacement;
+  menu.placement = 'bottom-end';
   menu.options = [
     { value: 'delete', label: 'Delete', leadingIcon: 'delete', leadingIconType: 'component' },
     { value: 'edit', label: 'Edit', leadingIcon: 'edit', leadingIconType: 'component' }

--- a/src/lib/core/mixins/form/with-form-associated.ts
+++ b/src/lib/core/mixins/form/with-form-associated.ts
@@ -113,9 +113,6 @@ export declare abstract class WithFormAssociationContract {
   public get name(): string;
   public set name(value: string);
 
-  public abstract get disabled(): boolean;
-  public abstract set disabled(value: boolean);
-
   public abstract get readonly(): boolean;
   public abstract set readonly(value: boolean);
 

--- a/src/lib/select/select/select.ts
+++ b/src/lib/select/select/select.ts
@@ -262,7 +262,7 @@ export class SelectComponent
   public declare placeholder: string;
 
   @coreProperty()
-  public declare readonly;
+  public declare readonly: boolean;
 
   public override get floatLabel(): boolean {
     return super.floatLabel;
@@ -287,7 +287,6 @@ export class SelectComponent
     this._core.syncFloatingLabelState();
   }
 
-  // @ts-ignore TS2611 - TODO: This is a getter/setter in the base class... TypeScript bug?
   public override get disabled(): boolean {
     return super.disabled;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
This is a temporary "fix" to just omit the `disabled` property in the `WithFormAssociation` mixin until TypeScript can fix this bug in how getter accessor properties are unioned.

For now, any classes that use the `WithFormAssociation` mixin will not be required to implement the `disabled` property, but it's likely that all instance will always have that property anyway.

Here is the TypeScript issue for tracking status:
https://github.com/microsoft/TypeScript/issues/58790