### PR TITLE
fix(accordion): always dispatch `forge-expansion-panel-toggle` event on panels that are closing in response to a user toggling another panel

### DIFF
--- a/src/lib/accordion/accordion-constants.ts
+++ b/src/lib/accordion/accordion-constants.ts
@@ -6,7 +6,12 @@ const attributes = {
   PANEL_SELECTOR: 'panel-selector'
 };
 
+const events = {
+  TOGGLE: `${elementName}-toggle`
+};
+
 export const ACCORDION_CONSTANTS = {
   elementName,
-  attributes
+  attributes,
+  events
 };

--- a/src/lib/accordion/accordion-core.ts
+++ b/src/lib/accordion/accordion-core.ts
@@ -41,7 +41,7 @@ export class AccordionCore implements IAccordionCore {
       }
     });
 
-    this._adapter.dispatchHostEvent(new CustomEvent(ACCORDION_CONSTANTS.events.TOGGLE, { detail: evt.target }));
+    this._adapter.dispatchHostEvent(new CustomEvent(ACCORDION_CONSTANTS.events.TOGGLE, { detail: evt.target, bubbles: true, composed: true }));
   }
 
   public get panelSelector(): string {

--- a/src/lib/accordion/accordion-core.ts
+++ b/src/lib/accordion/accordion-core.ts
@@ -1,5 +1,5 @@
 import { IAccordionAdapter } from './accordion-adapter';
-import { EXPANSION_PANEL_CONSTANTS } from '../expansion-panel/expansion-panel-constants';
+import { EXPANSION_PANEL_CONSTANTS, emulateUserToggle } from '../expansion-panel/expansion-panel-constants';
 import { IExpansionPanelComponent } from '../expansion-panel';
 import { ACCORDION_CONSTANTS } from './accordion-constants';
 
@@ -35,9 +35,13 @@ export class AccordionCore implements IAccordionCore {
     const panels = this._adapter.getChildPanels(this._panelSelector);
     panels.forEach(panel => {
       if (evt.target !== panel && !this._adapter.isNestedPanel(panel)) {
-        panel.open = false;
+        if (panel.open) {
+          panel[emulateUserToggle](false);
+        }
       }
     });
+
+    this._adapter.dispatchHostEvent(new CustomEvent(ACCORDION_CONSTANTS.events.TOGGLE, { detail: evt.target }));
   }
 
   public get panelSelector(): string {

--- a/src/lib/accordion/accordion.test.ts
+++ b/src/lib/accordion/accordion.test.ts
@@ -1,10 +1,12 @@
+import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { elementUpdated, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import { IAccordionComponent } from './accordion';
+import { IExpansionPanelComponent } from '../expansion-panel';
+import { ACCORDION_CONSTANTS } from './accordion-constants';
 
 import './accordion';
-import { IExpansionPanelComponent } from '../expansion-panel';
 
 describe('Accordion', () => {
   it('should not have shadow root', async () => {
@@ -120,6 +122,21 @@ describe('Accordion', () => {
     expect(secondPanel.open).to.be.false;
     expect(thirdPanel.open).to.be.true;
   });
+
+  it('should dispatch toggle event', async () => {
+    const harness = await createFixture();
+
+    const [panel] = harness.expansionPanels;
+    const button = panel.querySelector('button');
+
+    const toggleSpy = sinon.spy();
+    harness.accordionElement.addEventListener(ACCORDION_CONSTANTS.events.TOGGLE, toggleSpy);
+
+    button?.click();
+    await elementUpdated(panel);
+
+    expect(toggleSpy).to.have.been.calledOnce;
+  });
 });
 
 class AccordionHarness {
@@ -136,7 +153,7 @@ interface IAccordionFixtureConfig {
 
 async function createFixture({ panelSelector }: IAccordionFixtureConfig = {}): Promise<AccordionHarness> {
   const accordion = await fixture<IAccordionComponent>(html`
-    <forge-accordion .panelSelector=${panelSelector}>
+    <forge-accordion .panelSelector=${panelSelector as string}>
       <forge-expansion-panel class="test-class">
         <button type="button" slot="header"></button>
         <div slot="content">Content</div>

--- a/src/lib/accordion/accordion.ts
+++ b/src/lib/accordion/accordion.ts
@@ -19,6 +19,8 @@ declare global {
  * @tag forge-accordion
  *
  * @dependency forge-expansion-panel
+ *
+ * @fires {CustomEvent<IExpansionPanelComponent>} forge-accordion-toggle - Dispatched when a child expansion panel is toggled. Includes the related expansion panel element in the event detail.
  */
 @customElement({
   name: ACCORDION_CONSTANTS.elementName,

--- a/src/lib/expansion-panel/expansion-panel-constants.ts
+++ b/src/lib/expansion-panel/expansion-panel-constants.ts
@@ -41,3 +41,4 @@ export const EXPANSION_PANEL_CONSTANTS = {
 
 export type ExpansionPanelOrientation = 'horizontal' | 'vertical';
 export type ExpansionPanelAnimationType = 'default' | 'none';
+export const emulateUserToggle = Symbol('emulateUserToggle');

--- a/src/lib/expansion-panel/expansion-panel-core.ts
+++ b/src/lib/expansion-panel/expansion-panel-core.ts
@@ -5,6 +5,7 @@ export interface IExpansionPanelCore {
   open: boolean;
   orientation: ExpansionPanelOrientation;
   animationType: ExpansionPanelAnimationType;
+  dispatchToggleEvent(): void;
 }
 
 export class ExpansionPanelCore implements IExpansionPanelCore {
@@ -34,7 +35,7 @@ export class ExpansionPanelCore implements IExpansionPanelCore {
 
     evt.stopPropagation();
     this._toggle();
-    this._dispatchToggleEvent();
+    this.dispatchToggleEvent();
   }
 
   private _onKeydown(evt: KeyboardEvent): void {
@@ -42,7 +43,7 @@ export class ExpansionPanelCore implements IExpansionPanelCore {
       evt.stopPropagation();
       evt.preventDefault();
       this._toggle();
-      this._dispatchToggleEvent();
+      this.dispatchToggleEvent();
     }
   }
 
@@ -61,7 +62,7 @@ export class ExpansionPanelCore implements IExpansionPanelCore {
     }
   }
 
-  private _dispatchToggleEvent(): void {
+  public dispatchToggleEvent(): void {
     const evt = new CustomEvent<boolean>(EXPANSION_PANEL_CONSTANTS.events.TOGGLE, {
       detail: this._open,
       bubbles: true,

--- a/src/lib/expansion-panel/expansion-panel.test.ts
+++ b/src/lib/expansion-panel/expansion-panel.test.ts
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { spy } from 'sinon';
 import { elementUpdated, fixture, html } from '@open-wc/testing';
 import { IExpansionPanelComponent } from './expansion-panel';
-import { EXPANSION_PANEL_CONSTANTS } from './expansion-panel-constants';
+import { EXPANSION_PANEL_CONSTANTS, emulateUserToggle } from './expansion-panel-constants';
 import { task } from '../core/utils/utils';
 import { IOpenIconComponent } from '../open-icon/open-icon';
 
@@ -338,6 +338,19 @@ describe('Expansion Panel', () => {
       expect(el.hasAttribute(EXPANSION_PANEL_CONSTANTS.attributes.OPEN)).to.be.true;
       expect(contentEl.classList.contains(EXPANSION_PANEL_CONSTANTS.classes.HIDDEN)).to.be.false;
       expect(toggleSpy.calledOnce).to.be.true;
+    });
+
+    it('should dispatch toggle event when calling internal emulateUserToggle symbol method', async () => {
+      const el = await fixture<IExpansionPanelComponent>(html`<forge-expansion-panel></forge-expansion-panel>`);
+
+      const toggleSpy = spy();
+      el.addEventListener(EXPANSION_PANEL_CONSTANTS.events.TOGGLE, toggleSpy);
+
+      el[emulateUserToggle](true);
+      expect(toggleSpy.calledOnce).to.be.true;
+
+      el[emulateUserToggle](false);
+      expect(toggleSpy.calledTwice).to.be.true;
     });
   });
 

--- a/src/lib/expansion-panel/expansion-panel.ts
+++ b/src/lib/expansion-panel/expansion-panel.ts
@@ -1,7 +1,7 @@
 import { attachShadowTemplate, coerceBoolean, customElement, coreProperty } from '@tylertech/forge-core';
 import { BaseComponent, IBaseComponent } from '../core/base/base-component';
 import { ExpansionPanelAdapter } from './expansion-panel-adapter';
-import { ExpansionPanelAnimationType, ExpansionPanelOrientation, EXPANSION_PANEL_CONSTANTS } from './expansion-panel-constants';
+import { ExpansionPanelAnimationType, ExpansionPanelOrientation, EXPANSION_PANEL_CONSTANTS, emulateUserToggle } from './expansion-panel-constants';
 import { ExpansionPanelCore } from './expansion-panel-core';
 
 import template from './expansion-panel.html';
@@ -103,5 +103,18 @@ export class ExpansionPanelComponent extends BaseComponent implements IExpansion
    */
   public toggle(): void {
     this.open = !this.open;
+  }
+
+  /**
+   * @internal
+   *
+   * Emulates a user toggle of the panel, by also dispatching the toggle event.
+   */
+  public [emulateUserToggle](open: boolean): void {
+    if (this.open === open) {
+      return;
+    }
+    this.open = open;
+    this._core.dispatchToggleEvent();
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Previously when a user toggled a `<forge-expansion-panel>` element via the UI, any other open panels that are closing in response to that interaction would not dispatch their `forge-expansion-panel-toggle` event.

This was problematic when code is bound to each panel that needs to be updated based on the open state of that panel, so there was not way for that code to be autonomous in response to the users toggling other panels.

This change uses a new internal API (via `Symbol` property) to allow for the `<forge-accordion>` to programmatically tell the other open panels that need to close to also dispatch their `forge-expansion-panel-toggle` event.

Additionally, a new event was added that is always dispatched from the `<forge-accordion>` called `forge-accordion-toggle` to allow developers to use an element-specific event on the accordion to listen for when any toggle interaction is triggered.
