### PR TITLE
fix(button): fixed inline padding on all non-text variants

### DIFF
--- a/src/dev/pages/button/button.ejs
+++ b/src/dev/pages/button/button.ejs
@@ -16,12 +16,12 @@
     <div>
       <button class="forge-button">Text button</button>
       <button class="forge-button forge-button--outlined">
-        <!-- <forge-icon name="favorite"></forge-icon> -->
+        <forge-icon name="favorite"></forge-icon>
         Outlined button
       </button>
       <button class="forge-button forge-button--tonal">
         Tonal button
-        <!-- <forge-icon name="favorite"></forge-icon> -->
+        <forge-icon name="favorite"></forge-icon>
       </button>
       <button class="forge-button forge-button--filled">Filled button</button>
       <button class="forge-button forge-button--raised">Raised button</button>

--- a/src/dev/pages/button/button.ejs
+++ b/src/dev/pages/button/button.ejs
@@ -1,53 +1,56 @@
 <div class="button-demo">
-  <section class="vert">
+  <section>
     <h3 class="forge-typography--heading2">Variants</h3>
-    <forge-button>Text button</forge-button>
-    <forge-button variant="outlined">Outlined button</forge-button>
-    <forge-button variant="tonal">Tonal button</forge-button>
-    <forge-button variant="filled">Filled button</forge-button>
-    <forge-button variant="raised">Raised button</forge-button>
-    <forge-button variant="link">Link button</forge-button>
+    <div>
+      <forge-button>Text button</forge-button>
+      <forge-button variant="outlined">Outlined button</forge-button>
+      <forge-button variant="tonal">Tonal button</forge-button>
+      <forge-button variant="filled">Filled button</forge-button>
+      <forge-button variant="raised">Raised button</forge-button>
+      <forge-button variant="link">Link button</forge-button>
+    </div>
   </section>
 
-  <section class="vert">
+  <section>
     <h3 class="forge-typography--heading2">CSS only</h3>
-    <button class="forge-button">Text button</button>
-    <button class="forge-button forge-button--outlined">
-      <forge-icon name="favorite"></forge-icon>
-      Outlined button
-    </button>
-    <button class="forge-button forge-button--tonal">
-      Tonal button
-      <forge-icon name="favorite"></forge-icon>
-    </button>
-    <button class="forge-button forge-button--filled">Filled button</button>
-    <button class="forge-button forge-button--raised">Raised button</button>
     <div>
+      <button class="forge-button">Text button</button>
+      <button class="forge-button forge-button--outlined">
+        <!-- <forge-icon name="favorite"></forge-icon> -->
+        Outlined button
+      </button>
+      <button class="forge-button forge-button--tonal">
+        Tonal button
+        <!-- <forge-icon name="favorite"></forge-icon> -->
+      </button>
+      <button class="forge-button forge-button--filled">Filled button</button>
+      <button class="forge-button forge-button--raised">Raised button</button>
       <button class="forge-button forge-button--link">Link button</button>
     </div>
   </section>
 
-  <section class="vert">
+  <section>
     <h3 class="forge-typography--heading2">Slots</h3>
+    <div>
+      <forge-button variant="outlined">
+        <span>w/&lt;span&gt; text container</span>
+      </forge-button>
 
-    <forge-button variant="outlined">
-      <span>w/&lt;span&gt; text container</span>
-    </forge-button>
+      <forge-button variant="outlined">
+        <forge-icon slot="start" name="favorite"></forge-icon>
+        w/Start icon
+      </forge-button>
 
-    <forge-button variant="outlined">
-      <forge-icon slot="start" name="favorite"></forge-icon>
-      w/Start icon
-    </forge-button>
-
-    <forge-button variant="outlined">
-      w/End icon
-      <forge-icon slot="end" name="favorite"></forge-icon>
-    </forge-button>
+      <forge-button variant="outlined">
+        w/End icon
+        <forge-icon slot="end" name="favorite"></forge-icon>
+      </forge-button>
+    </div>
   </section>
 
   <section>
     <h3 class="forge-typography--heading2">Anchor</h3>
-    <div class="vert">
+    <div>
       <forge-button>
         <a href="javascript: console.log('Anchor button clicked');">
           Anchor button
@@ -94,7 +97,7 @@
 
   <section>
     <h3 class="forge-typography--heading2">Label aware</h3>
-    <forge-label class="vert">
+    <forge-label class="flex">
       <forge-button variant="outlined">
         <forge-icon name="favorite"></forge-icon>
       </forge-button>
@@ -175,38 +178,40 @@
     </dialog>
   </section>
 
-  <section class="vert">
+  <section>
     <h3 class="forge-typography--heading2">Deprecated (legacy) button</h3>
-    <forge-deprecated-button>
-      <button type="button">Default button</button>
-    </forge-deprecated-button>
-    <forge-deprecated-button type="outlined">
-      <button type="button">Outlined button</button>
-    </forge-deprecated-button>
-    <forge-deprecated-button type="unelevated">
-      <button type="button">Unelevated button</button>
-    </forge-deprecated-button>
-    <forge-deprecated-button type="raised">
-      <button type="button">Raised button</button>
-    </forge-deprecated-button>
-    <forge-deprecated-button type="outlined">
-      <button type="button">
-        <forge-icon name="favorite"></forge-icon>
-        <span>w/Leading Icon</span>
-      </button>
-    </forge-deprecated-button>
-    <forge-deprecated-button type="outlined">
-      <button type="button">
-        <span>w/Trailing icon</span>
-        <forge-icon name="favorite"></forge-icon>
-      </button>
-    </forge-deprecated-button>
-    <forge-deprecated-button type="outlined">
-      <a href="javascript: alert('Anchor link button works!');">
-        <span>w/anchor tag</span>
-        <forge-icon name="open_in_new"></forge-icon>
-      </a>
-    </forge-deprecated-button>
+    <div class="flex flex--wrap">
+      <forge-deprecated-button>
+        <button type="button">Default button</button>
+      </forge-deprecated-button>
+      <forge-deprecated-button type="outlined">
+        <button type="button">Outlined button</button>
+      </forge-deprecated-button>
+      <forge-deprecated-button type="unelevated">
+        <button type="button">Unelevated button</button>
+      </forge-deprecated-button>
+      <forge-deprecated-button type="raised">
+        <button type="button">Raised button</button>
+      </forge-deprecated-button>
+      <forge-deprecated-button type="outlined">
+        <button type="button">
+          <forge-icon name="favorite"></forge-icon>
+          <span>w/Leading Icon</span>
+        </button>
+      </forge-deprecated-button>
+      <forge-deprecated-button type="outlined">
+        <button type="button">
+          <span>w/Trailing icon</span>
+          <forge-icon name="favorite"></forge-icon>
+        </button>
+      </forge-deprecated-button>
+      <forge-deprecated-button type="outlined">
+        <a href="javascript: alert('Anchor link button works!');">
+          <span>w/anchor tag</span>
+          <forge-icon name="open_in_new"></forge-icon>
+        </a>
+      </forge-deprecated-button>
+    </div>
   </section>
 </div>
 

--- a/src/dev/pages/button/button.scss
+++ b/src/dev/pages/button/button.scss
@@ -4,14 +4,14 @@
 @use '../../../lib/focus-indicator';
 @use '../../../lib/core/styles/elevation';
 
+.content > .card {
+  max-width: 1024px;
+}
+
 .button-demo {
   display: flex;
   flex-direction: column;
   gap: 16px;
-}
-
-:is(forge-button,forge-deprecated-button,.forge-button:not(.forge-button--link)):not([full-width]) {
-  width: 256px;
 }
 
 form:has(forge-button) forge-button,

--- a/src/dev/src/styles/_flex.scss
+++ b/src/dev/src/styles/_flex.scss
@@ -2,4 +2,8 @@
   display: flex;
   gap: 16px;
   align-items: center;
+
+  &--wrap {
+    flex-wrap: wrap;
+  }
 }

--- a/src/lib/button/_core.scss
+++ b/src/lib/button/_core.scss
@@ -7,6 +7,7 @@
   display: #{token(display)};
   position: relative;
   outline: none;
+  vertical-align: middle;
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -94,6 +95,10 @@
   border-radius: #{token(shape)};
 
   text-decoration: none;
+}
+
+@mixin text {
+  @include override(padding-inline, text-padding-inline);
 }
 
 @mixin filled {

--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -131,6 +131,12 @@ forge-focus-indicator {
 // Variants
 //
 
+:host(:where(:not([variant]), [variant='text'])) {
+  .forge-button {
+    @include text;
+  }
+}
+
 :host([variant='filled']) {
   .forge-button {
     @include filled;

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -94,6 +94,9 @@ declare global {
  * @cssproperty --forge-button-hover-shadow - The shadow of the button on hover.
  * @cssproperty --forge-button-active-shadow - The shadow of the button on active state.
  * @cssproperty --forge-button-cursor - The cursor type of the button.
+ * @cssproperty --forge-button-transition-duration - The transition duration of the button.
+ * @cssproperty --forge-button-transition-timing - The transition timing of the button.
+ * @cssproperty --forge-button-text-padding-inline - The inline padding of the button when using the text variant.
  * @cssproperty --forge-button-filled-background - The background color of the filled button.
  * @cssproperty --forge-button-filled-disabled-background - The background color of the disabled filled button.
  * @cssproperty --forge-button-filled-color - The text color of the filled button.

--- a/src/lib/button/forge-button.scss
+++ b/src/lib/button/forge-button.scss
@@ -38,6 +38,11 @@
     pointer-events: initial;
   }
 
+  &:where(:not(.forge-button--outlined, .forge-button--tonal, .forge-button--filled, .forge-button--raised, .forge-button--link)),
+  &--text {
+    @include core.text;
+  }
+
   &--outlined {
     @include core.outlined;
 

--- a/src/lib/core/styles/tokens/button/_tokens.scss
+++ b/src/lib/core/styles/tokens/button/_tokens.scss
@@ -13,7 +13,7 @@ $tokens: (
   primary-color: utils.module-val(button, primary-color, theme.variable(primary)),
   text-color: utils.module-ref(button, text-color, primary-color),
   disabled-color: utils.module-val(button, disabled-color, theme.variable(surface-container)),
-  padding: utils.module-val(button, padding, 8px),
+  padding: utils.module-val(button, padding, spacing.variable(medium)),
   display: utils.module-val(button, display, inline-flex),
   justify: utils.module-val(button, justify, center),
   shape: utils.module-val(button, shape, shape.variable(medium)),
@@ -41,6 +41,8 @@ $tokens: (
   cursor: utils.module-val(button, cursor, pointer),
   transition-duration: utils.module-val(button, transition-duration, animation.variable(duration-short3)),
   transition-timing: utils.module-val(button, transition-timing, animation.variable(easing-standard)),
+  // Text
+  text-padding-inline: utils.module-val(button, text-padding-inline, spacing.variable(xsmall)),
   // Outlined
   outlined-background: utils.module-val(button, outlined-background, transparent),
   outlined-color: utils.module-ref(button, outlined-color, primary-color),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
All non-text and non-link variants will now use the correct `padding-inline` value.

Additionally, included a change to `vertical-align` on the host element to ensure that inline buttons next to each other are aligned properly.