### PR TITLE
fix: allow overflowing content in card, scaffold, and expansion panel

### DIFF
--- a/src/lib/core/styles/tokens/card/_tokens.scss
+++ b/src/lib/core/styles/tokens/card/_tokens.scss
@@ -16,7 +16,7 @@ $tokens: (
   elevation: utils.module-val(card, elevation, none),
   padding: utils.module-val(card, padding, spacing.variable(medium)),
   shape: utils.module-val(card, shape, shape.variable(medium)),
-  overflow: utils.module-val(card, overflow, hidden),
+  overflow: utils.module-val(card, overflow, initial),
   // Raised
   raised-elevation: utils.module-val(card, raised-elevation, elevation.value(1)),
   raised-outline-width: utils.module-val(card, raised-outline-width, 0)

--- a/src/lib/core/styles/tokens/scaffold/_tokens.scss
+++ b/src/lib/core/styles/tokens/scaffold/_tokens.scss
@@ -4,7 +4,7 @@
 $tokens: (
   height: utils.module-val(scaffold, height, 100%),
   width: utils.module-val(scaffold, width, 100%),
-  overflow: utils.module-val(scaffold, overflow, hidden),
+  overflow: utils.module-val(scaffold, overflow, initial),
   body-position: utils.module-val(scaffold, body-position, relative)
 ) !default;
 

--- a/src/lib/expansion-panel/_core.scss
+++ b/src/lib/expansion-panel/_core.scss
@@ -21,7 +21,6 @@
   transition-timing-function: #{token(animation-easing)};
 
   min-height: 0;
-  overflow: hidden;
 
   opacity: 0;
 }
@@ -29,7 +28,6 @@
 @mixin inner {
   display: grid;
   grid-template-rows: 1fr;
-  overflow: hidden;
 }
 
 @mixin orientation-horizontal-base {

--- a/src/lib/expansion-panel/expansion-panel-adapter.ts
+++ b/src/lib/expansion-panel/expansion-panel-adapter.ts
@@ -9,11 +9,14 @@ export interface IExpansionPanelAdapter extends IBaseAdapter {
   addHeaderListener(type: keyof HTMLElementEventMap, listener: EventListener): void;
   tryToggleOpenIcon(value: boolean): void;
   setContentVisibility(visible: boolean): void;
+  animationStart(): void;
+  animationEnd(): void;
 }
 
 export class ExpansionPanelAdapter extends BaseAdapter<IExpansionPanelComponent> implements IExpansionPanelAdapter {
   private _headerElement: HTMLElement;
   private _contentElement: HTMLElement;
+  private _innerElement: HTMLElement;
 
   private _transitionStartListener: EventListener = this._onTransitionStart.bind(this);
   private _transitionEndListener: EventListener = this._onTransitionEnd.bind(this);
@@ -23,6 +26,7 @@ export class ExpansionPanelAdapter extends BaseAdapter<IExpansionPanelComponent>
     super(component);
     this._headerElement = getShadowElement(this._component, EXPANSION_PANEL_CONSTANTS.selectors.HEADER);
     this._contentElement = getShadowElement(this._component, EXPANSION_PANEL_CONSTANTS.selectors.CONTENT);
+    this._innerElement = getShadowElement(this._component, EXPANSION_PANEL_CONSTANTS.selectors.INNER);
   }
 
   public setAnimationCompleteListener(listener: () => void): void {
@@ -57,5 +61,13 @@ export class ExpansionPanelAdapter extends BaseAdapter<IExpansionPanelComponent>
       this.toggleHostAttribute(EXPANSION_PANEL_CONSTANTS.attributes.OPENING, false);
       this._transitionCompleteListener();
     }
+  }
+
+  public animationStart(): void {
+    this._innerElement.style.overflow = 'hidden';
+  }
+
+  public animationEnd(): void {
+    this._innerElement.style.removeProperty('overflow');
   }
 }

--- a/src/lib/expansion-panel/expansion-panel-constants.ts
+++ b/src/lib/expansion-panel/expansion-panel-constants.ts
@@ -21,6 +21,7 @@ const classes = {
 const selectors = {
   HEADER: '.header',
   CONTENT: '.content',
+  INNER: '.inner',
   IGNORE: ':is([data-forge-ignore],[forge-ignore])',
   OPEN_ICON: `:is([slot=header] ${OPEN_ICON_CONSTANTS.elementName}, ${OPEN_ICON_CONSTANTS.elementName}[slot^=header])`
 };

--- a/src/lib/expansion-panel/expansion-panel-core.ts
+++ b/src/lib/expansion-panel/expansion-panel-core.ts
@@ -49,6 +49,8 @@ export class ExpansionPanelCore implements IExpansionPanelCore {
   private _onAnimationComplete(): void {
     if (!this._open) {
       this._adapter.setContentVisibility(false);
+    } else if (this._animationType !== 'none') {
+      this._adapter.animationEnd();
     }
     this._adapter.dispatchHostEvent(new CustomEvent(EXPANSION_PANEL_CONSTANTS.events.ANIMATION_COMPLETE, { detail: this._open }));
   }
@@ -57,6 +59,9 @@ export class ExpansionPanelCore implements IExpansionPanelCore {
     this._adapter.toggleHostAttribute(EXPANSION_PANEL_CONSTANTS.attributes.OPEN, this._open);
     this._adapter.tryToggleOpenIcon(this._open);
     if (this._open) {
+      if (this._animationType !== 'none') {
+        this._adapter.animationStart();
+      }
       this._adapter.setContentVisibility(true);
     }
   }

--- a/src/lib/expansion-panel/expansion-panel.scss
+++ b/src/lib/expansion-panel/expansion-panel.scss
@@ -46,6 +46,12 @@
 // Open
 //
 
+:host(:not([open])) {
+  .inner {
+    overflow: hidden;
+  }
+}
+
 :host([open]) {
   .content {
     @include open-base;

--- a/src/lib/expansion-panel/forge-expansion-panel.scss
+++ b/src/lib/expansion-panel/forge-expansion-panel.scss
@@ -18,6 +18,8 @@
 
   &__content {
     @include core.inner;
+
+    overflow: hidden;
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/lib/scaffold/_core.scss
+++ b/src/lib/scaffold/_core.scss
@@ -47,7 +47,7 @@
   width: #{token(width)};
   min-width: 0;
   min-height: 0;
-  overflow: hidden;
+  overflow: #{token(overflow)};
 }
 
 @mixin footer {

--- a/src/lib/scaffold/forge-scaffold.scss
+++ b/src/lib/scaffold/forge-scaffold.scss
@@ -28,7 +28,7 @@
     grid-area: body;
     min-width: 0;
     min-height: 0;
-    overflow: hidden;
+    overflow: #{core.token(overflow)};
 
     > * {
       @include core.scrollable;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Updates the card, scaffold, and expansion panel internal `overflow` styles to default to `initial` (or `visible` by default) instead of `hidden`.

This allows for content nested within to properly overflow its bounds for things like focus indicators.

## Additional information
This change _could_ potentially cause inadvertent overflow in specific layouts that rely on it, but in initial testing this would likely be pretty rare, and it is much more likely (and predictable) that developers want overflow by default and instead manually set `hidden` if desired via the component specific tokens. This is consistent with how default CSS works.
