### PR TITLE
fix(popover): gracefully handle how popovers are positioned when their dimensions are clipped by the viewport to ensure access to the content

### DIFF
--- a/src/lib/list-dropdown/list-dropdown-adapter.ts
+++ b/src/lib/list-dropdown/list-dropdown-adapter.ts
@@ -363,7 +363,7 @@ export class ListDropdownAdapter implements IListDropdownAdapter {
     if (cb && isFunction(cb)) {
       return cb();
     }
-    return this._targetElement.clientWidth;
+    return this._targetElement.getBoundingClientRect().width;
   }
 
   private _activateListOption(listItem: IListItemComponent | undefined, activeChangeCallback?: (id: string) => void): void {

--- a/src/lib/overlay/overlay-constants.ts
+++ b/src/lib/overlay/overlay-constants.ts
@@ -21,7 +21,9 @@ const observedAttributes = {
 
 const attributes = {
   ...observedAttributes,
-  POSITION_PLACEMENT: 'position-placement'
+  POSITION_PLACEMENT: 'position-placement',
+  CLIPPED_X: 'clipped-x',
+  CLIPPED_Y: 'clipped-y'
 } as const;
 
 const classes = {

--- a/src/lib/popover/popover.scss
+++ b/src/lib/popover/popover.scss
@@ -296,6 +296,28 @@
   }
 }
 
+//
+// Clipped - Allow scrolling when the overlay is clipped by the viewport (edge case for small containers)
+//
+
+forge-overlay[clipped-x] {
+  .forge-popover {
+    width: auto;
+    min-width: 0;
+    max-width: 100vw;
+    overflow-x: auto;
+  }
+}
+
+forge-overlay[clipped-y] {
+  .forge-popover {
+    height: auto;
+    min-height: 0;
+    max-height: 100vh;
+    overflow-y: auto;
+  }
+}
+
 @layer reduced-motion {
   //
   // Prefers reduced motion


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
This change adds some post-positioning logic to the overlay that handles positional adjustments if the overlay contents are clipped by the viewport in either the x or y axis. The popover itself will now apply styles to itself based on this clipping state as well to ensure that the content can gracefully handle small containers/viewports by scrolling the content.
