### PR TITLE
fix(field): extend box to include outline

### DIFF
--- a/src/lib/field/_core.scss
+++ b/src/lib/field/_core.scss
@@ -78,6 +78,7 @@
   outline-style: #{token(outline-style)};
   outline-width: #{token(outline-width)};
   outline-color: #{token(outline-color, custom)};
+  outline-offset: calc(#{token(outline-width)} * -1);
   pointer-events: none;
 }
 

--- a/src/lib/field/_core.theme.scss
+++ b/src/lib/field/_core.theme.scss
@@ -88,7 +88,6 @@ $elevations: (
     @include override(tonal-background, map.get($tonal-backgrounds, $theme), value);
     @include override(tonal-background-hover, map.get($tonal-backgrounds-hover, $theme), value);
   }
-
   @include override(content-color, map.get($content-colors, $theme), value);
   @include override(inner-border-color, map.get($outline-colors, $theme), value);
   @include override(inner-border-color-hover, map.get($outline-colors-hover, $theme), value);

--- a/src/lib/field/_core.theme.scss
+++ b/src/lib/field/_core.theme.scss
@@ -107,7 +107,6 @@ $elevations: (
     @include override(padding-inline, 0, value);
     @include override(surface-display, none, value);
   } @else if $variant == outlined {
-    @include with-outline;
     @include hidden-background;
   } @else if $variant == tonal {
     @include no-outline;
@@ -115,7 +114,6 @@ $elevations: (
     @include visible-background(tonal);
     @include override(multiline-inset-label-background, #{token(multiline-inset-label-tonal-background, custom)}, value);
   } @else if $variant == filled {
-    @include with-outline;
     @include visible-background(filled);
   } @else if $variant == raised {
     @include elevated;
@@ -123,10 +121,6 @@ $elevations: (
     @include unoutlined-variant-inner-border;
     @include visible-background(filled);
   }
-}
-
-@mixin with-outline {
-  padding: #{token(outline-width)};
 }
 
 @mixin no-outline($no-inner: false) {

--- a/src/lib/field/_core.theme.scss
+++ b/src/lib/field/_core.theme.scss
@@ -88,6 +88,7 @@ $elevations: (
     @include override(tonal-background, map.get($tonal-backgrounds, $theme), value);
     @include override(tonal-background-hover, map.get($tonal-backgrounds-hover, $theme), value);
   }
+
   @include override(content-color, map.get($content-colors, $theme), value);
   @include override(inner-border-color, map.get($outline-colors, $theme), value);
   @include override(inner-border-color-hover, map.get($outline-colors-hover, $theme), value);
@@ -106,6 +107,7 @@ $elevations: (
     @include override(padding-inline, 0, value);
     @include override(surface-display, none, value);
   } @else if $variant == outlined {
+    @include with-outline;
     @include hidden-background;
   } @else if $variant == tonal {
     @include no-outline;
@@ -113,6 +115,7 @@ $elevations: (
     @include visible-background(tonal);
     @include override(multiline-inset-label-background, #{token(multiline-inset-label-tonal-background, custom)}, value);
   } @else if $variant == filled {
+    @include with-outline;
     @include visible-background(filled);
   } @else if $variant == raised {
     @include elevated;
@@ -120,6 +123,10 @@ $elevations: (
     @include unoutlined-variant-inner-border;
     @include visible-background(filled);
   }
+}
+
+@mixin with-outline {
+  padding: #{token(outline-width)};
 }
 
 @mixin no-outline($no-inner: false) {

--- a/src/lib/field/field.scss
+++ b/src/lib/field/field.scss
@@ -671,7 +671,7 @@ forge-focus-indicator {
   @include focus-indicator.provide-theme(
     (
       color: #{token(focus-indicator-color, custom)},
-      outward-offset: 0px,
+      outward-offset: calc(#{token(outline-width)} * -1),
       shape: #{token(shape)},
       width: #{token(focus-indicator-width)}
     )

--- a/src/lib/field/forge-field.scss
+++ b/src/lib/field/forge-field.scss
@@ -36,12 +36,12 @@ $_input-selector: ':where(input, textarea, select, .forge-field__input)';
 
     box-shadow: #{token(elevation, custom)};
 
-    margin: #{token(outline-width)};
     padding-inline: #{token(padding-inline)};
     border-radius: #{token(shape)};
     outline-style: #{token(outline-style)};
     outline-width: #{token(outline-width)};
     outline-color: #{theme.variable(outline-low)};
+    outline-offset: calc(#{token(outline-width)} * -1);
 
     background: #{token(background)};
 
@@ -328,7 +328,8 @@ $_input-selector: ':where(input, textarea, select, .forge-field__input)';
       &.forge-field:has(#{$_input-selector}:focus) {
         @include focus-indicator.provide-theme(
           (
-            color: #{theme.variable(error)}
+            color: #{theme.variable(error)},
+            outward-offset: calc(#{token(outline-width)} * -1)
           )
         );
       }

--- a/src/lib/field/forge-field.scss
+++ b/src/lib/field/forge-field.scss
@@ -36,6 +36,7 @@ $_input-selector: ':where(input, textarea, select, .forge-field__input)';
 
     box-shadow: #{token(elevation, custom)};
 
+    margin: #{token(outline-width)};
     padding-inline: #{token(padding-inline)};
     border-radius: #{token(shape)};
     outline-style: #{token(outline-style)};
@@ -72,12 +73,14 @@ $_input-selector: ':where(input, textarea, select, .forge-field__input)';
     &--plain {
       @include core.variant(plain);
 
+      margin: 0;
       outline-width: 0;
     }
 
     &--tonal {
       @include core.variant(tonal);
 
+      margin: 0;
       outline-width: 0;
       background: #{theme.variable(primary-container-low)};
 
@@ -95,6 +98,7 @@ $_input-selector: ':where(input, textarea, select, .forge-field__input)';
     &--raised {
       @include core.variant(raised);
 
+      margin: 0;
       outline-width: 0;
 
       &:hover:not(:has(#{$_input-selector}:disabled)) {

--- a/src/lib/field/forge-field.scss
+++ b/src/lib/field/forge-field.scss
@@ -73,14 +73,12 @@ $_input-selector: ':where(input, textarea, select, .forge-field__input)';
     &--plain {
       @include core.variant(plain);
 
-      margin: 0;
       outline-width: 0;
     }
 
     &--tonal {
       @include core.variant(tonal);
 
-      margin: 0;
       outline-width: 0;
       background: #{theme.variable(primary-container-low)};
 
@@ -98,7 +96,6 @@ $_input-selector: ':where(input, textarea, select, .forge-field__input)';
     &--raised {
       @include core.variant(raised);
 
-      margin: 0;
       outline-width: 0;
 
       &:hover:not(:has(#{$_input-selector}:disabled)) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
This fixes an issue where the outline of certain field variants wasn't encompassed by the field's box, leading to situations where the outline could overflow or overlap other elements. Margin or padding equal to the outline's width has been added to account for this.

**Update**: Refactored to move the outline inward instead of adding margin or padding.