### PR TITLE
fix(chip): remove attribute syncing to prevent value being forced to string

### DIFF
--- a/src/lib/chips/chip/chip-core.ts
+++ b/src/lib/chips/chip/chip-core.ts
@@ -227,7 +227,6 @@ export class ChipCore implements IChipCore {
   public set value(value: unknown) {
     if (this._value !== value) {
       this._value = value;
-      this._adapter.setHostAttribute(CHIP_CONSTANTS.attributes.VALUE, String(this._value));
     }
   }
 

--- a/src/lib/chips/chips.test.ts
+++ b/src/lib/chips/chips.test.ts
@@ -263,13 +263,6 @@ describe('Chips', () => {
       expect(el.value).to.equal('test');
     });
 
-    it('should set value attribute when setting property', async () => {
-      const el = await fixture<IChipComponent>(html`<forge-chip>Test</forge-chip>`);
-      el.value = 'test';
-
-      expect(el.getAttribute(CHIP_CONSTANTS.attributes.VALUE)).to.equal('test');
-    });
-
     it('should set selected attribute', async () => {
       const el = await fixture<IChipComponent>(html`<forge-chip selected>Test</forge-chip>`);
       expect(el.selected).to.be.true;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?
The `forge-chip` element will no longer sync `value` property changes back to the attribute, as this caused the `attributeChangedCallback` to run and overwrite non-string values to string values, which is problematic if the value was numeric or an object.  The `value` will continue to initialize/update the property, but changes will not be reflected back.  This is consistent with Forge 2.0, and also the checkbox/switch/radio components.
