### PR TITLE
fix(stepper): remove the internal `z-index` style and fix overflowing content

### DIFF
--- a/src/lib/stepper/step/_core.scss
+++ b/src/lib/stepper/step/_core.scss
@@ -16,7 +16,7 @@
   display: flex;
   overflow: hidden;
   align-items: center;
-  z-index: 1;
+  box-sizing: border-box;
 
   &:focus {
     outline: none;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Removes the unnecessary `z-index` style from the base container element, and sets `box-sizing: border-box` to ensure that the size of the element properly accounts for its internal spacing.
