### PR TITLE
fix(tab-bar): allow individually disabled tabs with enabled tab-bar

### DIFF
--- a/src/lib/tabs/tab-bar/tab-bar-core.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-core.ts
@@ -180,7 +180,7 @@ export class TabBarCore implements ITabBarCore {
   private _syncTabState(): void {
     this._tabs.forEach((tab, index) => {
       tab.selected = index === this._activeTab;
-      tab.disabled = this._disabled;
+      if (this._disabled) tab.disabled = this._disabled;
       tab.vertical = this._vertical;
       tab.stacked = this._stacked;
       tab.secondary = this._secondary;

--- a/src/lib/tabs/tab-bar/tab-bar.ts
+++ b/src/lib/tabs/tab-bar/tab-bar.ts
@@ -47,7 +47,7 @@ declare global {
  * @dependency forge-icon-button
  * @dependency forge-icon
  *
- * @property {boolean} [disabled=false] - The disabled state of the tab bar.
+ * @property {boolean} [disabled=false] - Sets the disabled state of all child tabs.  If true, any new tabs added to the DOM will be disabled by default. This can be used instead of setting individual tab disabled properties, mixing the two methods of disabling is not supported.
  * @property {number} [activeTab=null] - The index of the active tab.
  * @property {boolean} [vertical=false] - Controls whether the tab bar is vertical or horizontal.
  * @property {boolean} [clustered=false] - Controls whether the tabs stretch the full width of their container or cluster together at their minimum width.

--- a/src/lib/tabs/tab/tab-constants.ts
+++ b/src/lib/tabs/tab/tab-constants.ts
@@ -19,9 +19,7 @@ const selectors = {
   INDICATOR: '.indicator'
 };
 
-const classes = {
-  SELECTED: 'selected'
-};
+const classes = {};
 
 const events = {
   SELECT: `${elementName}-select`

--- a/src/lib/tabs/tab/tab.ts
+++ b/src/lib/tabs/tab/tab.ts
@@ -35,7 +35,7 @@ declare global {
  * @dependency forge-focus-indicator
  * @dependency forge-state-layer
  *
- * @property {boolean} [disabled=false] - The disabled state of the tab.
+ * @property {boolean} [disabled=false] - The disabled state of the tab. Should not be set if using the disabled property on `forge-tab-bar`.
  * @property {boolean} [selected=false] - The selected state of the tab.
  * @property {boolean} [vertical=false] - Controls whether the tab is vertical or horizontal.
  * @property {boolean} [stacked=false] - Controls whether the tab is taller to allow for slotted leading/trailing elements.

--- a/src/lib/tabs/tabs.test.ts
+++ b/src/lib/tabs/tabs.test.ts
@@ -104,6 +104,20 @@ describe('Tabs', () => {
     ).to.be.true;
   });
 
+  it('should not override tab disabled if disabled is false', async () => {
+    const el = await createFixture({ disabled: false, tabDisabled: [true, true, true] });
+    const ctx = new TabsHarness(el);
+
+    await expect(el).to.be.accessible();
+    expect(el.disabled).to.be.false;
+    expect(
+      ctx.tabs.every(tab => {
+        const stateLayer = getShadowElement(tab, STATE_LAYER_CONSTANTS.elementName) as IStateLayerComponent;
+        return tab.disabled && tab.hasAttribute('disabled') && stateLayer.disabled;
+      })
+    ).to.be.true;
+  });
+
   it('should set stacked', async () => {
     const el = await createFixture({ stacked: true });
     const ctx = new TabsHarness(el);
@@ -705,6 +719,7 @@ interface TabsFixtureConfig {
   autoActivate?: boolean;
   width?: string;
   height?: string;
+  tabDisabled?: [boolean, boolean, boolean];
 }
 
 async function createFixture({
@@ -718,12 +733,13 @@ async function createFixture({
   scrollButtons,
   autoActivate,
   width,
-  height
+  height,
+  tabDisabled
 }: TabsFixtureConfig = {}): Promise<ITabBarComponent> {
   return fixture(html`
     <forge-tab-bar
       .activeTab=${activeTab}
-      .disabled=${disabled}
+      ?disabled=${disabled}
       .vertical=${vertical}
       .clustered=${clustered}
       .stacked=${stacked}
@@ -732,9 +748,9 @@ async function createFixture({
       .autoActivate=${autoActivate}
       .scrollButtons=${scrollButtons}
       style="width: ${width ?? 'auto'}; height: ${height ?? 'auto'}">
-      <forge-tab>First</forge-tab>
-      <forge-tab>Second</forge-tab>
-      <forge-tab>Third</forge-tab>
+      <forge-tab ?disabled=${tabDisabled?.[0]}>First</forge-tab>
+      <forge-tab ?disabled=${tabDisabled?.[1]}>Second</forge-tab>
+      <forge-tab ?disabled=${tabDisabled?.[2]}>Third</forge-tab>
     </forge-tab-bar>
   `);
 }


### PR DESCRIPTION
Fixes #707

## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Initially and when new tabs are added to the DOM, only override their disabled state if the tab-bar is disabled, otherwise respect the disabled state of the tabs itself.

Setting the disabled property of the tab-bar will still override the disabled state of all child tabs.  Documentation has been updated to indicate that mixing the two methods of disabling tabs is not supported.  In scenarios where tabs are always enabled/disabled as a group, the developer has the option of setting tab-bar disabled as a convenience.  If there are scenarios where individual tabs can be disabled under separate conditions, then the developer should update the tab disabled properties exclusively.

## Additional information
Had to update the test harness to update the disabled attribute rather than property.  Lit's property binding always sets the property, and was explicitly setting the tab-bar `disabled` property to false, which is not the same as omitting the attribute.