### PR TITLE
feat(dialog): automatically switch to fullscreen at the new `fullscreenThreshold` property value

### DIFF
--- a/src/dev/pages/dialog/dialog.ts
+++ b/src/dev/pages/dialog/dialog.ts
@@ -31,6 +31,7 @@ inlineDialog.addEventListener('forge-dialog-close', evt => console.log('[forge-d
 inlineDialog.addEventListener('forge-dialog-move-start', evt => console.log('[forge-dialog]', evt));
 inlineDialog.addEventListener('forge-dialog-move', evt => console.log('[forge-dialog]', evt));
 inlineDialog.addEventListener('forge-dialog-move-end', evt => console.log('[forge-dialog]', evt));
+inlineDialog.addEventListener('forge-dialog-fullscreen-change', evt => console.log('[forge-dialog]', evt));
 
 const showDynamicDialogButton = document.getElementById('show-dynamic-dialog-button');
 showDynamicDialogButton.addEventListener('click', () => openDynamicDialog());

--- a/src/lib/dialog/dialog-adapter.ts
+++ b/src/lib/dialog/dialog-adapter.ts
@@ -26,6 +26,8 @@ export interface IDialogAdapter extends IBaseAdapter<IDialogComponent> {
   showBackdrop(): void;
   addSurfaceClass(className: string): void;
   removeSurfaceClass(className: string): void;
+  addFullscreenListener(breakpoint: number, listener: (value: boolean) => void): void;
+  removeFullscreenListener(listener: (value: boolean) => void): void;
 }
 
 export class DialogAdapter extends BaseAdapter<IDialogComponent> implements IDialogAdapter {
@@ -33,6 +35,7 @@ export class DialogAdapter extends BaseAdapter<IDialogComponent> implements IDia
   private _surfaceElement: HTMLDivElement;
   private _backdropElement: IBackdropComponent;
   private _moveHandleElement: HTMLElement;
+  private _fullscreenMediaQuery: MediaQueryList | undefined;
 
   public triggerElement: HTMLElement | null;
 
@@ -201,5 +204,19 @@ export class DialogAdapter extends BaseAdapter<IDialogComponent> implements IDia
 
   public removeSurfaceClass(className: string): void {
     this._surfaceElement.classList.remove(className);
+  }
+
+  public addFullscreenListener(breakpoint: number, listener: (value: boolean) => void): void {
+    this._fullscreenMediaQuery = window.matchMedia(`(max-width: ${breakpoint}px)`);
+    this._fullscreenMediaQuery.addEventListener('change', event => listener(event.matches));
+
+    if (!this._component.fullscreen && this._fullscreenMediaQuery.matches) {
+      listener(true);
+    }
+  }
+
+  public removeFullscreenListener(listener: (value: boolean) => void): void {
+    this._fullscreenMediaQuery?.removeEventListener('change', event => listener(event.matches));
+    this._fullscreenMediaQuery = undefined;
   }
 }

--- a/src/lib/dialog/dialog-constants.ts
+++ b/src/lib/dialog/dialog-constants.ts
@@ -11,6 +11,7 @@ const observedAttributes = {
   PRESET: 'preset',
   PERSISTENT: 'persistent',
   FULLSCREEN: 'fullscreen',
+  FULLSCREEN_THRESHOLD: 'fullscreen-threshold',
   TRIGGER: 'trigger',
   MOVEABLE: 'moveable',
   MOVE_TARGET: 'move-target',
@@ -41,7 +42,8 @@ const events = {
   CLOSE: `${elementName}-close`,
   MOVE_START: `${elementName}-move-start`,
   MOVE: `${elementName}-move`,
-  MOVE_END: `${elementName}-move-end`
+  MOVE_END: `${elementName}-move-end`,
+  FULLSCREEN_CHANGE: `${elementName}-fullscreen-change`
 };
 
 const defaults = {
@@ -51,7 +53,8 @@ const defaults = {
   PRESET: 'dialog' as DialogPreset,
   SIZE_STRATEGY: 'content' as DialogSizeStrategy,
   POSITION_STRATEGY: 'viewport' as DialogPositionStrategy,
-  PLACEMENT: 'center' as DialogPlacement
+  PLACEMENT: 'center' as DialogPlacement,
+  FULLSCREEN_THRESHOLD: 599
 };
 
 export const DIALOG_CONSTANTS = {

--- a/src/lib/dialog/dialog-core.ts
+++ b/src/lib/dialog/dialog-core.ts
@@ -21,6 +21,7 @@ export interface IDialogCore {
   preset: DialogPreset;
   persistent: boolean;
   fullscreen: boolean;
+  fullscreenThreshold: number;
   trigger: string;
   triggerElement: HTMLElement | null;
   positionStrategy: DialogPositionStrategy;
@@ -40,6 +41,8 @@ export class DialogCore implements IDialogCore {
   private _preset: DialogPreset = DIALOG_CONSTANTS.defaults.PRESET;
   private _persistent = false;
   private _fullscreen = false;
+  private _fullscreenThreshold = DIALOG_CONSTANTS.defaults.FULLSCREEN_THRESHOLD;
+  private _originalFullscreenValue: boolean | undefined;
   private _trigger = '';
   private _moveable = false;
   private _sizeStrategy: DialogSizeStrategy = DIALOG_CONSTANTS.defaults.SIZE_STRATEGY;
@@ -51,11 +54,12 @@ export class DialogCore implements IDialogCore {
   private _backdropDismissListener: EventListener = this._onBackdropDismiss.bind(this);
   private _dialogFormSubmitListener: EventListener = this._onDialogFormSubmit.bind(this);
   private _triggerClickListener: EventListener = this._onTriggerClick.bind(this);
+  private _fullscreenListener: (value: boolean) => void = this._onFullscreenChange.bind(this);
 
   constructor(public _adapter: IDialogAdapter) {}
 
   public initialize(): void {
-    this._adapter.tryApplyGlobalConfiguration(['animationType', 'positionStrategy', 'sizeStrategy', 'persistent', 'moveable']);
+    this._adapter.tryApplyGlobalConfiguration(['animationType', 'positionStrategy', 'sizeStrategy', 'persistent', 'moveable', 'fullscreenThreshold']);
 
     if (this._trigger && !this._adapter.triggerElement) {
       this._adapter.tryLocateTriggerElement(this._trigger);
@@ -121,6 +125,11 @@ export class DialogCore implements IDialogCore {
       this._initializeMoveController();
     }
 
+    if (!this._fullscreen && this._fullscreenThreshold > 0) {
+      this._originalFullscreenValue = this._fullscreen;
+      this._adapter.addFullscreenListener(this._fullscreenThreshold, this._fullscreenListener);
+    }
+
     this._adapter.dispatchHostEvent(new CustomEvent(DIALOG_CONSTANTS.events.OPEN, { bubbles: true, composed: true }));
   }
 
@@ -132,6 +141,12 @@ export class DialogCore implements IDialogCore {
     DismissibleStack.instance.remove(this._adapter.hostElement);
 
     await this._adapter.hide();
+
+    // Reset the fullscreen value to the original value if it was changed internally by our media query listener
+    if (typeof this._originalFullscreenValue === 'boolean') {
+      this.fullscreen = this._originalFullscreenValue;
+    }
+    this._originalFullscreenValue = undefined;
 
     if (this._moveController) {
       this._destroyMoveController();
@@ -177,6 +192,12 @@ export class DialogCore implements IDialogCore {
     if (isDialogSubmitter) {
       this._tryClose();
     }
+  }
+
+  private _onFullscreenChange(value: boolean): void {
+    this.fullscreen = value;
+    const event = new CustomEvent(DIALOG_CONSTANTS.events.FULLSCREEN_CHANGE, { bubbles: true, composed: true, detail: value });
+    this._adapter.dispatchHostEvent(event);
   }
 
   private _tryClose(): void {
@@ -298,6 +319,22 @@ export class DialogCore implements IDialogCore {
     if (this._fullscreen !== value) {
       this._fullscreen = value;
       this._adapter.toggleHostAttribute(DIALOG_CONSTANTS.attributes.FULLSCREEN, this._fullscreen);
+    }
+  }
+
+  public get fullscreenThreshold(): number {
+    return this._fullscreenThreshold;
+  }
+  public set fullscreenThreshold(value: number) {
+    if (this._fullscreenThreshold !== value) {
+      this._fullscreenThreshold = value;
+
+      if (this._adapter.isConnected && this._open && !this._fullscreen && this._fullscreenThreshold > 0) {
+        this._adapter.removeFullscreenListener(this._fullscreenListener);
+        this._adapter.addFullscreenListener(this._fullscreenThreshold, this._fullscreenListener);
+      }
+
+      this._adapter.setHostAttribute(DIALOG_CONSTANTS.attributes.FULLSCREEN_THRESHOLD, this._fullscreenThreshold.toString());
     }
   }
 

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -1,4 +1,4 @@
-import { attachShadowTemplate, coerceBoolean, customElement, coreProperty } from '@tylertech/forge-core';
+import { attachShadowTemplate, coerceBoolean, customElement, coreProperty, coerceNumber } from '@tylertech/forge-core';
 import { BackdropComponent } from '../backdrop';
 import { BaseComponent } from '../core/base/base-component';
 import { IWithDefaultAria, WithDefaultAria } from '../core/mixins/internals/with-default-aria';
@@ -33,6 +33,7 @@ export interface IDialogProperties {
   preset: DialogPreset;
   persistent: boolean;
   fullscreen: boolean;
+  fullscreenThreshold: number;
   trigger: string;
   triggerElement: HTMLElement | null;
   positionStrategy: DialogPositionStrategy;
@@ -58,6 +59,7 @@ declare global {
     'forge-dialog-move-start': CustomEvent<IDialogMoveStartEventData>;
     'forge-dialog-move': CustomEvent<IDialogMoveEventData>;
     'forge-dialog-move-end': CustomEvent<void>;
+    'forge-dialog-fullscreen-change': CustomEvent<boolean>;
   }
 }
 
@@ -75,6 +77,7 @@ declare global {
  * @property {DialogPreset} [preset="dialog"] - The preset design that the dialog will apply.
  * @property {boolean} [persistent=false] - Indicates whether the dialog is dismissible via escape and backdrop click or not.
  * @property {boolean} [fullscreen=false] - Indicates whether the dialog is fullscreen or not.
+ * @property {number} [fullscreenThreshold=599] - The screen width at which the dialog will switch to fullscreen.
  * @property {string} trigger - The selector of the element that triggers the dialog.
  * @property {HTMLElement | null} [triggerElement=null] - The element that triggers the dialog.
  * @property {boolean} [moveable=false] - Indicates whether the dialog is moveable or not.
@@ -87,6 +90,7 @@ declare global {
  * @globalconfig sizeStrategy
  * @globalconfig persistent
  * @globalconfig moveable
+ * @globalconfig fullscreenThreshold
  *
  * @attribute {boolean} [open=false] - Indicates whether the dialog is open.
  * @attribute {DialogMode} [mode="modal"] - The mode of the dialog.
@@ -95,6 +99,7 @@ declare global {
  * @attribute {DialogPreset} [preset="dialog"] - The preset design that the dialog will apply.
  * @attribute {boolean} [persistent=false] - Indicates whether the dialog is dismissible via escape and backdrop click or not.
  * @attribute {boolean} [fullscreen=false] - Indicates whether the dialog is fullscreen or not.
+ * @attribute {number} [fullscreen-threshold=599] - The screen width at which the dialog will switch to fullscreen.
  * @attribute {string} trigger - The selector of the element that triggers the dialog.
  * @attribute {boolean} [moveable=false] - Indicates whether the dialog is moveable or not.
  * @attribute {DialogPositionStrategy} [positionStrategy="viewport"] - Controls whether the dialog is rendered relative to the viewport its nearest containing block.
@@ -107,6 +112,7 @@ declare global {
  * @event {CustomEvent<IDialogMoveStartEventData>} forge-dialog-move-start - Dispatched when the dialog is first moved.
  * @event {CustomEvent<IDialogMoveEventData>} forge-dialog-move - Dispatched when the dialog is being moved.
  * @event {CustomEvent<void>} forge-dialog-move-end - Dispatched when the dialog is done being moved.
+ * @event {CustomEvent<boolean>} forge-dialog-fullscreen-change - Dispatched when the dialog's fullscreen state changes.
  *
  * @cssproperty --forge-dialog-background - The background color of the dialog.
  * @cssproperty --forge-dialog-shape - The shape of the dialog.
@@ -228,6 +234,9 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
       case DIALOG_CONSTANTS.observedAttributes.FULLSCREEN:
         this.fullscreen = coerceBoolean(newValue);
         break;
+      case DIALOG_CONSTANTS.observedAttributes.FULLSCREEN_THRESHOLD:
+        this.fullscreenThreshold = newValue == null ? DIALOG_CONSTANTS.defaults.FULLSCREEN_THRESHOLD : coerceNumber(newValue);
+        break;
       case DIALOG_CONSTANTS.observedAttributes.TRIGGER:
         this.trigger = newValue;
         break;
@@ -266,6 +275,9 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
 
   @coreProperty()
   public declare fullscreen: boolean;
+
+  @coreProperty()
+  public declare fullscreenThreshold: number;
 
   @coreProperty()
   public declare trigger: string;

--- a/src/stories/components/dialog/Dialog.mdx
+++ b/src/stories/components/dialog/Dialog.mdx
@@ -51,6 +51,18 @@ forge-scaffold {
 }
 ```
 
+### Fullscreen
+
+Dialogs can be displayed in fullscreen mode by setting the `fullscreen` property or attribute. This will cause the dialog to fit the viewport height and width, and is
+typically used on smaller viewports and mobile devices.
+
+Additionally, the dialog will automatically adjust itself to be fullscreen when the viewport width is less than `600px`. This is to ensure that the dialog is always usable
+on smaller screens, and to alleviate the burden for developers to manage this manually since it is a common desired behavior.
+
+If you need to adjust the breakpoint at which the dialog switches to fullscreen mode, you can use the `fullscreenThreshold` property to set a custom breakpoint in pixels. Or
+if you'd like to disable the automatic fullscreen functionality entirely, you can set the `fullscreenThreshold` property to `0` and the dialog will never automatically switch
+to fullscreen unless you explicitly set the `fullscreen` attribute.
+
 ### Focus Trap
 
 The `<forge-dialog>` uses the native [&lt;dialog&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) element under the hood, which

--- a/src/stories/components/dialog/Dialog.stories.ts
+++ b/src/stories/components/dialog/Dialog.stories.ts
@@ -33,7 +33,8 @@ const meta = {
         placement: {
           control: 'select',
           options: ['custom', 'center', 'top', 'right', 'bottom', 'left', 'top-right', 'top-left', 'bottom-right', 'bottom-left']
-        }
+        },
+        fullscreenThreshold: { control: 'number' }
       }
     })
   },
@@ -41,6 +42,7 @@ const meta = {
     open: false,
     persistent: false,
     fullscreen: false,
+    fullscreenThreshold: DIALOG_CONSTANTS.defaults.FULLSCREEN_THRESHOLD,
     moveable: false,
     mode: DIALOG_CONSTANTS.defaults.MODE,
     type: DIALOG_CONSTANTS.defaults.TYPE,

--- a/src/stories/components/dialog/Dialog.ts
+++ b/src/stories/components/dialog/Dialog.ts
@@ -21,6 +21,7 @@ const beforeCloseEventAction = action('forge-dialog-before-close');
 const moveStartEventAction = action('forge-dialog-move-start');
 const moveEventAction = action('forge-dialog-move');
 const moveEndEventAction = action('forge-dialog-move-end');
+const fullscreenChangeAction = action('forge-dialog-fullscreen-change');
 
 export const Dialog = (args: ArgTypes) => {
   IconRegistry.define(tylIconClose);
@@ -43,6 +44,7 @@ export const Dialog = (args: ArgTypes) => {
   dialog.addEventListener('forge-dialog-move-start', moveStartEventAction);
   dialog.addEventListener('forge-dialog-move', moveEventAction);
   dialog.addEventListener('forge-dialog-move-end', moveEndEventAction);
+  dialog.addEventListener('forge-dialog-fullscreen-change', fullscreenChangeAction);
   container.appendChild(dialog);
 
   const content = html`

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -1,6 +1,6 @@
 import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { fromRollup } from '@web/dev-server-rollup';
-import { sendKeysPlugin, sendMousePlugin } from '@web/test-runner-commands/plugins';
+import { sendKeysPlugin, sendMousePlugin, setViewportPlugin } from '@web/test-runner-commands/plugins';
 import { fileURLToPath } from 'url';
 import { readdirSync } from 'fs';
 import { compileString } from 'sass';
@@ -64,6 +64,7 @@ export default {
   plugins: [
     sendKeysPlugin(),
     sendMousePlugin(),
+    setViewportPlugin(),
     inlineScss(),
     esbuildPlugin({
       ts: true,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Added default behavior to automatically switch the dialog to fullscreen at a specific media query breakpoint of `599px`. This breakpoint threshold can be controlled via the new `fullscreenThreshold` property/attribute if desired. Setting the threshold to a value of `0` disables this new functionality if you don't want the dialog to adjust itself automatically.

## Additional information
I did not use a CSS-based media query for this because the value cannot be adjusted without rewriting the CSS styles that are applied to the shadow DOM dynamically.
