### PR TITLE
Fix tab disabled

### DIFF
--- a/src/lib/tabs/tab-bar/tab-bar-core.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-core.ts
@@ -180,11 +180,11 @@ export class TabBarCore implements ITabBarCore {
   private _syncTabState(): void {
     this._tabs.forEach((tab, index) => {
       tab.selected = index === this._activeTab;
-      tab.disabled = this._disabled;
       tab.vertical = this._vertical;
       tab.stacked = this._stacked;
       tab.secondary = this._secondary;
       tab.inverted = this._inverted;
+      tab.syncTabDisabledState();
     });
   }
 
@@ -263,7 +263,7 @@ export class TabBarCore implements ITabBarCore {
     value = Boolean(value);
     if (this._disabled !== value) {
       this._disabled = value;
-      this._tabs.forEach(tab => (tab.disabled = this._disabled));
+      this._tabs.forEach(tab => tab.syncTabDisabledState());
       this._adapter.toggleHostAttribute(TAB_BAR_CONSTANTS.attributes.DISABLED, this._disabled);
     }
   }

--- a/src/lib/tabs/tab/tab-adapter.ts
+++ b/src/lib/tabs/tab/tab-adapter.ts
@@ -1,9 +1,10 @@
-import { getShadowElement, requireParent, toggleAttribute } from '@tylertech/forge-core';
+import { getShadowElement, requireParent, toggleAttribute, toggleClass } from '@tylertech/forge-core';
 import { IStateLayerComponent, STATE_LAYER_CONSTANTS } from '../../state-layer';
 import { BaseAdapter, IBaseAdapter } from '../../core/base/base-adapter';
 import { TAB_BAR_CONSTANTS } from '../tab-bar/tab-bar-constants';
 import type { ITabComponent } from './tab';
 import { TAB_CONSTANTS } from './tab-constants';
+import { TabBarComponent } from '../tab-bar';
 
 export interface ITabAdapter extends IBaseAdapter {
   initialize(): void;
@@ -35,10 +36,14 @@ export class TabAdapter extends BaseAdapter<ITabComponent> implements ITabAdapte
   }
 
   public setDisabled(value: boolean): void {
-    this._stateLayerElement.disabled = value;
-    this._component.tabIndex = value ? -1 : this._component.selected ? 0 : -1;
-    this._component.setAttribute('aria-disabled', String(value));
+    const parentDisabled = requireParent<TabBarComponent>(this._component, TAB_BAR_CONSTANTS.elementName)?.disabled ?? false;
+    const disabled = value || parentDisabled;
+    this._stateLayerElement.disabled = disabled;
+    this._component.tabIndex = disabled ? -1 : this._component.selected ? 0 : -1;
+    this._component.setAttribute('aria-disabled', String(disabled));
+    // Attribute should match individual tab disabled state, not be overwritten by parent state.
     toggleAttribute(this._component, value, TAB_CONSTANTS.attributes.DISABLED, String(value));
+    toggleClass(this._component, disabled, 'forge-tab--disabled');
   }
 
   public setSelected(value: boolean): void {

--- a/src/lib/tabs/tab/tab-adapter.ts
+++ b/src/lib/tabs/tab/tab-adapter.ts
@@ -13,6 +13,7 @@ export interface ITabAdapter extends IBaseAdapter {
   setSelected(value: boolean): void;
   animateSelected(): void;
   animateStateLayer(): void;
+  isParentDisabled(): boolean;
 }
 
 export class TabAdapter extends BaseAdapter<ITabComponent> implements ITabAdapter {
@@ -35,15 +36,18 @@ export class TabAdapter extends BaseAdapter<ITabComponent> implements ITabAdapte
     this._component.addEventListener(type, listener);
   }
 
+  public isParentDisabled(): boolean {
+    return requireParent<TabBarComponent>(this._component, TAB_BAR_CONSTANTS.elementName)?.disabled ?? false;
+  }
+
   public setDisabled(value: boolean): void {
-    const parentDisabled = requireParent<TabBarComponent>(this._component, TAB_BAR_CONSTANTS.elementName)?.disabled ?? false;
-    const disabled = value || parentDisabled;
+    const disabled = value || this.isParentDisabled();
     this._stateLayerElement.disabled = disabled;
     this._component.tabIndex = disabled ? -1 : this._component.selected ? 0 : -1;
     this._component.setAttribute('aria-disabled', String(disabled));
     // Attribute should match individual tab disabled state, not be overwritten by parent state.
     toggleAttribute(this._component, value, TAB_CONSTANTS.attributes.DISABLED, String(value));
-    toggleClass(this._component, disabled, 'forge-tab--disabled');
+    toggleClass(this._component, disabled, TAB_CONSTANTS.classes.DISABLED);
   }
 
   public setSelected(value: boolean): void {

--- a/src/lib/tabs/tab/tab-constants.ts
+++ b/src/lib/tabs/tab/tab-constants.ts
@@ -20,7 +20,7 @@ const selectors = {
 };
 
 const classes = {
-  SELECTED: 'selected'
+  DISABLED: `${elementName}--disabled`
 };
 
 const events = {

--- a/src/lib/tabs/tab/tab-core.ts
+++ b/src/lib/tabs/tab/tab-core.ts
@@ -69,6 +69,10 @@ export class TabCore implements ITabCore {
     }
   }
 
+  public syncTabDisabledState(): void {
+    this._adapter.setDisabled(this._disabled);
+  }
+
   public get selected(): boolean {
     return this._selected;
   }

--- a/src/lib/tabs/tab/tab-core.ts
+++ b/src/lib/tabs/tab/tab-core.ts
@@ -35,14 +35,14 @@ export class TabCore implements ITabCore {
   }
 
   private _onClick(): void {
-    if (this._disabled || this._selected) {
+    if (this._disabled || this._adapter.isParentDisabled() || this._selected) {
       return;
     }
     this._dispatchSelectEvent();
   }
 
   private _onKeydown(evt: KeyboardEvent): void {
-    if (this._disabled || this._selected) {
+    if (this._disabled || this._adapter.isParentDisabled() || this._selected) {
       return;
     }
 

--- a/src/lib/tabs/tab/tab.scss
+++ b/src/lib/tabs/tab/tab.scss
@@ -80,7 +80,7 @@ forge-state-layer {
 // Disabled
 //
 
-:host([disabled]) {
+:host(.forge-tab--disabled) {
   @include host-disabled;
 
   .forge-tab {

--- a/src/lib/tabs/tab/tab.ts
+++ b/src/lib/tabs/tab/tab.ts
@@ -17,6 +17,8 @@ export interface ITabComponent extends IBaseComponent {
   stacked: boolean;
   secondary: boolean;
   inverted: boolean;
+
+  syncTabDisabledState(): void;
 }
 
 declare global {
@@ -163,4 +165,9 @@ export class TabComponent extends BaseComponent implements ITabComponent {
 
   @coreProperty()
   public declare inverted: boolean;
+
+  /** Called when parent tab-bar disabled state changes. */
+  public syncTabDisabledState(): void {
+    this._core.syncTabDisabledState();
+  }
 }

--- a/src/lib/tabs/tabs.test.ts
+++ b/src/lib/tabs/tabs.test.ts
@@ -96,7 +96,6 @@ describe('Tabs', () => {
 
     await expect(el).to.be.accessible();
     expect(el.disabled).to.be.true;
-    // expect(el.className).to.contain(TAB_CONSTANTS.classes.DISABLED);
     expect(
       ctx.tabs.every(tab => {
         const stateLayer = getShadowElement(tab, STATE_LAYER_CONSTANTS.elementName) as IStateLayerComponent;

--- a/src/lib/tabs/tabs.test.ts
+++ b/src/lib/tabs/tabs.test.ts
@@ -90,16 +90,17 @@ describe('Tabs', () => {
     expect(el.hasAttribute(TAB_BAR_CONSTANTS.attributes.ACTIVE_TAB)).to.be.false;
   });
 
-  it('should set disabled', async () => {
+  it('should set disabled class', async () => {
     const el = await createFixture({ disabled: true });
     const ctx = new TabsHarness(el);
 
     await expect(el).to.be.accessible();
     expect(el.disabled).to.be.true;
+    // expect(el.className).to.contain(TAB_CONSTANTS.classes.DISABLED);
     expect(
       ctx.tabs.every(tab => {
         const stateLayer = getShadowElement(tab, STATE_LAYER_CONSTANTS.elementName) as IStateLayerComponent;
-        return tab.disabled && tab.hasAttribute('disabled') && stateLayer.disabled;
+        return tab.classList.contains(TAB_CONSTANTS.classes.DISABLED) && stateLayer.disabled;
       })
     ).to.be.true;
   });
@@ -396,7 +397,7 @@ describe('Tabs', () => {
     ctx.clickTab(0);
 
     expect(ctx.tabs[0].selected).to.be.true;
-    expect(ctx.tabs[0].disabled).to.be.true;
+    expect(ctx.tabs[0].className).to.contain(TAB_CONSTANTS.classes.DISABLED);
     expect(ctx.selectedTabCount).to.equal(1);
     expect(selectSpy.called).to.be.false;
     expect(changeSpy.called).to.be.false;


### PR DESCRIPTION
Fixes #707 

## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior? 
Open to any suggestions on a more idiomatic way to accomplish this.  Was originally going to keep the `forge-tab--disabled` class abstracted inside the Shadow DOM, but currently the not-allowed cursor is applied directly to the host so I needed something at that level.  Could also have used an event instead of a callback to sync the parent state.  Also wondering whether I should just do the `requireParent` on initialize, but I worry with Angular content projection it might be possible for a tab to be rendered detached.  Not sure if there's a simple way to ensure the parent reference is kept up to date if the tab is attached after initialization.

In Forge 2.0, the TabBar did not have a disabled property, and developers would have needed to set disabled on each tab individually, and they could have used something like `parentDisabledCondition || individualTabCondition`.  So I did consider just making it so that if the parent is not disabled, it wouldn't initially override the children, so if you wanted to handle both you'd need to do the same as before, and just not use them together, but I felt like even if documented, that would lead to confusion and questions because developers wouldn't find that intuitive. 

## Additional information
[Teams Discussion](https://teams.microsoft.com/l/message/19:1gCw-wLjrS56X_iAY0mpHpk4PyWOi08JiMM7Kc1xvho1@thread.tacv2/1729105258525?tenantId=7cc5f0f9-ee5b-4106-a62d-1b9f7be46118&groupId=2bb1b8ea-cd12-4df5-a4ab-0c895bfcda5c&parentMessageId=1729105258525&teamName=Forge&channelName=General&createdTime=1729105258525)
