### PR TITLE
fix(tab): add missing inline padding

### DIFF
--- a/src/lib/core/styles/tokens/tabs/tab/_tokens.scss
+++ b/src/lib/core/styles/tokens/tabs/tab/_tokens.scss
@@ -9,6 +9,8 @@ $tokens: (
   inactive-color: utils.module-val(tab, inactive-color, theme.variable(text-medium)),
   height: utils.module-val(tab, height, 48px),
   stacked-height: utils.module-val(tab, stacked-height, 64px),
+  padding-block: utils.module-val(tab, padding-block, 0),
+  padding-inline: utils.module-val(tab, padding-inline, spacing.variable(medium)),
   // Disabled
   disabled-opacity: utils.module-val(tab, disabled-opacity, 0.38),
   // Indicator
@@ -29,7 +31,11 @@ $tokens: (
   container-shape: utils.module-val(tab, container-shape, 0),
   // Content
   content-height: utils.module-ref(tab, content-height, height),
+  content-spacing: utils.module-val(tab, content-spacing, spacing.variable(xxsmall)),
   content-padding: utils.module-val(tab, content-padding, spacing.variable(xxsmall)),
+  content-padding-block: utils.module-ref(tab, content-padding-block, content-padding),
+  content-padding-inline: utils.module-ref(tab, content-padding-inline, content-padding),
+  content-padding-inline-secondary: utils.module-val(tab, content-padding-inline-secondary, spacing.variable(medium)),
   // Icon
   active-focus-icon-color: utils.module-ref(tab, active-focus-icon-color, active-color),
   active-hover-icon-color: utils.module-ref(tab, active-hover-icon-color, active-color),

--- a/src/lib/tabs/tab/_core.scss
+++ b/src/lib/tabs/tab/_core.scss
@@ -34,7 +34,8 @@
   text-decoration: none;
   width: 100%;
   position: relative;
-  padding: 0;
+  padding-block: #{token(padding-block)};
+  padding-inline: #{token(padding-inline)};
   margin: 0;
   z-index: 0; // Ensure this is a stacking context so the indicator displays
   background-color: #{token(container-color)};
@@ -69,6 +70,12 @@
       color: #{token(hover-icon-color)};
     }
   }
+}
+
+@mixin tab-secondary {
+  @include override(indicator-height, secondary-indicator-height);
+  @include override(indicator-shape, secondary-indicator-shape);
+  @include override(padding-inline, 0, value);
 }
 
 @mixin focus {
@@ -117,10 +124,11 @@
   justify-content: center;
   white-space: nowrap;
   transition: 150ms color linear;
-  max-height: calc(#{token(content-height)} + 2 * #{token(content-padding)});
+  max-height: calc(#{token(content-height)} + 2 * #{token(content-padding-block)});
   min-height: #{token(content-height)};
-  padding: #{token(content-padding)} calc(2 * #{token(content-padding)});
-  gap: #{token(content-padding)};
+  padding-block: #{token(content-padding-block)};
+  padding-inline: #{token(content-padding-inline)};
+  gap: #{token(content-spacing)};
 }
 
 @mixin label {
@@ -141,6 +149,8 @@
 }
 
 @mixin content-secondary {
+  @include override(content-padding-inline, content-padding-inline-secondary);
+
   width: 100%;
 }
 
@@ -149,6 +159,8 @@
 }
 
 @mixin vertical {
+  @include override(padding-inline, 0, value);
+
   width: 100%;
   flex-direction: row;
   border-bottom: none;

--- a/src/lib/tabs/tab/tab.scss
+++ b/src/lib/tabs/tab/tab.scss
@@ -174,8 +174,7 @@ forge-state-layer {
 
 :host([secondary]) {
   .forge-tab {
-    @include override(indicator-height, secondary-indicator-height);
-    @include override(indicator-shape, secondary-indicator-shape);
+    @include tab-secondary;
   }
 
   .content {

--- a/src/lib/tabs/tab/tab.ts
+++ b/src/lib/tabs/tab/tab.ts
@@ -51,30 +51,47 @@ declare global {
  *
  * @event {CustomEvent<void>} forge-tab-select - Dispatched when the tab is selected. This event bubbles and it can be useful to capture it on the `<forge-tab-bar>` element.
  *
- * @cssproperty --forge-tab-indicator-color - The color of the tab indicator. Defaults to the primary theme.
- * @cssproperty --forge-tab-indicator-height - The height of the tab indicator.
- * @cssproperty --forge-tab-indicator-shape - The shape of the tab indicator.
- * @cssproperty --forge-tab-container-color - The color of the tab container. Defaults to the surface theme.
+ * @cssproperty --forge-tab-active-color - The primary color of the contents when active.
+ * @cssproperty --forge-tab-inactive-color - The primary color of the contents when inactive.
  * @cssproperty --forge-tab-height - The height of the tab.
- * @cssproperty --forge-tab-shape - The shape of the tab.
+ * @cssproperty --forge-tab-stacked-height - The height of the tab when stacked.
+ * @cssproperty --forge-tab-padding-block - The block space between the tab contents and the bounds of the tab.
+ * @cssproperty --forge-tab-padding-inline - The inline space between the tab contents and the bounds of the tab.
  * @cssproperty --forge-tab-disabled-opacity - The opacity of the tab when disabled.
- * @cssproperty --forge-tab-active-focus-icon-color - The color of the icon when the tab is active and focused. Defaults to the primary theme.
- * @cssproperty --forge-tab-active-hover-icon-color - The color of the icon when the tab is active and hovered. Defaults to the primary theme.
- * @cssproperty --forge-tab-active-icon-color - The color of the icon when the tab is active. Defaults to the primary theme.
- * @cssproperty --forge-tab-active-pressed-icon-color - The color of the icon when the tab is active and pressed. Defaults to the primary theme.
+ * @cssproperty --forge-tab-indicator-color - The color of the active tab indicator.
+ * @cssproperty --forge-tab-indicator-height - The height of the active tab indicator.
+ * @cssproperty --forge-tab-indicator-shape - The shape of the active tab indicator.
+ * @cssproperty --forge-tab-vertical-indicator-shape - The shape of the active tab indicator when vertical.
+ * @cssproperty --forge-tab-secondary-indicator-height - The height of the secondary tab indicator.
+ * @cssproperty --forge-tab-secondary-indicator-shape - The shape of the secondary tab indicator.
+ * @cssproperty --forge-tab-inverted-indicator-shape - The shape of the active tab indicator when inverted.
+ * @cssproperty --forge-tab-vertical-inverted-indicator-shape - The shape of the active tab indicator when vertical and inverted.
+ * @cssproperty --forge-tab-container-color - The color of the tab container.
+ * @cssproperty --forge-tab-container-height - The height of the tab container.
+ * @cssproperty --forge-tab-container-shape - The shape of the tab container.
+ * @cssproperty --forge-tab-content-height - The height of the tab content.
+ * @cssproperty --forge-tab-content-spacing - The spacing between tab contents.
+ * @cssproperty --forge-tab-content-padding - The padding value for both block and inline of the tab content.
+ * @cssproperty --forge-tab-content-padding-block - The block padding of the tab content.
+ * @cssproperty --forge-tab-content-padding-inline - The inline padding of the tab content.
+ * @cssproperty --forge-tab-content-padding-inline-secondary - The inline padding of the tab content when secondary.
+ * @cssproperty --forge-tab-active-focus-icon-color - The color of the icon when the tab is active and focused.
+ * @cssproperty --forge-tab-active-hover-icon-color - The color of the icon when the tab is active and hovered.
+ * @cssproperty --forge-tab-active-icon-color - The color of the icon when the tab is active.
+ * @cssproperty --forge-tab-active-pressed-icon-color - The color of the icon when the tab is active and pressed.
  * @cssproperty --forge-tab-icon-size - The size of the icon.
- * @cssproperty --forge-tab-focus-icon-color - The color of the icon when the tab is focused. Defaults to the text-on-background theme.
- * @cssproperty --forge-tab-hover-icon-color - The color of the icon when the tab is hovered. Defaults to the text-on-background theme.
- * @cssproperty --forge-tab-icon-color - The color of the icon. Defaults to the text-on-background theme.
- * @cssproperty --forge-tab-pressed-icon-color - The color of the icon when the tab is pressed. Defaults to the text-on-background theme.
- * @cssproperty --forge-tab-active-focus-label-text-color - The color of the label text when the tab is active and focused. Defaults to the primary theme.
- * @cssproperty --forge-tab-active-hover-label-text-color - The color of the label text when the tab is active and hovered. Defaults to the primary theme.
- * @cssproperty --forge-tab-active-label-text-color - The color of the label text when the tab is active. Defaults to the primary theme.
- * @cssproperty --forge-tab-active-pressed-label-text-color - The color of the label text when the tab is active and pressed. Defaults to the primary theme.
- * @cssproperty --forge-tab-focus-label-text-color - The color of the label text when the tab is focused. Defaults to the text-on-background theme.
- * @cssproperty --forge-tab-hover-label-text-color - The color of the label text when the tab is hovered. Defaults to the text-on-background theme.
- * @cssproperty --forge-tab-label-text-color - The color of the label text. Defaults to the text-on-background theme.
- * @cssproperty --forge-tab-pressed-label-text-color - The color of the label text when the tab is pressed. Defaults to the text-on-background theme.
+ * @cssproperty --forge-tab-focus-icon-color - The color of the icon when the tab is focused.
+ * @cssproperty --forge-tab-hover-icon-color - The color of the icon when the tab is hovered.
+ * @cssproperty --forge-tab-icon-color - The color of the icon.
+ * @cssproperty --forge-tab-pressed-icon-color - The color of the icon when the tab is pressed.
+ * @cssproperty --forge-tab-active-focus-label-text-color - The color of the label text when the tab is active and focused.
+ * @cssproperty --forge-tab-active-hover-label-text-color - The color of the label text when the tab is active and hovered.
+ * @cssproperty --forge-tab-active-label-text-color - The color of the label text when the tab is active.
+ * @cssproperty --forge-tab-active-pressed-label-text-color - The color of the label text when the tab is active and pressed.
+ * @cssproperty --forge-tab-focus-label-text-color - The color of the label text when the tab is focused.
+ * @cssproperty --forge-tab-hover-label-text-color - The color of the label text when the tab is hovered.
+ * @cssproperty --forge-tab-label-text-color - The color of the label text.
+ * @cssproperty --forge-tab-pressed-label-text-color - The color of the label text when the tab is pressed.
  *
  * @csspart container - The tab container.
  * @csspart content - The tab content container.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
When rendered in small containers, or when using the `clustered` mode, tabs did not have enough space in the inline axis (horizontally by default) which caused the tab contents to be too close to each other in these scenarios. This was a regression from the 2.x to 3.0 version.

This change ensures that the default "primary" variant has `16px` of `padding-inline` set on the tab container, whereas in "secondary" mode the padding moves from the tab container to around the tab contents. This is done to ensure that the active tab indicator in both of these modes spans to the correct element.

## Additional information
Additionally, I noticed that the CSS custom property docs for the tab were incorrect and I updated those with this change.
