### PR TITLE
fix(date-picker): prevent toggle from being added to tab order after enabling the date picker

### DIFF
--- a/src/lib/date-picker/date-picker-adapter.ts
+++ b/src/lib/date-picker/date-picker-adapter.ts
@@ -125,6 +125,8 @@ export class DatePickerAdapter extends BaseDatePickerAdapter<IDatePickerComponen
       this._toggleElement.setAttribute('aria-disabled', value.toString());
       if (this._toggleElement.hasOwnProperty('disabled')) {
         (this._toggleElement as HTMLButtonElement).disabled = value;
+        // The toggle element should never be in the tab order
+        this._toggleElement.tabIndex = -1;
       }
     }
   }

--- a/src/lib/date-range-picker/date-range-picker-adapter.ts
+++ b/src/lib/date-range-picker/date-range-picker-adapter.ts
@@ -218,6 +218,8 @@ export class DateRangePickerAdapter extends BaseDatePickerAdapter<IDateRangePick
       this._toggleElement.setAttribute('aria-disabled', isDisabled.toString());
       if (this._toggleElement.hasOwnProperty('disabled')) {
         (this._toggleElement as HTMLButtonElement).disabled = isDisabled;
+        // The toggle element should never be in the tab order
+        this._toggleElement.tabIndex = -1;
       }
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
This change manually sets the `tabindex="-1"` on the date picker's and date range picker's toggle button when they disable or enable.

Closes #685 
