### PR TITLE
fix(paginator): append select popover to shadow root to attach IDREFs

### DIFF
--- a/src/dev/pages/paginator/paginator.ejs
+++ b/src/dev/pages/paginator/paginator.ejs
@@ -1,3 +1,3 @@
-<forge-paginator disabled id="forge-paginator-example" total="100"></forge-paginator>
+<forge-paginator id="forge-paginator-example" total="100"></forge-paginator>
 
 <script type="module" src="paginator.ts"></script>

--- a/src/lib/paginator/paginator.html
+++ b/src/lib/paginator/paginator.html
@@ -1,5 +1,5 @@
 <template>
-  <div class="forge-paginator" part="root">
+  <div class="forge-paginator" part="root" forge-popover-host>
     <div class="container" part="container">
       <div class="label" part="label" id="label">
         <slot name="label"></slot>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Ensures that the `<forge-popover>` element for the rows per page select is appended within the shadow root of the paginator to allow for IDREF attributes to reference the correct elements in the dynamic dropdown.

## Additional information
Fixes #715 
