### PR TITLE
fix(field): use error color for support text when field is invalid

### DIFF
--- a/src/lib/field/_core.theme.scss
+++ b/src/lib/field/_core.theme.scss
@@ -161,3 +161,7 @@ $elevations: (
 @mixin invalid-label-color {
   @include override(label-color, theme.variable(error), value);
 }
+
+@mixin invalid-support-text-color {
+  color: #{theme.variable(error)};
+}

--- a/src/lib/field/field.scss
+++ b/src/lib/field/field.scss
@@ -173,6 +173,10 @@ $variants: (
   .forge-field {
     @include core.theme('error');
     @include core.invalid-label-color;
+
+    .support-text {
+      @include core.invalid-support-text-color;
+    }
   }
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N/A

## Describe the new behavior?
Fixes a regression where support text wasn't changing to the error color when a field is invalid.