### PR TITLE
fix(autocomplete): properly reflect dropdown open state if dismissed by anchor click

### DIFF
--- a/src/lib/autocomplete/autocomplete-adapter.ts
+++ b/src/lib/autocomplete/autocomplete-adapter.ts
@@ -145,13 +145,7 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
   }
 
   public setDismissListener(listener: () => void): void {
-    if (!this._listDropdown || !this._listDropdown.dropdownElement) {
-      return;
-    }
-    const dropdownElement = this._listDropdown.dropdownElement as IPopoverComponent;
-    if (dropdownElement.anchorElement && dropdownElement.anchorElement instanceof HTMLElement) {
-      dropdownElement.anchorElement.addEventListener(POPOVER_CONSTANTS.events.TOGGLE, listener);
-    }
+    this._listDropdown?.dropdownElement?.addEventListener(POPOVER_CONSTANTS.events.TOGGLE, listener);
   }
 
   public focus(): void {

--- a/src/test/spec/autocomplete/autocomplete.spec.ts
+++ b/src/test/spec/autocomplete/autocomplete.spec.ts
@@ -22,7 +22,7 @@ import { TEXT_FIELD_CONSTANTS, ITextFieldComponent, ITextFieldComponentDelegateO
 import { AVATAR_CONSTANTS, IAvatarComponent } from '@tylertech/forge/avatar';
 import { ICON_CONSTANTS, IconComponent } from '@tylertech/forge/icon';
 import { LIST_DROPDOWN_CONSTANTS } from '@tylertech/forge/list-dropdown';
-import { POPOVER_CONSTANTS } from '@tylertech/forge/popover';
+import { IPopoverComponent, POPOVER_CONSTANTS } from '@tylertech/forge/popover';
 import { tryCleanupPopovers } from '../../utils';
 
 const DEFAULT_FILTER_OPTIONS = [
@@ -1633,6 +1633,17 @@ describe('AutocompleteComponent', function(this: ITestContext) {
         expect(this.context.component.value).toBe(DEFAULT_FILTER_OPTIONS[2].value);
       });
     });
+  });
+
+  it('should update open status if popup dismissed via click inside the anchor element', async function(this: ITestContext) {
+    this.context = setupTestContext(true);
+    this.context.component.filter = () => DEFAULT_FILTER_OPTIONS;
+    this.context.component.openDropdown();
+    await task();
+    this.context.input.click();
+    await task(POPOVER_ANIMATION_DURATION);
+    expect(this.context.component.open).toBe(false);
+    expect(this.context.component.popupElement).toBeNull();
   });
 
   interface ITestAutocompleteGroup {


### PR DESCRIPTION
Fixes #682

## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The `forge-popover-toggle` event is raised from the `forge-popup` host element, but the autocomplete was listening for the event on its `anchorElement`, so when dismissed via clicking on the input (or anywhere in the anchor) it was not properly reflecting the open state of the dropdown.

## Additional information
<!-- Add any other context about the change here. -->
