### PR TITLE
feat(tokens): include color-emphasis tokens as part of the `forge-tokens.css` stylesheet

### DIFF
--- a/src/lib/core/styles/theme/_color-utils.scss
+++ b/src/lib/core/styles/theme/_color-utils.scss
@@ -42,7 +42,7 @@
 
   $minimumContrast: 3.1;
   $lightContrast: contrast-ratio($color, white);
-  $darkContrast: contrast-ratio($color, rgba(black 0.87));
+  $darkContrast: contrast-ratio($color, rgba(black, 0.87));
 
   @if $lightContrast < $minimumContrast and $darkContrast > $lightContrast {
     @return 'light';

--- a/src/lib/core/styles/theme/index.scss
+++ b/src/lib/core/styles/theme/index.scss
@@ -26,6 +26,15 @@
 }
 
 ///
+/// Emits custom property declarations for all color-emphasis tokens that used as part of the theme composition.
+///
+@mixin color-emphasis-properties {
+  @each $emphasis, $value in color-emphasis.$color-emphasis {
+    @include utils.declare-var(color-emphasis, $emphasis, math.div($value, 100%));
+  }
+}
+
+///
 /// Generates utility classes for each theme token as both `color` and `background-color` styles separately.
 ///
 @mixin classes {

--- a/src/lib/core/styles/tokens/theme/_token-utils.scss
+++ b/src/lib/core/styles/tokens/theme/_token-utils.scss
@@ -15,8 +15,6 @@
     @error 'The value for "#{$name}" must be a color type.';
   }
 
-  $surface-tone: color-utils.tone($surface);
-
   // The container colors are the provided color mixed with the surface color at lower emphasis levels
   $container-high: theme-utils.hexify($color, $surface, color-emphasis.value(medium-low));
   $container: theme-utils.hexify($color, $surface, color-emphasis.value(low));

--- a/src/lib/forge-tokens.scss
+++ b/src/lib/forge-tokens.scss
@@ -1,8 +1,14 @@
+@use './core/styles/theme';
 @use './core/styles/animation';
 @use './core/styles/border';
 @use './core/styles/elevation';
 @use './core/styles/shape';
 @use './core/styles/spacing';
+
+// Color emphasis tokens
+:root {
+  @include theme.color-emphasis-properties;
+}
 
 // Animation
 :root {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The color-emphasis token values are useful for consumers to use in their applications and/or libraries to ensure seamless integration with Forge. This change emits `--forge-color-emphasis-*` CSS variables for each color-emphasis token in the `forge-tokens.css` stylesheet.
