### PR TITLE
fix: fixed a composition/initialization bug for `<forge-autocomplete>` and `<forge-app-bar-search>`

### DIFF
--- a/src/lib/app-bar/search/app-bar-search-adapter.ts
+++ b/src/lib/app-bar/search/app-bar-search-adapter.ts
@@ -25,10 +25,6 @@ export class AppBarSearchAdapter extends BaseAdapter<IAppBarSearchComponent> imp
     if (inputElement) {
       this._inputElement = inputElement as HTMLInputElement;
 
-      if (!this._inputElement.hasAttribute('slot')) {
-        this._inputElement.slot = 'input';
-      }
-
       const focusIndicator = document.createElement('forge-focus-indicator');
       focusIndicator.targetElement = this._inputElement;
       this._rootElement.appendChild(focusIndicator);

--- a/src/lib/app-bar/search/app-bar-search.html
+++ b/src/lib/app-bar/search/app-bar-search.html
@@ -4,6 +4,7 @@
       <forge-icon name="search" class="icon" part="icon"></forge-icon>
     </slot>
     <slot name="input"></slot>
+    <slot></slot>
     <slot name="end"></slot>
   </div>
 </template>

--- a/src/lib/autocomplete/autocomplete-adapter.ts
+++ b/src/lib/autocomplete/autocomplete-adapter.ts
@@ -1,15 +1,15 @@
-import { deepQuerySelectorAll, getActiveElement, toggleAttribute } from '@tylertech/forge-core';
-import { BaseAdapter, IBaseAdapter } from '../core/base/base-adapter';
-import { IAutocompleteComponent } from './autocomplete';
-import { AUTOCOMPLETE_CONSTANTS, IAutocompleteOption, IAutocompleteOptionGroup } from './autocomplete-constants';
-import { ITextFieldComponent, TEXT_FIELD_CONSTANTS } from '../text-field';
-import { IListDropdown, IListDropdownConfig, ListDropdown } from '../list-dropdown';
+import { getActiveElement, toggleAttribute } from '@tylertech/forge-core';
 import { CHIP_FIELD_CONSTANTS, IChipFieldComponent } from '../chip-field';
-import { IPopoverComponent } from '../popover/popover';
-import { POPOVER_CONSTANTS } from '../popover';
-import type { IFieldComponent } from '../field/field';
+import { BaseAdapter, IBaseAdapter } from '../core/base/base-adapter';
 import { setAriaControls, tryCreateAriaControlsPlaceholder } from '../core/utils/utils';
 import { FIELD_CONSTANTS } from '../field';
+import type { IFieldComponent } from '../field/field';
+import { IListDropdown, IListDropdownConfig, ListDropdown } from '../list-dropdown';
+import { POPOVER_CONSTANTS } from '../popover';
+import { IPopoverComponent } from '../popover/popover';
+import { ITextFieldComponent, TEXT_FIELD_CONSTANTS } from '../text-field';
+import { IAutocompleteComponent } from './autocomplete';
+import { AUTOCOMPLETE_CONSTANTS, IAutocompleteOption, IAutocompleteOptionGroup } from './autocomplete-constants';
 
 export interface IAutocompleteAdapter extends IBaseAdapter {
   readonly inputElement: HTMLInputElement;
@@ -68,7 +68,7 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
   }
 
   public setInputElement(): HTMLInputElement {
-    const inputElements = deepQuerySelectorAll(this._component, AUTOCOMPLETE_CONSTANTS.selectors.INPUT, false);
+    const inputElements = this._component.querySelectorAll(AUTOCOMPLETE_CONSTANTS.selectors.INPUT);
     if (inputElements.length) {
       this._inputElement = inputElements[0] as HTMLInputElement;
     }

--- a/src/lib/autocomplete/autocomplete-core.ts
+++ b/src/lib/autocomplete/autocomplete-core.ts
@@ -191,9 +191,11 @@ export class AutocompleteCore extends ListDropdownAwareCore implements IAutocomp
     return this._options as IAutocompleteOption[];
   }
 
-  private _onClick(evt: MouseEvent): void {
+  private _onClick(_evt: MouseEvent): void {
     if (!this._isDropdownOpen && this._filterOnFocus) {
       this._showDropdown();
+    } else {
+      this._closeDropdown();
     }
   }
 

--- a/src/lib/list-dropdown/list-dropdown-utils.ts
+++ b/src/lib/list-dropdown/list-dropdown-utils.ts
@@ -64,6 +64,7 @@ export function createPopupDropdown(config: IListDropdownOpenConfig, targetEleme
   popoverElement.anchorElement = targetElement;
   popoverElement.placement = config.popupPlacement || 'bottom-start';
   popoverElement.persistent = Boolean(config.popupStatic);
+  popoverElement.triggerType = 'manual';
 
   if (config.popupFallbackPlacements?.length) {
     popoverElement.fallbackPlacements = config.popupFallbackPlacements;

--- a/src/lib/popover/popover-core.ts
+++ b/src/lib/popover/popover-core.ts
@@ -324,7 +324,7 @@ export class PopoverCore extends WithLongpressListener(OverlayAwareCore<IPopover
    *
    * Only called when using the "click" (default) trigger type.
    */
-  private _onAnchorClick(evt: PointerEvent): void {
+  private _onAnchorClick(_evt: PointerEvent): void {
     if (!this.open) {
       this._openPopover();
     } else {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
There are 3 bugs fixed in this PR, and they are all related so I chose to keep them together in a single PR:

1. `ListDropdown`: The resulting `<forge-popover>` will now use `triggerType = 'manual'` to avoid click event conflicts with the anchor element when the popover is "anchored" to a different element than the element it listens for interactions on. All components that utilize the `ListDropdown` already handle their own interaction events anyway, so this just required a small tweak to the autocomplete to ensure it closes the dropdown when clicking on the `<input>` element while open.
2. `<forge-autocomplete>` updated the initialization logic to only search direct DOM children instead of deep shadow root recursion. The deep querying was not necessary to begin with due to the component only ever initializing if a direct `<input>` element in the children existed anyway... 
3. `<forge-app-bar-search>` added a new default (unnamed) `<slot>`. The "input" slot was not document, and it the component attempts to set `slot="input"` on any `<input>` elements without a `slot` attr during initialization which causes a race condition when composed with `<forge-autocomplete>` during initialization and attempting to locate the target `<input>`.
