### PR TITLE
fix(list-dropdown): restore display of secondaryLabel

### DIFF
--- a/src/dev/pages/autocomplete/autocomplete.html
+++ b/src/dev/pages/autocomplete/autocomplete.html
@@ -28,7 +28,8 @@ include('./src/partials/page.ejs', {
       { type: 'switch', label: 'Use group header builder', id: 'autocomplete-group-header-builder' },
       { type: 'switch', label: 'Use item builder', id: 'autocomplete-item-builder' },
       { type: 'switch', label: 'Use header builder', id: 'autocomplete-header-builder' },
-      { type: 'switch', label: 'Use footer builder', id: 'autocomplete-footer-builder' }
+      { type: 'switch', label: 'Use footer builder', id: 'autocomplete-footer-builder' },
+      { type: 'switch', label: 'Use secondary label', id: 'autocomplete-secondary-label' }
     ]
   }
 })

--- a/src/dev/pages/autocomplete/autocomplete.ts
+++ b/src/dev/pages/autocomplete/autocomplete.ts
@@ -7,7 +7,7 @@ import '@tylertech/forge/autocomplete';
 import '@tylertech/forge/label-value';
 
 // Icons
-import type { AutocompleteFilterCallback, IAutocompleteComponent } from '@tylertech/forge/autocomplete';
+import type { AutocompleteFilterCallback, IAutocompleteComponent, IAutocompleteOption } from '@tylertech/forge/autocomplete';
 import type { IListItemComponent } from '@tylertech/forge/list/list-item';
 import type { ISelectComponent } from '@tylertech/forge/select';
 import type { IOption, IOptionGroup } from '@tylertech/forge/select';
@@ -24,7 +24,7 @@ const autocomplete = document.querySelector('#autocomplete') as IAutocompleteCom
 autocomplete.filter = filterOptions as AutocompleteFilterCallback<string>;
 
 // State
-const states = data as IOption[];
+let states = data as IAutocompleteOption[];
 let asyncFilter = false;
 let useGroupedData = false;
 let useGroupHeaderBuilder = false;
@@ -114,6 +114,11 @@ groupToggle.addEventListener('forge-switch-change', ({ detail: selected }) => us
 
 const groupHeaderBuilderToggle = document.querySelector('#autocomplete-group-header-builder') as HTMLInputElement;
 groupHeaderBuilderToggle.addEventListener('forge-switch-change', ({ detail: selected }) => useGroupHeaderBuilder = selected);
+
+const secondaryLabelToggle = document.querySelector('#autocomplete-secondary-label') as HTMLInputElement;
+secondaryLabelToggle.addEventListener('forge-switch-change', ({ detail: selected }) => {
+  states = selected ? data.map(state => ({...state, secondaryLabel: state.value})) : data;
+});
 
 
 function itemBuilder(option: IListDropdownOption, filterText: string, _listItem: IListItemComponent): HTMLElement {

--- a/src/lib/list-dropdown/list-dropdown-utils.ts
+++ b/src/lib/list-dropdown/list-dropdown-utils.ts
@@ -240,7 +240,7 @@ export function createListItems(
       // Check for secondary (subtitle) text
       if (option.secondaryLabel) {
         const secondaryLabelElement = document.createElement('span');
-        secondaryLabelElement.slot = 'subtitle';
+        secondaryLabelElement.slot = 'secondary-text';
         secondaryLabelElement.textContent = option.secondaryLabel;
         secondaryLabelElement.id = `list-dropdown-option-${config.id}-${optionIdIndex++}-secondary`;
         listItemElement.twoLine = true;

--- a/src/test/spec/list-dropdown/list-dropdown.spec.ts
+++ b/src/test/spec/list-dropdown/list-dropdown.spec.ts
@@ -977,6 +977,6 @@ describe('ListDropdown', function(this: ITestContext) {
     await frame();
 
     const listItems = getListItems();
-    expect(listItems[0].querySelector('span[slot=subtitle]')?.textContent).toBe('Secondary label');
+    expect(listItems[0].querySelector('span[slot=secondary-text]')?.textContent).toBe('Secondary label');
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?
The `secondaryLabel` property of list dropdown options now uses the correct slot to display as it did in Forge 2.0.

## Additional information
<!-- Add any other context about the change here. -->
