### PR TITLE
fix(field): hide required asterisk at extra-small density

### DIFF
--- a/src/lib/field/field.scss
+++ b/src/lib/field/field.scss
@@ -141,7 +141,8 @@ $variants: (
 
     @if $density == 'extra-small' {
       :host(#{map.get($label-positions, inset)}#{$selector}) {
-        .label {
+        .label,
+        .label::before {
           @include utils.visually-hidden;
         }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Visually hides the `::before` pseudo element at the "extra-small" density.

## Additional information
Fixes #728 
