### PR TITLE
fix(field): fixed a rare bug where the inset label state was not initializing properly based on the existence of slotted content

### DIFF
--- a/src/lib/field/field-adapter.ts
+++ b/src/lib/field/field-adapter.ts
@@ -13,6 +13,7 @@ export interface IFieldAdapter extends IBaseAdapter<IFieldComponent> {
   setLabelPosition(value: FieldLabelPosition): void;
   setFloatingLabel(value: boolean, skipAnimation?: boolean): void;
   handleSlotChange(slot: HTMLSlotElement): void;
+  initializeSlots(): void;
 }
 
 export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IFieldAdapter {
@@ -112,6 +113,11 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
     if (slot.name in classMap) {
       toggleClass(this._rootElement, !!slot.assignedNodes({ flatten: true }).length, classMap[slot.name]);
     }
+  }
+
+  public initializeSlots(): void {
+    const slotElements = this._rootElement.querySelectorAll<HTMLSlotElement>('slot');
+    slotElements.forEach(slotElement => this.handleSlotChange(slotElement));
   }
 
   /**

--- a/src/lib/field/field-core.ts
+++ b/src/lib/field/field-core.ts
@@ -60,6 +60,7 @@ export class FieldCore implements IFieldCore {
 
   public initialize(): void {
     this._adapter.addRootListener('slotchange', this._slotChangeListener);
+    this._adapter.initializeSlots();
     this._adapter.tryApplyGlobalConfiguration(['labelPosition', 'variant']);
     this._adapter.setLabelPosition(this._labelPosition);
 

--- a/src/lib/select/select/select.html
+++ b/src/lib/select/select/select.html
@@ -1,6 +1,6 @@
 <template>
   <forge-field id="field" popover-icon focus-indicator-allow-focus focus-indicator-focus-mode="focus">
-    <label id="select-label" aria-hidden="true" part="label"></label>
+    <label id="select-label" aria-hidden="true" part="label" slot="label"></label>
     <slot slot="start" name="start"></slot>
     <div data-forge-field-input class="selected-text-container" part="text-container" aria-live="assertive" aria-atomic="true">
       <slot name="value">

--- a/src/lib/text-field/text-field-adapter.ts
+++ b/src/lib/text-field/text-field-adapter.ts
@@ -10,20 +10,23 @@ export interface ITextFieldAdapter extends IBaseFieldAdapter {
   addRootListener(name: keyof HTMLElementEventMap, listener: EventListener): void;
   removeRootListener(name: keyof HTMLElementEventMap, listener: EventListener): void;
   disableInput(disabled: boolean): void;
-  handleDefaultSlotChange(slot: HTMLSlotElement, listener: TextFieldInputAttributeObserver): void;
+  handleDefaultSlotChange(listener: TextFieldInputAttributeObserver): void;
   tryAddValueChangeListener(context: unknown, listener: TextFieldValueChangeListener): void;
   removeValueChangeListener(): void;
   tryFloatLabel(force?: boolean): void;
-  tryConnectSlottedLabel(slot: HTMLSlotElement): void;
+  tryConnectSlottedLabel(): void;
   connectClearButton(listener: EventListener): void;
   disconnectClearButton(listener: EventListener): void;
   toggleClearButtonVisibility(visible: boolean): void;
   clearInput(): void;
+  getAllSlotElements(): HTMLSlotElement[];
 }
 
 export class TextFieldAdapter extends BaseFieldAdapter implements ITextFieldAdapter {
   protected readonly _fieldElement: IFieldComponent;
   private readonly _clearButtonSlotElement: HTMLSlotElement;
+  private readonly _defaultSlotElement: HTMLSlotElement;
+  private readonly _labelSlotElement: HTMLSlotElement;
   private _popoverTargetElement: HTMLElement;
   private _inputElements: (HTMLInputElement | HTMLTextAreaElement)[] = [];
   private _inputMutationObserver?: MutationObserver;
@@ -48,6 +51,8 @@ export class TextFieldAdapter extends BaseFieldAdapter implements ITextFieldAdap
     super(component);
     this._fieldElement = getShadowElement(component, TEXT_FIELD_CONSTANTS.selectors.FIELD) as IFieldComponent;
     this._clearButtonSlotElement = getShadowElement(component, TEXT_FIELD_CONSTANTS.selectors.CLEAR_BUTTON_SLOT) as HTMLSlotElement;
+    this._defaultSlotElement = getShadowElement(component, TEXT_FIELD_CONSTANTS.selectors.DEFAULT_SLOT) as HTMLSlotElement;
+    this._labelSlotElement = getShadowElement(component, TEXT_FIELD_CONSTANTS.selectors.LABEL_SLOT) as HTMLSlotElement;
     this._fieldElement.setAttribute('exportparts', Object.values(FIELD_CONSTANTS.parts).join(', '));
     this._clearButtonSlotElement.remove();
   }
@@ -78,12 +83,12 @@ export class TextFieldAdapter extends BaseFieldAdapter implements ITextFieldAdap
     });
   }
 
-  public handleDefaultSlotChange(slot: HTMLSlotElement, listener: TextFieldInputAttributeObserver): void {
+  public handleDefaultSlotChange(listener: TextFieldInputAttributeObserver): void {
     // Destroy the mutation observer if it exists
     this._inputMutationObserver?.disconnect();
 
     // If there are no assigned elements, return
-    const assignedElements = slot.assignedElements();
+    const assignedElements = this._defaultSlotElement.assignedElements();
     if (!assignedElements.length) {
       return;
     }
@@ -146,7 +151,7 @@ export class TextFieldAdapter extends BaseFieldAdapter implements ITextFieldAdap
     this._fieldElement.floatLabel = this.hasValue || this.hasPlaceholder;
   }
 
-  public tryConnectSlottedLabel(slot: HTMLSlotElement): void {
+  public tryConnectSlottedLabel(): void {
     // Only one input can be automatically connected to a label, return if there are no or more
     // than one inputs or if the input is already labelled
     if (this._inputElements.length !== 1 || this._inputElements[0].labels?.length) {
@@ -154,7 +159,7 @@ export class TextFieldAdapter extends BaseFieldAdapter implements ITextFieldAdap
     }
 
     const inputElement = this._inputElements[0];
-    const elements = slot.assignedElements({ flatten: true });
+    const elements = this._labelSlotElement.assignedElements({ flatten: true });
 
     // Attempt to find and connect a `<forge-label>` element
     const forgeLabel = elements.find(el => el.matches(TEXT_FIELD_CONSTANTS.selectors.FORGE_LABEL)) as LabelComponent | undefined;
@@ -197,5 +202,9 @@ export class TextFieldAdapter extends BaseFieldAdapter implements ITextFieldAdap
     }
     this._inputElements.forEach(el => (el.value = ''));
     this._inputElements[0].focus();
+  }
+
+  public getAllSlotElements(): HTMLSlotElement[] {
+    return Array.from(this._component.shadowRoot?.querySelectorAll('slot') ?? []);
   }
 }

--- a/src/lib/text-field/text-field-constants.ts
+++ b/src/lib/text-field/text-field-constants.ts
@@ -13,6 +13,8 @@ const attributes = {
 
 const selectors = {
   FIELD: '#field',
+  DEFAULT_SLOT: 'slot:not([name])',
+  LABEL_SLOT: 'slot[name=label]',
   CLEAR_BUTTON_SLOT: 'slot[name=clear-button]',
   FORGE_LABEL: LABEL_CONSTANTS.elementName,
   INPUT:

--- a/src/lib/text-field/text-field-core.ts
+++ b/src/lib/text-field/text-field-core.ts
@@ -24,6 +24,7 @@ export class TextFieldCore extends BaseFieldCore<ITextFieldAdapter> implements I
     this._adapter.tryApplyGlobalConfiguration(['labelPosition', 'variant']);
     this._adapter.addRootListener('slotchange', this._slotChangeListener);
     this._adapter.addRootListener('input', this._inputListener);
+    this._initializeSlots();
   }
 
   public destroy(): void {
@@ -36,14 +37,22 @@ export class TextFieldCore extends BaseFieldCore<ITextFieldAdapter> implements I
     return this._adapter.popoverTargetElement;
   }
 
+  private _initializeSlots(): void {
+    this._adapter.getAllSlotElements().forEach(slot => this._handleSlotChange(slot.name));
+  }
+
   private _onSlotChange(evt: Event): void {
     const target = evt.target as HTMLSlotElement;
-    switch (target.name) {
+    this._handleSlotChange(target.name);
+  }
+
+  private _handleSlotChange(name: string): void {
+    switch (name) {
       case 'label':
-        this._adapter.tryConnectSlottedLabel(target);
+        this._adapter.tryConnectSlottedLabel();
         break;
       case '':
-        this._adapter.handleDefaultSlotChange(target, this._inputAttributeListener);
+        this._adapter.handleDefaultSlotChange(this._inputAttributeListener);
         this._adapter.tryAddValueChangeListener(this, this._valueChangeListener);
         this._tryFloatLabel();
         break;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
In a rare edge case if fields are added to the DOM before the `slotchange` event listener runs, the internal state for inset (floating) labels would not initialize properly. This change adds an explicit detection step when connecting to the DOM to ensure that this DOM state is properly captured on initialization and when slotted content changes.

## Additional information
This was found (and only reproducible) in an Angular component where content projection and conditional `<ng-content>` elements were used together. This resulted in a timing edge case that the field-like components were not capturing properly.
