### PR TITLE
feat(tooltip): CSS-Only tooltip

### DIFF
--- a/packages/forge/.storybook/preview-global.scss
+++ b/packages/forge/.storybook/preview-global.scss
@@ -33,3 +33,4 @@
 @use '../src/lib/switch/forge-switch.scss';
 @use '../src/lib/table/forge-table.scss';
 @use '../src/lib/toolbar/forge-toolbar.scss';
+@use '../src/lib/tooltip/forge-tooltip.scss';

--- a/packages/forge/src/dev/pages/tooltip/tooltip.ejs
+++ b/packages/forge/src/dev/pages/tooltip/tooltip.ejs
@@ -27,6 +27,12 @@
       </forge-tooltip>
     </div>
   </section>
+  <section class="vert">
+    <h3 class="forge-typography--heading2">CSS Only</h3>
+    <div class="forge-tooltip" data-text="CSS-Only tooltip" style="width: fit-content;">
+      <span style="text-decoration: underline dotted;">Hover me</span>
+    </div>
+  </section>
 </div>
 
 <script type="module" src="tooltip.ts"></script>

--- a/packages/forge/src/dev/pages/tooltip/tooltip.ejs
+++ b/packages/forge/src/dev/pages/tooltip/tooltip.ejs
@@ -29,8 +29,19 @@
   </section>
   <section class="vert">
     <h3 class="forge-typography--heading2">CSS Only</h3>
-    <div class="forge-tooltip" data-text="CSS-Only tooltip" style="width: fit-content;">
-      <span style="text-decoration: underline dotted;">Hover me</span>
+    <div style="display: flex; gap: 48px; align-items: center; justify-content: center; padding: 64px;">
+      <div class="forge-tooltip forge-tooltip--left" data-text="Left tooltip" tabindex="0" style="width: fit-content;">
+        <span style="text-decoration: underline dotted;">Left</span>
+      </div>
+      <div class="forge-tooltip forge-tooltip--top" data-text="Top tooltip" tabindex="0" style="width: fit-content;">
+        <span style="text-decoration: underline dotted;">Top</span>
+      </div>
+      <div class="forge-tooltip forge-tooltip--bottom" data-text="Bottom tooltip" tabindex="0" style="width: fit-content;">
+        <span style="text-decoration: underline dotted;">Bottom</span>
+      </div>
+      <div class="forge-tooltip" data-text="Right tooltip (default)" tabindex="0" style="width: fit-content;">
+        <span style="text-decoration: underline dotted;">Right</span>
+      </div>
     </div>
   </section>
 </div>

--- a/packages/forge/src/dev/pages/tooltip/tooltip.ts
+++ b/packages/forge/src/dev/pages/tooltip/tooltip.ts
@@ -1,6 +1,7 @@
 import '$src/shared';
 import '@tylertech/forge/button';
 import '@tylertech/forge/tooltip';
+import '@tylertech/forge/tooltip/forge-tooltip.scss';
 import './tooltip.scss';
 import { ITooltipComponent } from '@tylertech/forge/tooltip';
 import { ISelectComponent } from '@tylertech/forge/select';

--- a/packages/forge/src/lib/core/styles/tokens/tooltip/_tokens.scss
+++ b/packages/forge/src/lib/core/styles/tokens/tooltip/_tokens.scss
@@ -18,7 +18,8 @@ $tokens: (
   elevation: utils.module-val(tooltip, elevation, theme.variable(surface-bright-shadow)),
   content-align: utils.module-val(tooltip, content-align, center),
   // Border
-  border-width: utils.module-val(tooltip, border-width, 0),
+  // Unit required: this token is summed with lengths in calc(), and calc() rejects unitless 0.
+  border-width: utils.module-val(tooltip, border-width, 0px),
   border-style: utils.module-val(tooltip, border-style, solid),
   border-color: utils.module-val(tooltip, border-color, theme.variable(outline)),
   // Animation

--- a/packages/forge/src/lib/tooltip/_animations.scss
+++ b/packages/forge/src/lib/tooltip/_animations.scss
@@ -8,6 +8,18 @@
 
   to {
     opacity: 1;
-    transform: translateX(0) translateY(0);
+    transform: translateX(0) translateY(#{token(slideout-y, custom)});
+  }
+}
+
+@keyframes slidein-arrow {
+  from {
+    opacity: 0;
+    transform: translate(#{token(slidein-x, custom)}) translateY(#{token(slidein-y, custom)}) rotate(#{token(arrow-rotation, custom)});
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(0) translateY(#{token(slideout-y, custom)}) rotate(#{token(arrow-rotation, custom)});
   }
 }

--- a/packages/forge/src/lib/tooltip/_animations.scss
+++ b/packages/forge/src/lib/tooltip/_animations.scss
@@ -8,18 +8,18 @@
 
   to {
     opacity: 1;
-    transform: translateX(0) translateY(#{token(slideout-y, custom)});
+    transform: translateX(#{token(slideout-x, custom)}) translateY(#{token(slideout-y, custom)});
   }
 }
 
 @keyframes slidein-arrow {
   from {
     opacity: 0;
-    transform: translate(#{token(slidein-x, custom)}) translateY(#{token(slidein-y, custom)}) rotate(#{token(arrow-rotation, custom)});
+    transform: translateX(#{token(slidein-x, custom)}) translateY(#{token(slidein-y, custom)}) rotate(#{token(arrow-rotation, custom)});
   }
 
   to {
     opacity: 1;
-    transform: translate(0) translateY(#{token(slideout-y, custom)}) rotate(#{token(arrow-rotation, custom)});
+    transform: translateX(#{token(slideout-x, custom)}) translateY(#{token(slideout-y, custom)}) rotate(#{token(arrow-rotation, custom)});
   }
 }

--- a/packages/forge/src/lib/tooltip/_core.scss
+++ b/packages/forge/src/lib/tooltip/_core.scss
@@ -36,6 +36,10 @@
   animation-fill-mode: forwards;
 }
 
+@function arrow-inset($offset: null) {
+  @return if($offset, calc(#{token(border-width)} + #{$offset}), token(border-width));
+}
+
 @mixin arrow {
   position: absolute;
   contain: strict;
@@ -51,28 +55,28 @@
   clip-path: #{token(arrow-clip-path, custom)};
 }
 
-@mixin arrow-placement-top {
+@mixin arrow-placement-top($offset: null) {
   @include override(arrow-rotation, arrow-top-rotation);
 
-  margin-block-end: #{token(border-width)};
+  margin-block-end: arrow-inset($offset);
 }
 
-@mixin arrow-placement-right {
+@mixin arrow-placement-right($offset: null) {
   @include override(arrow-rotation, arrow-right-rotation);
 
-  margin-inline-start: #{token(border-width)};
+  margin-inline-start: arrow-inset($offset);
 }
 
-@mixin arrow-placement-bottom {
+@mixin arrow-placement-bottom($offset: null) {
   @include override(arrow-rotation, arrow-bottom-rotation);
 
-  margin-block-start: #{token(border-width)};
+  margin-block-start: arrow-inset($offset);
 }
 
-@mixin arrow-placement-left {
+@mixin arrow-placement-left($offset: null) {
   @include override(arrow-rotation, arrow-left-rotation);
 
-  margin-inline-end: #{token(border-width)};
+  margin-inline-end: arrow-inset($offset);
 }
 
 @mixin visually-hidden {

--- a/packages/forge/src/lib/tooltip/build.json
+++ b/packages/forge/src/lib/tooltip/build.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../node_modules/@tylertech/forge-cli/config/build-schema.json",
+  "extends": "../build.json",
+  "stylesheets": ["./forge-tooltip.scss"]
+}

--- a/packages/forge/src/lib/tooltip/forge-tooltip.scss
+++ b/packages/forge/src/lib/tooltip/forge-tooltip.scss
@@ -1,0 +1,76 @@
+@use './core' as *;
+@use './animations';
+@use '../core/styles/typography';
+
+.forge-tooltip {
+  @include tokens;
+  #{declare(slidein-x)}: -10px;
+  #{declare(slidein-y)}: -50%;
+  #{declare(slideout-y)}: -50%;
+  #{declare(right-margin)}: calc(100% + 6px);
+  #{declare(arrow-clip-path)}: polygon(0 0, 0 100%, 100% 100%);
+  position: relative;
+
+  &::before {
+    @include typography.style(body1);
+    content: attr(data-text);
+    position: absolute;
+    top: 50%;
+    left: #{token(right-margin, custom)};
+    margin-left: calc(#{token(arrow-width)}/ 2 + #{token(border-width)});
+    display: none;
+
+    background: #{token(background)};
+    color: #{token(color)};
+
+    width: #{token(width)};
+    max-width: #{token(max-width)};
+    pointer-events: none;
+    text-align: #{token(content-align)};
+    line-height: normal;
+    white-space: normal;
+
+    border-radius: #{token(shape)};
+    border-width: #{token(border-width)};
+    border-style: #{token(border-style)};
+    border-color: #{token(border-color)};
+    padding-block: #{token(padding-block)};
+    padding-inline: #{token(padding-inline)};
+    box-shadow: #{token(elevation)};
+  }
+
+  &:hover::before {
+    display: block;
+    animation-duration: #{token(animation-duration)};
+    animation-timing-function: #{token(animation-timing)};
+    animation-name: slidein;
+    animation-fill-mode: forwards;
+  }
+
+  &:hover::after {
+    display: block;
+    animation-duration: #{token(animation-duration)};
+    animation-timing-function: #{token(animation-timing)};
+    animation-name: slidein-arrow;
+    animation-fill-mode: forwards;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: #{token(right-margin, custom)};
+    height: #{token(arrow-height)};
+    width: #{token(arrow-width)};
+    border-width: #{token(border-width)};
+    border-style: #{token(border-style)};
+    border-color: #{token(border-color)};
+    background: #{token(background)};
+    color: #{token(color)};
+    display: none;
+    border-end-start-radius: #{token(arrow-shape)};
+    clip-path: #{token(arrow-clip-path, custom)};
+
+    @include arrow-placement-right;
+  }
+}

--- a/packages/forge/src/lib/tooltip/forge-tooltip.scss
+++ b/packages/forge/src/lib/tooltip/forge-tooltip.scss
@@ -1,31 +1,41 @@
+@use 'sass:string';
 @use './core' as *;
 @use './animations';
 @use '../core/styles/typography';
+@use '../core/styles/utils' as style-utils;
 
 .forge-tooltip {
   @include tokens;
+
+  // Gap between the tooltip and its anchor. CSS-only equivalent of the `offset` property
+  // on <forge-tooltip>, so it is declared here rather than in the shared token map.
+  #{declare(offset)}: #{style-utils.module-val(tooltip, offset, 4px)};
+
+  // Animation custom properties (defaults for right placement)
   #{declare(slidein-x)}: -10px;
   #{declare(slidein-y)}: -50%;
+  #{declare(slideout-x)}: 0px;
   #{declare(slideout-y)}: -50%;
-  #{declare(right-margin)}: calc(100% + 6px);
   #{declare(arrow-clip-path)}: polygon(0 0, 0 100%, 100% 100%);
+
   position: relative;
+
+  //
+  // Tooltip content
+  //
 
   &::before {
     @include typography.style(body1);
+
     content: attr(data-text);
     position: absolute;
-    top: 50%;
-    left: #{token(right-margin, custom)};
-    margin-left: calc(#{token(arrow-width)}/ 2 + #{token(border-width)});
     display: none;
+    pointer-events: none;
 
     background: #{token(background)};
     color: #{token(color)};
-
     width: #{token(width)};
     max-width: #{token(max-width)};
-    pointer-events: none;
     text-align: #{token(content-align)};
     line-height: normal;
     white-space: normal;
@@ -37,40 +47,132 @@
     padding-block: #{token(padding-block)};
     padding-inline: #{token(padding-inline)};
     box-shadow: #{token(elevation)};
+
+    // Default: right placement
+    top: 50%;
+    left: 100%;
+    margin-left: calc(#{token(arrow-width)} / 2 + #{token(border-width)} + #{token(offset, custom)});
   }
 
-  &:hover::before {
-    display: block;
-    animation-duration: #{token(animation-duration)};
-    animation-timing-function: #{token(animation-timing)};
-    animation-name: slidein;
-    animation-fill-mode: forwards;
-  }
-
-  &:hover::after {
-    display: block;
-    animation-duration: #{token(animation-duration)};
-    animation-timing-function: #{token(animation-timing)};
-    animation-name: slidein-arrow;
-    animation-fill-mode: forwards;
-  }
+  //
+  // Tooltip arrow
+  //
 
   &::after {
     content: '';
     position: absolute;
-    top: 50%;
-    left: #{token(right-margin, custom)};
+    display: none;
+
     height: #{token(arrow-height)};
     width: #{token(arrow-width)};
+    background: #{token(background)};
     border-width: #{token(border-width)};
     border-style: #{token(border-style)};
     border-color: #{token(border-color)};
-    background: #{token(background)};
-    color: #{token(color)};
-    display: none;
     border-end-start-radius: #{token(arrow-shape)};
     clip-path: #{token(arrow-clip-path, custom)};
 
-    @include arrow-placement-right;
+    // Default: right placement
+    top: 50%;
+    left: 100%;
+    @include arrow-placement-right(#{token(offset, custom)});
+  }
+
+  //
+  // Show on hover and focus-visible
+  //
+
+  &:hover,
+  &:focus-visible {
+    &::before,
+    &::after {
+      display: block;
+      z-index: 1;
+      animation-duration: #{token(animation-duration)};
+      animation-timing-function: #{token(animation-timing)};
+      animation-fill-mode: forwards;
+    }
+
+    &::before {
+      animation-name: slidein;
+    }
+
+    &::after {
+      animation-name: slidein-arrow;
+    }
+  }
+
+  //
+  // Top placement
+  //
+
+  &--top {
+    #{declare(slidein-x)}: -50%;
+    #{declare(slidein-y)}: 10px;
+    #{declare(slideout-x)}: -50%;
+    #{declare(slideout-y)}: 0px;
+
+    &::before {
+      top: auto;
+      left: 50%;
+      bottom: 100%;
+      margin-left: 0;
+      margin-bottom: calc(#{token(arrow-height)} / 2 + #{token(border-width)} + #{token(offset, custom)});
+    }
+
+    &::after {
+      top: auto;
+      left: 50%;
+      bottom: 100%;
+      margin-inline-start: 0;
+      @include arrow-placement-top(#{token(offset, custom)});
+    }
+  }
+
+  //
+  // Bottom placement
+  //
+
+  &--bottom {
+    #{declare(slidein-x)}: -50%;
+    #{declare(slidein-y)}: -10px;
+    #{declare(slideout-x)}: -50%;
+    #{declare(slideout-y)}: 0px;
+
+    &::before {
+      top: 100%;
+      left: 50%;
+      margin-left: 0;
+      margin-top: calc(#{token(arrow-height)} / 2 + #{token(border-width)} + #{token(offset, custom)});
+    }
+
+    &::after {
+      top: 100%;
+      left: 50%;
+      margin-inline-start: 0;
+      @include arrow-placement-bottom(#{token(offset, custom)});
+    }
+  }
+
+  //
+  // Left placement
+  //
+
+  &--left {
+    #{declare(slidein-x)}: 10px;
+
+    &::before {
+      left: auto;
+      right: 100%;
+      margin-left: 0;
+      margin-right: calc(#{token(arrow-width)} / 2 + #{token(border-width)} + #{token(offset, custom)});
+    }
+
+    &::after {
+      left: auto;
+      right: 100%;
+      margin-inline-start: 0;
+      @include arrow-placement-left(#{token(offset, custom)});
+    }
   }
 }

--- a/packages/forge/src/lib/tooltip/tooltip.scss
+++ b/packages/forge/src/lib/tooltip/tooltip.scss
@@ -57,6 +57,8 @@
 .forge-tooltip {
   #{declare(slidein-x)}: 0;
   #{declare(slidein-y)}: 0;
+  #{declare(slideout-x)}: 0;
+  #{declare(slideout-y)}: 0;
 }
 
 forge-overlay[open] {

--- a/packages/forge/src/lib/tooltip/tooltip.ts
+++ b/packages/forge/src/lib/tooltip/tooltip.ts
@@ -108,6 +108,11 @@ declare global {
  * @csspart surface - The tooltip surface.
  * @csspart arrow - The tooltip arrow.
  * @csspart overlay - The overlay surface.
+ *
+ * @cssclass forge-tooltip - The tooltip class, with text provided via a `data-text` attribute _(required)_.
+ * @cssclass forge-tooltip--top - Positions the tooltip above the element.
+ * @cssclass forge-tooltip--bottom - Positions the tooltip below the element.
+ * @cssclass forge-tooltip--left - Positions the tooltip to the left of the element.
  */
 @customElement({
   name: TOOLTIP_CONSTANTS.elementName,

--- a/packages/forge/src/stories/components/tooltip/Tooltip.mdx
+++ b/packages/forge/src/stories/components/tooltip/Tooltip.mdx
@@ -1,5 +1,6 @@
 import { Meta, Title, Canvas } from '@storybook/addon-docs/blocks';
 import CustomArgTypes from '../../blocks/CustomArgTypes';
+import CssOnlyInformation from '../../blocks/CssOnlyInformation';
 import * as TooltipStories from './Tooltip.stories';
 
 <Meta of={TooltipStories} />
@@ -103,3 +104,60 @@ tooltip is rendered at the same time as the anchor element, and attached via a t
 - Verify that there is sufficient contrast between the foreground text and background to meet WCAG requirements.
 - The target element receives the proper ARIA attributes such as `aria-labelledby` or `aria-describedby` where necessary.
 - Should not contain interactive content.
+
+## CSS-Only
+
+The tooltip component is also available as a CSS-only component without the need for JavaScript. This is useful for simple
+tooltips where you don't need programmatic control, accessibility type associations, or advanced positioning.
+
+The CSS-only tooltip uses `::before` and `::after` pseudo-elements to render the tooltip content and arrow respectively.
+Tooltip text is provided via the `data-text` attribute, and the tooltip is shown on `:hover` and `:focus-visible`.
+
+<Canvas of={TooltipStories.CSSOnly} />
+
+<CssOnlyInformation />
+
+### Placement
+
+The CSS-only tooltip supports four placement directions via modifier classes. The default placement is `right`.
+
+### Offset
+
+The gap between the tooltip and its anchor element is the CSS-only equivalent of the `offset` property on `<forge-tooltip>`, and defaults to `4px` to match.
+
+```html
+<span class="forge-tooltip" data-text="Tooltip text" style="--_tooltip-offset: 12px" tabindex="0">Hover me</span>
+```
+
+| Class | Description |
+|---|---|
+| `.forge-tooltip` | Right placement (default) |
+| `.forge-tooltip--top` | Positions the tooltip above the element |
+| `.forge-tooltip--bottom` | Positions the tooltip below the element |
+| `.forge-tooltip--left` | Positions the tooltip to the left of the element |
+
+### Usage
+
+```html
+<!-- Default (right) placement -->
+<span class="forge-tooltip" data-text="Tooltip text" tabindex="0">
+  Hover me
+</span>
+
+<!-- Top placement -->
+<span class="forge-tooltip forge-tooltip--top" data-text="Tooltip text" tabindex="0">
+  Hover me
+</span>
+
+<!-- Bottom placement -->
+<span class="forge-tooltip forge-tooltip--bottom" data-text="Tooltip text" tabindex="0">
+  Hover me
+</span>
+
+<!-- Left placement -->
+<span class="forge-tooltip forge-tooltip--left" data-text="Tooltip text" tabindex="0">
+  Hover me
+</span>
+```
+
+> Add `tabindex="0"` to non-focusable elements (like `<span>` or `<div>`) to ensure the tooltip is accessible via keyboard navigation.

--- a/packages/forge/src/stories/components/tooltip/Tooltip.stories.ts
+++ b/packages/forge/src/stories/components/tooltip/Tooltip.stories.ts
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/web-components-vite';
 import { html, nothing } from 'lit-html';
+import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { OVERLAY_PLACEMENT_OPTIONS, OVERLAY_FLIP_OPTIONS, generateCustomElementArgTypes, getCssVariableArgs } from '../../utils.js';
 import { TOOLTIP_CONSTANTS } from '@tylertech/forge/tooltip';
@@ -8,6 +9,8 @@ import '@tylertech/forge/button';
 import '@tylertech/forge/tooltip';
 
 const component = 'forge-tooltip';
+
+const CSS_ONLY_PLACEMENTS = ['right', 'top', 'bottom', 'left'] as const;
 
 const meta = {
   title: 'Components/Tooltip',
@@ -65,3 +68,30 @@ export default meta;
 type Story = StoryObj;
 
 export const Demo: Story = {};
+
+export const CSSOnly: Story = {
+  parameters: {
+    controls: { disable: false, exclude: ['open', 'type', 'delay', 'offset', 'flip', 'triggerType', 'fallbackPlacements'] }
+  },
+  argTypes: {
+    placement: { control: 'select', options: CSS_ONLY_PLACEMENTS },
+    text: { control: 'text' }
+  },
+  args: {
+    placement: 'right',
+    text: 'CSS-only tooltip'
+  },
+  render: ({ placement, text, ...args }) => {
+    const cssVarArgs = getCssVariableArgs(args);
+    const style = cssVarArgs ? styleMap(cssVarArgs) : nothing;
+    const classes = {
+      'forge-tooltip': true,
+      [`forge-tooltip--${placement}`]: placement !== 'right'
+    };
+    return html`
+      <span class=${classMap(classes)} data-text=${text} tabindex="0" style=${style}>
+        <span style="text-decoration: underline dotted;">Hover or focus me</span>
+      </span>
+    `;
+  }
+};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
<!-- A clear and concise description of the changes, including any breaking changes (if applicable) -->
Implements a css-only version of the tooltip component. With animations and good looks.

## Additional information
<!-- Add any other context about the change here. -->
This is only partially complete. Leaving here in case someone wants to finish the work.

Remaining work:
- [ ] Clean up scss for forge-tooltip
- [x] Support different positions (left, top, bottom)
- [x] Support different animation directions
- [ ] Finish documentation
