### PR TITLE
fix(list-item): fixed a bug where focus was being forced to propagate to the interactive element when used within a list dropdown

### DIFF
--- a/src/dev/pages/list/list.scss
+++ b/src/dev/pages/list/list.scss
@@ -2,6 +2,10 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--forge-spacing-large);
+
+  & > div {
+    min-width: 0;
+  }
 }
 
 .list-demo {

--- a/src/lib/list-dropdown/list-dropdown-utils.ts
+++ b/src/lib/list-dropdown/list-dropdown-utils.ts
@@ -193,7 +193,7 @@ export function createListItems(
 
       let listItemElement = document.createElement('forge-list-item');
       listItemElement.value = option.value;
-      listItemElement.allowFocusPropagation = false;
+      listItemElement.focusPropagation = 'off';
       listItemElement.setAttribute('role', 'presentation');
 
       const buttonElement = document.createElement('button');

--- a/src/lib/list-dropdown/list-dropdown-utils.ts
+++ b/src/lib/list-dropdown/list-dropdown-utils.ts
@@ -193,6 +193,7 @@ export function createListItems(
 
       let listItemElement = document.createElement('forge-list-item');
       listItemElement.value = option.value;
+      listItemElement.allowFocusPropagation = false;
       listItemElement.setAttribute('role', 'presentation');
 
       const buttonElement = document.createElement('button');

--- a/src/lib/list/list-item/list-item-constants.ts
+++ b/src/lib/list/list-item/list-item-constants.ts
@@ -12,7 +12,7 @@ const observedAttributes = {
   THREE_LINE: 'three-line',
   WRAP: 'wrap',
   NONINTERACTIVE: 'noninteractive',
-  NO_FOCUS_PROPAGATION: 'no-focus-propagation'
+  FOCUS_PROPAGATION: 'focus-propagation'
 };
 
 const attributes = {
@@ -44,6 +44,10 @@ const events = {
   SELECT: `${elementName}-select`
 };
 
+const defaults = {
+  FOCUS_PROPAGATION: 'allow' as ListItemFocusPropagation
+};
+
 export const LIST_ITEM_CONSTANTS = {
   elementName,
   observedAttributes,
@@ -51,9 +55,12 @@ export const LIST_ITEM_CONSTANTS = {
   classes,
   selectors,
   ids,
-  events
+  events,
+  defaults
 };
 
 export interface IListItemSelectEventData<T = any> {
   value: T;
 }
+
+export type ListItemFocusPropagation = 'allow' | 'off';

--- a/src/lib/list/list-item/list-item-constants.ts
+++ b/src/lib/list/list-item/list-item-constants.ts
@@ -11,7 +11,8 @@ const observedAttributes = {
   TWO_LINE: 'two-line',
   THREE_LINE: 'three-line',
   WRAP: 'wrap',
-  NONINTERACTIVE: 'noninteractive'
+  NONINTERACTIVE: 'noninteractive',
+  NO_FOCUS_PROPAGATION: 'no-focus-propagation'
 };
 
 const attributes = {

--- a/src/lib/list/list-item/list-item-core.ts
+++ b/src/lib/list/list-item/list-item-core.ts
@@ -11,6 +11,7 @@ export interface IListItemCore {
   threeLine: boolean;
   wrap: boolean;
   noninteractive: boolean;
+  allowFocusPropagation: boolean;
 }
 
 export class ListItemCore implements IListItemCore {
@@ -23,6 +24,7 @@ export class ListItemCore implements IListItemCore {
   private _threeLine = false;
   private _wrap = false;
   private _noninteractive = false;
+  private _allowFocusPropagation = true;
 
   private _interactiveStateChangeListener: (value: boolean) => void = this._onInteractiveStateChange.bind(this);
   private _mousedownListener: EventListener = this._onMousedown.bind(this);
@@ -132,7 +134,9 @@ export class ListItemCore implements IListItemCore {
   }
 
   private _clickInteractiveElement(): void {
-    this._adapter.interactiveElement?.focus();
+    if (this._allowFocusPropagation) {
+      this._adapter.interactiveElement?.focus();
+    }
     this._adapter.tempDeactivateFocusIndicator(); // Workaround until we can call `focus({ focusVisible: false })` to prevent focus ring from showing
     this._adapter.interactiveElement?.click();
   }
@@ -264,6 +268,17 @@ export class ListItemCore implements IListItemCore {
       }
 
       this._adapter.toggleHostAttribute(LIST_ITEM_CONSTANTS.attributes.NONINTERACTIVE, this._noninteractive);
+    }
+  }
+
+  public get allowFocusPropagation(): boolean {
+    return this._allowFocusPropagation;
+  }
+  public set allowFocusPropagation(value: boolean) {
+    value = Boolean(value);
+    if (this._allowFocusPropagation !== value) {
+      this._allowFocusPropagation = value;
+      this._adapter.toggleHostAttribute(LIST_ITEM_CONSTANTS.attributes.NO_FOCUS_PROPAGATION, !this._allowFocusPropagation);
     }
   }
 }

--- a/src/lib/list/list-item/list-item.ts
+++ b/src/lib/list/list-item/list-item.ts
@@ -1,7 +1,7 @@
 import { customElement, attachShadowTemplate, coreProperty, coerceBoolean } from '@tylertech/forge-core';
 import { ListItemAdapter } from './list-item-adapter';
 import { ListItemCore } from './list-item-core';
-import { IListItemSelectEventData, LIST_ITEM_CONSTANTS } from './list-item-constants';
+import { IListItemSelectEventData, LIST_ITEM_CONSTANTS, ListItemFocusPropagation } from './list-item-constants';
 import { StateLayerComponent } from '../../state-layer';
 import { FocusIndicatorComponent } from '../../focus-indicator';
 import { IWithElementInternals, WithElementInternals } from '../../core/mixins/internals/with-element-internals';
@@ -21,7 +21,7 @@ export interface IListItemProperties<T = unknown> {
   threeLine: boolean;
   wrap: boolean;
   noninteractive: boolean;
-  allowFocusPropagation: boolean;
+  focusPropagation: ListItemFocusPropagation;
 }
 
 export interface IListItemComponent<T = unknown> extends IListItemProperties<T>, IWithElementInternals, IWithDefaultAria {}
@@ -50,7 +50,7 @@ declare global {
  * @property {boolean} [threeLine=false] - Sets the list item height to support at least three lines of text.
  * @property {boolean} [wrap=false] - Sets the list item to wrap its text content.
  * @property {boolean} [noninteractive=false] - Controls whether the list item will automatically attach itself to interactive slotted elements or not.
- * @property {boolean} [allowFocusPropagation=true] - Controls whether the interactive element will receive focus if a non-interactive element is clicked within the list item.
+ * @property {boolean} [focusPropagation="allow"] - Controls whether the interactive element will receive focus if a non-interactive element is clicked within the list item.
  *
  * @attribute {boolean} [selected=false] - Applies the selected state to the list item.
  * @attribute {boolean} [active=false] - Applies the active state to the list item by emulating its focused state.
@@ -61,7 +61,7 @@ declare global {
  * @attribute {boolean} [three-line=false] - Sets the list item height to support at least three lines of text.
  * @attribute {boolean} [wrap=false] - Sets the list item to wrap its text content.
  * @attribute {boolean} [noninteractive=false] - Controls whether the list item will automatically attach itself to interactive slotted elements or not.
- * @attribute {boolean} [no-focus-propagation=false] - Disables focus propagation to the interactive element when a non-interactive element is clicked within the list item.
+ * @attribute {boolean} [focus-propagation="allow"] - Controls whether the interactive element will receive focus if a non-interactive element is clicked within the list item.
  *
  * @event {CustomEvent<IListItemSelectEventData>} forge-list-item-select - Fires when the list item is selected.
  *
@@ -176,8 +176,8 @@ export class ListItemComponent extends WithElementInternals(WithDefaultAria(Base
       case LIST_ITEM_CONSTANTS.observedAttributes.NONINTERACTIVE:
         this.noninteractive = coerceBoolean(newValue);
         break;
-      case LIST_ITEM_CONSTANTS.observedAttributes.NO_FOCUS_PROPAGATION:
-        this.allowFocusPropagation = !coerceBoolean(newValue);
+      case LIST_ITEM_CONSTANTS.observedAttributes.FOCUS_PROPAGATION:
+        this.focusPropagation = newValue as ListItemFocusPropagation;
         break;
     }
   }
@@ -210,5 +210,5 @@ export class ListItemComponent extends WithElementInternals(WithDefaultAria(Base
   public declare noninteractive: boolean;
 
   @coreProperty()
-  public declare allowFocusPropagation: boolean;
+  public declare focusPropagation: ListItemFocusPropagation;
 }

--- a/src/lib/list/list-item/list-item.ts
+++ b/src/lib/list/list-item/list-item.ts
@@ -21,6 +21,7 @@ export interface IListItemProperties<T = unknown> {
   threeLine: boolean;
   wrap: boolean;
   noninteractive: boolean;
+  allowFocusPropagation: boolean;
 }
 
 export interface IListItemComponent<T = unknown> extends IListItemProperties<T>, IWithElementInternals, IWithDefaultAria {}
@@ -49,6 +50,7 @@ declare global {
  * @property {boolean} [threeLine=false] - Sets the list item height to support at least three lines of text.
  * @property {boolean} [wrap=false] - Sets the list item to wrap its text content.
  * @property {boolean} [noninteractive=false] - Controls whether the list item will automatically attach itself to interactive slotted elements or not.
+ * @property {boolean} [allowFocusPropagation=true] - Controls whether the interactive element will receive focus if a non-interactive element is clicked within the list item.
  *
  * @attribute {boolean} [selected=false] - Applies the selected state to the list item.
  * @attribute {boolean} [active=false] - Applies the active state to the list item by emulating its focused state.
@@ -59,6 +61,7 @@ declare global {
  * @attribute {boolean} [three-line=false] - Sets the list item height to support at least three lines of text.
  * @attribute {boolean} [wrap=false] - Sets the list item to wrap its text content.
  * @attribute {boolean} [noninteractive=false] - Controls whether the list item will automatically attach itself to interactive slotted elements or not.
+ * @attribute {boolean} [no-focus-propagation=true] - Disables focus propagation to the interactive element when a non-interactive element is clicked within the list item.
  *
  * @event {CustomEvent<IListItemSelectEventData>} forge-list-item-select - Fires when the list item is selected.
  *
@@ -173,6 +176,9 @@ export class ListItemComponent extends WithElementInternals(WithDefaultAria(Base
       case LIST_ITEM_CONSTANTS.observedAttributes.NONINTERACTIVE:
         this.noninteractive = coerceBoolean(newValue);
         break;
+      case LIST_ITEM_CONSTANTS.observedAttributes.NO_FOCUS_PROPAGATION:
+        this.allowFocusPropagation = !coerceBoolean(newValue);
+        break;
     }
   }
 
@@ -202,4 +208,7 @@ export class ListItemComponent extends WithElementInternals(WithDefaultAria(Base
 
   @coreProperty()
   public declare noninteractive: boolean;
+
+  @coreProperty()
+  public declare allowFocusPropagation: boolean;
 }

--- a/src/lib/list/list-item/list-item.ts
+++ b/src/lib/list/list-item/list-item.ts
@@ -61,7 +61,7 @@ declare global {
  * @attribute {boolean} [three-line=false] - Sets the list item height to support at least three lines of text.
  * @attribute {boolean} [wrap=false] - Sets the list item to wrap its text content.
  * @attribute {boolean} [noninteractive=false] - Controls whether the list item will automatically attach itself to interactive slotted elements or not.
- * @attribute {boolean} [no-focus-propagation=true] - Disables focus propagation to the interactive element when a non-interactive element is clicked within the list item.
+ * @attribute {boolean} [no-focus-propagation=false] - Disables focus propagation to the interactive element when a non-interactive element is clicked within the list item.
  *
  * @event {CustomEvent<IListItemSelectEventData>} forge-list-item-select - Fires when the list item is selected.
  *


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged?N

## Describe the new behavior?
Adds new `allowFocusPropagation` configuration to the `<forge-list-item>` element to allow for controlling whether focus is propagated to the interactive element or not (`true` by default).

This is used within the list-dropdown to ensure that when the user interactive with a non-interactive element in a list item within the dropdown (which should never receive focus) that the interactive element doesn't inadvertently get focused. When used statically within a page, list items should always propagate focus.