### PR TITLE
fix(chip-field): fixed a bug where the dropdown would close immediately if clicking directly on the `<input>` element

### DIFF
--- a/src/lib/chip-field/chip-field-adapter.ts
+++ b/src/lib/chip-field/chip-field-adapter.ts
@@ -10,6 +10,7 @@ export interface IChipFieldAdapter extends IBaseFieldAdapter {
   readonly popoverTargetElement: HTMLElement;
   readonly hasInputValue: boolean;
   readonly inputHasFocus: boolean;
+  readonly inputElement: HTMLInputElement | undefined;
   initialize(): void;
   addRootListener(type: string, listener: EventListener, options?: EventListenerOptions): void;
   removeRootListener(type: string, listener: EventListener, options?: EventListenerOptions): void;
@@ -50,6 +51,10 @@ export class ChipFieldAdapter extends BaseFieldAdapter implements IChipFieldAdap
 
   public get inputHasFocus(): boolean {
     return !!this._inputElement?.matches(':focus');
+  }
+
+  public get inputElement(): HTMLInputElement | undefined {
+    return this._inputElement;
   }
 
   public get popoverTargetElement(): HTMLElement {

--- a/src/lib/chip-field/chip-field-core.ts
+++ b/src/lib/chip-field/chip-field-core.ts
@@ -68,8 +68,11 @@ export class ChipFieldCore extends BaseFieldCore<IChipFieldAdapter> implements I
     }
   }
 
-  private _onClick(_evt: MouseEvent): void {
+  private _onClick(evt: MouseEvent): void {
     if (this._disabled) {
+      return;
+    }
+    if (evt.target === this._adapter.inputElement) {
       return;
     }
     this._adapter.focusInput();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Updates the `<forge-chip-field>` to ignore click events that original from its child `<input>` element. This was unnecessary to begin with, but it was also causing conflicts with `<forge-autocomplete>` where the dropdown was opening and immediately closing due to both elements responding to the same click event in succession.

## Additional information
Fixes #735 caused by a regression recently in #725 
