### PR TITLE
fix(field): fixed a bug where the width could collapse while the inset label animation is executing

### DIFF
--- a/src/lib/field/field-adapter.ts
+++ b/src/lib/field/field-adapter.ts
@@ -19,6 +19,7 @@ export interface IFieldAdapter extends IBaseAdapter<IFieldComponent> {
 export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IFieldAdapter {
   private readonly _rootElement: HTMLElement;
   private readonly _containerElement: HTMLElement;
+  private readonly _inputContainerElement: HTMLElement;
   private readonly _labelElement: HTMLElement;
   private readonly _popoverIconElement: HTMLElement;
   private readonly _focusIndicatorElement: IFocusIndicatorComponent;
@@ -31,6 +32,7 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
     super(component);
     this._rootElement = getShadowElement(component, FIELD_CONSTANTS.selectors.ROOT);
     this._containerElement = getShadowElement(component, FIELD_CONSTANTS.selectors.CONTAINER);
+    this._inputContainerElement = getShadowElement(component, FIELD_CONSTANTS.selectors.INPUT_CONTAINER);
     this._labelElement = getShadowElement(component, FIELD_CONSTANTS.selectors.LABEL);
     this._popoverIconElement = getShadowElement(component, FIELD_CONSTANTS.selectors.POPOVER_ICON);
     this._focusIndicatorElement = getShadowElement(component, FOCUS_INDICATOR_CONSTANTS.elementName) as IFocusIndicatorComponent;
@@ -70,11 +72,18 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
       return;
     }
 
+    // Temporarily lock the input container element width to its current width before the animation starts
+    // to ensure that the element cannot collapse while the animation is executing. The width will be
+    // removed after the animation completes.
+    const { width: inputContainerWidth } = this._inputContainerElement.getBoundingClientRect();
+    this._inputContainerElement.style.setProperty('width', `${inputContainerWidth}px`);
+
     const className = value ? FIELD_CONSTANTS.classes.FLOATING_IN : FIELD_CONSTANTS.classes.FLOATING_OUT;
     const animationName = value ? FIELD_CONSTANTS.animations.FLOAT_IN_LABEL : FIELD_CONSTANTS.animations.FLOAT_OUT_LABEL;
     const animationEndListener: EventListener = (evt: AnimationEvent) => {
       if (evt.animationName === animationName) {
         removeClass(className, this._rootElement);
+        this._inputContainerElement.style.removeProperty('width');
         this._rootElement.removeEventListener('animationend', animationEndListener);
       }
     };

--- a/src/lib/field/field-constants.ts
+++ b/src/lib/field/field-constants.ts
@@ -30,6 +30,7 @@ const classes = {
 const selectors = {
   ROOT: '#root',
   CONTAINER: '#container',
+  INPUT_CONTAINER: '#input',
   LABEL: '#label',
   POPOVER_ICON: '#popover-icon',
   LABEL_ELEMENTS: `:where(label, ${LABEL_CONSTANTS.elementName})`,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
When fields (text-fields for example) are used within layouts that collapse their content, such as flexbox, the field width could collapse down to the min content width while the inset/floating label animation is executing. This change ensures that the internal input container locks its width to the current width before the animation begins to avoid the collapse, and then removes the locked width after the animation completes.

## Additional information
Given that this is only temporary while the animation executes, and there is no reliable CSS-based solution to it without restructuring the field component to avoid using `position: absolute`, this should be adequate.
