### PR TITLE
fix(list-item): use `layout` containment on the text-container part to ensure that slotted elements (specifically tooltips) do no affect the layout

### DIFF
--- a/src/lib/list/list-item/_core.scss
+++ b/src/lib/list/list-item/_core.scss
@@ -75,6 +75,8 @@
   line-height: #{token(text-line-height)};
 
   flex: 1;
+
+  contain: layout;
 }
 
 @mixin selected {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
It was found that when list items using tooltips are placed within a mini-drawer and interacted with, it causes layout calculation to be incorrect. This change forces the list item to use layout containment to ensure the descendants of the element do not affect its size incorrectly.
