### PR TITLE
feat(shape): enable use of `--forge-shape-factor` to uniformly control shape tokens via multiplier

### DIFF
--- a/src/lib/core/styles/shape/index.scss
+++ b/src/lib/core/styles/shape/index.scss
@@ -23,7 +23,8 @@
 /// Gets a CSS custom property declaration for a specific shape token, with its token value as the fallback value.
 ///
 @function variable($key, $prefix: config.$prefix) {
-  @return utils.variable(shape, tokens.$tokens, $key, $prefix);
+  $shape-factor-var: utils.create-var(shape, factor, 1);
+  @return calc(utils.variable(shape, tokens.$tokens, $key, $prefix) * $shape-factor-var);
 }
 
 ///


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Updates the shape token references in all components to use a `calc()` with a new `--forge-shape-factor` multiplier token to allow for uniformly scaling the shape token values.

The utility of this is for either easily setting all `border-radius` values to `0` or to scale them up or down relative to their default value. The "full" and "round" shape tokens would likely be manually adjusted since they are kind of "presets" in a way, but they would also be affected by this.

## Additional information
This could be useful for branding applications potentially, or demonstrations of the tokens, but otherwise we should consider whether this brings enough value to warrant the `calc()` overhead...
