### PR TITLE
fix: updated card and scaffold to allow for overflowing content by default

### DIFF
--- a/src/lib/core/styles/tokens/card/_tokens.scss
+++ b/src/lib/core/styles/tokens/card/_tokens.scss
@@ -16,7 +16,7 @@ $tokens: (
   elevation: utils.module-val(card, elevation, none),
   padding: utils.module-val(card, padding, spacing.variable(medium)),
   shape: utils.module-val(card, shape, shape.variable(medium)),
-  overflow: utils.module-val(card, overflow, hidden),
+  overflow: utils.module-val(card, overflow, initial),
   // Raised
   raised-elevation: utils.module-val(card, raised-elevation, elevation.value(1)),
   raised-outline-width: utils.module-val(card, raised-outline-width, 0)

--- a/src/lib/core/styles/tokens/scaffold/_tokens.scss
+++ b/src/lib/core/styles/tokens/scaffold/_tokens.scss
@@ -4,7 +4,7 @@
 $tokens: (
   height: utils.module-val(scaffold, height, 100%),
   width: utils.module-val(scaffold, width, 100%),
-  overflow: utils.module-val(scaffold, overflow, hidden),
+  overflow: utils.module-val(scaffold, overflow, initial),
   body-position: utils.module-val(scaffold, body-position, relative)
 ) !default;
 

--- a/src/lib/scaffold/_core.scss
+++ b/src/lib/scaffold/_core.scss
@@ -47,7 +47,7 @@
   width: #{token(width)};
   min-width: 0;
   min-height: 0;
-  overflow: hidden;
+  overflow: #{token(overflow)};
 }
 
 @mixin footer {

--- a/src/lib/scaffold/forge-scaffold.scss
+++ b/src/lib/scaffold/forge-scaffold.scss
@@ -28,7 +28,7 @@
     grid-area: body;
     min-width: 0;
     min-height: 0;
-    overflow: hidden;
+    overflow: #{core.token(overflow)};
 
     > * {
       @include core.scrollable;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? Potentially, but this is a more sane default for the majority of use cases.
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Updates the card and scaffold internal `overflow` styles to default to `initial` (allow overflowing content) instead of `hidden`.

## Additional information
This change _could_ potentially cause inadvertent overflow in specific layouts that rely on it, but in initial testing this would likely be pretty rare, and it is much more likely (and predictable) that developers want overflow by default and instead manually set `hidden` if desired via the component specific tokens. This is consistent with how default CSS works.
