### PR TITLE
fix(base-button): fixed a bug where calling `.click()` on a button before it's connected would result in an exception

### DIFF
--- a/src/lib/button/base/base-button-adapter.ts
+++ b/src/lib/button/base/base-button-adapter.ts
@@ -225,7 +225,7 @@ export abstract class BaseButtonAdapter<T extends IBaseButton> extends BaseAdapt
   }
 
   public animateStateLayer(): void {
-    if (this._stateLayerElement.disabled) {
+    if (this._stateLayerElement.disabled || !this._stateLayerElement.isConnected) {
       return;
     }
     this._stateLayerElement?.playAnimation();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Calling `click()` on any element that derives from the base button before the element is connected to the DOM would result in an exception relating to the state-layer `playAnimation()` method. This change ensures that the state layer is connected to the DOM before attempting to run its visual animation-related logic in response to a click event.
