### PR TITLE
fix(text-field): fixed a regression where the input container `width` could be set to `0px` if hidden while attempting to float the label or set a value

### DIFF
--- a/src/lib/field/field-adapter.ts
+++ b/src/lib/field/field-adapter.ts
@@ -68,7 +68,7 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
    * Adds or removes animation classes on the root element.
    */
   public setFloatingLabel(value: boolean, skipAnimation = false): void {
-    if (skipAnimation) {
+    if (skipAnimation || !this._labelElement) {
       return;
     }
 
@@ -76,7 +76,9 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
     // to ensure that the element cannot collapse while the animation is executing. The width will be
     // removed after the animation completes.
     const { width: inputContainerWidth } = this._inputContainerElement.getBoundingClientRect();
-    this._inputContainerElement.style.setProperty('width', `${inputContainerWidth}px`);
+    if (inputContainerWidth > 0) {
+      this._inputContainerElement.style.setProperty('width', `${inputContainerWidth}px`);
+    }
 
     const className = value ? FIELD_CONSTANTS.classes.FLOATING_IN : FIELD_CONSTANTS.classes.FLOATING_OUT;
     const animationName = value ? FIELD_CONSTANTS.animations.FLOAT_IN_LABEL : FIELD_CONSTANTS.animations.FLOAT_OUT_LABEL;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The field will now only lock the input container width if it's greater than `0` at the time of animation. This will account for the element being hidden at the time of the inset floating label animation running.

## Additional information
Caused by #730
