### PR TITLE
fix(circular-progress): updated the host element to set `block-size` and `inline-size` explicitly

### DIFF
--- a/src/lib/circular-progress/_core.scss
+++ b/src/lib/circular-progress/_core.scss
@@ -9,8 +9,8 @@ $_cycle-duration: calc(4 * #{token(arc-duration)});
 @mixin container {
   display: inline-flex;
   vertical-align: middle;
-  min-block-size: #{token(size)};
-  min-inline-size: #{token(size)};
+  block-size: #{token(size)};
+  inline-size: #{token(size)};
   position: relative;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The host element styles will now use `block-size` and `inline-size` to set an explicit size instead of `min-block-size` and `min-inline-size` to avoid cases where flex layouts could inadvertently take control of the element dimensions.