### PR TITLE
fix(button-toggle): relax the generic type on the event data interfaces to `any`

### DIFF
--- a/src/lib/button-toggle/button-toggle-group/button-toggle-group-constants.ts
+++ b/src/lib/button-toggle/button-toggle-group/button-toggle-group-constants.ts
@@ -42,5 +42,5 @@ export const BUTTON_TOGGLE_GROUP_CONSTANTS = {
   events
 };
 
-export type IButtonToggleGroupChangeEventData<T = unknown> = T;
+export type IButtonToggleGroupChangeEventData<T = any> = T;
 export type ButtonToggleGroupTheme = Theme;

--- a/src/lib/button-toggle/button-toggle/button-toggle-constants.ts
+++ b/src/lib/button-toggle/button-toggle/button-toggle-constants.ts
@@ -25,7 +25,7 @@ export const BUTTON_TOGGLE_CONSTANTS = {
   events
 };
 
-export interface IButtonToggleSelectEventData<T = unknown> {
+export interface IButtonToggleSelectEventData<T = any> {
   value: T;
   selected: boolean;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
While I would prefer to keep `unknown` since that is technically more correct, `any` is still appropriate, and it helps alleviate some friction in framework bindings such as in Angular where you cannot access the value inline due to type conflicts. This requires the use of `$any()` in some cases.