### PR TITLE
fix(dialog): expose CSS-only stylesheet

### DIFF
--- a/src/lib/dialog/_animations.scss
+++ b/src/lib/dialog/_animations.scss
@@ -4,7 +4,7 @@
 // Zoom (default)
 //
 
-@keyframes zoom-in {
+@keyframes forge-dialog-zoom-in {
   from {
     opacity: #{token(zoom-opacity)};
     scale: #{token(zoom-scale)};
@@ -15,7 +15,7 @@
   }
 }
 
-@keyframes zoom-out {
+@keyframes forge-dialog-zoom-out {
   from {
     opacity: 1;
     scale: 1;
@@ -30,7 +30,7 @@
 // Fade
 //
 
-@keyframes fade-in {
+@keyframes forge-dialog-fade-in {
   from {
     opacity: #{token(fade-opacity)};
   }
@@ -39,7 +39,7 @@
   }
 }
 
-@keyframes fade-out {
+@keyframes forge-dialog-fade-out {
   from {
     opacity: 1;
   }
@@ -52,7 +52,7 @@
 // Slide
 //
 
-@keyframes slide-in {
+@keyframes forge-dialog-slide-in {
   from {
     opacity: #{token(slide-opacity)};
     translate: #{token(slide-translate)};
@@ -64,7 +64,7 @@
   }
 }
 
-@keyframes slide-out {
+@keyframes forge-dialog-slide-out {
   from {
     opacity: 1;
     translate: 0 0;

--- a/src/lib/dialog/build.json
+++ b/src/lib/dialog/build.json
@@ -1,5 +1,5 @@
 {
   "$schema": "../../../node_modules/@tylertech/forge-cli/config/build-schema.json",
   "extends": "../build.json",
-  "stylesheets": ["./forge-dialog-utils.scss"]
+  "stylesheets": ["./forge-dialog.scss", "./forge-dialog-utils.scss"]
 }

--- a/src/lib/dialog/dialog.scss
+++ b/src/lib/dialog/dialog.scss
@@ -168,10 +168,10 @@ $can-animate: '[visible]:not([animation-type=none])';
   :host(#{$can-animate}:is(:not([animation-type]), [animation-type='zoom'])) {
     dialog.forge-dialog[open] {
       .surface {
-        animation-name: zoom-in;
+        animation-name: forge-dialog-zoom-in;
 
         &.exiting {
-          animation-name: zoom-out;
+          animation-name: forge-dialog-zoom-out;
         }
       }
     }
@@ -181,10 +181,10 @@ $can-animate: '[visible]:not([animation-type=none])';
   :host(#{$can-animate}[animation-type='fade']) {
     dialog.forge-dialog[open] {
       .surface {
-        animation-name: fade-in;
+        animation-name: forge-dialog-fade-in;
 
         &.exiting {
-          animation-name: fade-out;
+          animation-name: forge-dialog-fade-out;
         }
       }
     }
@@ -194,10 +194,10 @@ $can-animate: '[visible]:not([animation-type=none])';
   :host(#{$can-animate}[animation-type='slide']) {
     dialog.forge-dialog[open] {
       .surface {
-        animation-name: slide-in;
+        animation-name: forge-dialog-slide-in;
 
         &.exiting {
-          animation-name: slide-out;
+          animation-name: forge-dialog-slide-out;
         }
       }
     }
@@ -247,10 +247,10 @@ $can-animate: '[visible]:not([animation-type=none])';
     }
 
     .surface {
-      animation-name: slide-in;
+      animation-name: forge-dialog-slide-in;
 
       &.exiting {
-        animation-name: slide-out;
+        animation-name: forge-dialog-slide-out;
       }
     }
   }
@@ -353,10 +353,10 @@ $can-animate: '[visible]:not([animation-type=none])';
 @layer media {
   @media (prefers-reduced-motion: reduce) {
     .surface {
-      animation-name: fade-in;
+      animation-name: forge-dialog-fade-in;
 
       &.exiting {
-        animation-name: fade-out;
+        animation-name: forge-dialog-fade-out;
       }
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The `forge-dialog.scss` file was not being built and distributed with the npm package. This change ensures that happens, as well as updated the animation names to be prefixed for when they are potentially loaded on the page globally to avoid conflicts.
