### PR TITLE
fix(theme): use correct error theme color in dark theme

### DIFF
--- a/src/lib/badge/badge.scss
+++ b/src/lib/badge/badge.scss
@@ -85,7 +85,7 @@
 // Map both "error" and "danger" for backwards compatibility with legacy "danger" theme
 :host(:not([strong]):is([theme='error'], [theme='danger'])) {
   .forge-badge {
-    @include override(background, theme.variable(error-container), value);
+    @include override(background, theme.variable(error-container-low), value);
     @include override(color, theme.variable(error), value);
   }
 }

--- a/src/lib/core/styles/tokens/theme/_tokens.status.scss
+++ b/src/lib/core/styles/tokens/theme/_tokens.status.scss
@@ -57,7 +57,7 @@ $tokens-dark: (
   on-success-container-low: #bed5a9,
   on-success-container: #bed5a9,
   on-success-container-high: color-palette.$white,
-  error: color-palette.$ruddy-pink-500,
+  error: color-palette.$ruddy-pink-200,
   error-container-minimum: #342f30,
   error-container-low: #433639,
   error-container: #5a4145,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Updates the `error` theme token to the `ruddy-pink-200` palette color.

Additionally, updated the badge error theme to properly use `error-container-low` for the background color to ensure passing contrast.

Fixes #648 
