### PR TITLE
fix(text-field): fixed a bug where the input container would lock its width if there is no floating label to animate

### DIFF
--- a/src/lib/field/field-adapter.ts
+++ b/src/lib/field/field-adapter.ts
@@ -7,11 +7,12 @@ import { FIELD_CONSTANTS } from './field-constants';
 
 export interface IFieldAdapter extends IBaseAdapter<IFieldComponent> {
   readonly focusIndicator: IFocusIndicatorComponent;
+  readonly hasSlottedLabel: boolean;
   addRootListener(name: keyof HTMLElementEventMap, listener: EventListener): void;
   addPopoverIconClickListener(listener: EventListener): void;
   removePopoverIconClickListener(listener: EventListener): void;
   setLabelPosition(value: FieldLabelPosition): void;
-  setFloatingLabel(value: boolean, skipAnimation?: boolean): void;
+  setFloatingLabel(value: boolean): void;
   handleSlotChange(slot: HTMLSlotElement): void;
   initializeSlots(): void;
 }
@@ -21,11 +22,16 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
   private readonly _containerElement: HTMLElement;
   private readonly _inputContainerElement: HTMLElement;
   private readonly _labelElement: HTMLElement;
+  private readonly _labelSlotElement: HTMLSlotElement;
   private readonly _popoverIconElement: HTMLElement;
   private readonly _focusIndicatorElement: IFocusIndicatorComponent;
 
   public get focusIndicator(): IFocusIndicatorComponent {
     return this._focusIndicatorElement;
+  }
+
+  public get hasSlottedLabel(): boolean {
+    return !!this._labelSlotElement.assignedNodes({ flatten: true }).length;
   }
 
   constructor(component: IFieldComponent) {
@@ -34,6 +40,7 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
     this._containerElement = getShadowElement(component, FIELD_CONSTANTS.selectors.CONTAINER);
     this._inputContainerElement = getShadowElement(component, FIELD_CONSTANTS.selectors.INPUT_CONTAINER);
     this._labelElement = getShadowElement(component, FIELD_CONSTANTS.selectors.LABEL);
+    this._labelSlotElement = getShadowElement(component, FIELD_CONSTANTS.selectors.LABEL_SLOT) as HTMLSlotElement;
     this._popoverIconElement = getShadowElement(component, FIELD_CONSTANTS.selectors.POPOVER_ICON);
     this._focusIndicatorElement = getShadowElement(component, FOCUS_INDICATOR_CONSTANTS.elementName) as IFocusIndicatorComponent;
   }
@@ -67,11 +74,7 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
   /**
    * Adds or removes animation classes on the root element.
    */
-  public setFloatingLabel(value: boolean, skipAnimation = false): void {
-    if (skipAnimation || !this._labelElement) {
-      return;
-    }
-
+  public setFloatingLabel(value: boolean): void {
     // Temporarily lock the input container element width to its current width before the animation starts
     // to ensure that the element cannot collapse while the animation is executing. The width will be
     // removed after the animation completes.

--- a/src/lib/field/field-constants.ts
+++ b/src/lib/field/field-constants.ts
@@ -32,6 +32,7 @@ const selectors = {
   CONTAINER: '#container',
   INPUT_CONTAINER: '#input',
   LABEL: '#label',
+  LABEL_SLOT: 'slot[name=label]',
   POPOVER_ICON: '#popover-icon',
   LABEL_ELEMENTS: `:where(label, ${LABEL_CONSTANTS.elementName})`,
   POPOVER_TARGET: '.popover-target'

--- a/src/lib/field/field-core.ts
+++ b/src/lib/field/field-core.ts
@@ -80,7 +80,6 @@ export class FieldCore implements IFieldCore {
   public floatLabelWithoutAnimation(value: boolean): void {
     if (this._floatLabel !== value) {
       this._floatLabel = value;
-      this._adapter.setFloatingLabel(this._floatLabel, true);
       this._adapter.toggleHostAttribute(FIELD_CONSTANTS.attributes.FLOAT_LABEL, this._floatLabel);
     }
   }
@@ -117,7 +116,9 @@ export class FieldCore implements IFieldCore {
   public set floatLabel(value: boolean) {
     if (this._floatLabel !== value) {
       this._floatLabel = value;
-      this._adapter.setFloatingLabel(this._floatLabel);
+      if (this._adapter.hasSlottedLabel) {
+        this._adapter.setFloatingLabel(this._floatLabel);
+      }
       this._adapter.toggleHostAttribute(FIELD_CONSTANTS.attributes.FLOAT_LABEL, this._floatLabel);
     }
   }

--- a/src/lib/field/field.test.ts
+++ b/src/lib/field/field.test.ts
@@ -534,6 +534,43 @@ describe('Field', () => {
 
       expect(animationSpy.called).to.be.false;
     });
+
+    it('should lock input container width during float label animation', async () => {
+      const harness = await createFixture({ labelPosition: 'inset' });
+      harness.addSlottedContent('label');
+      harness.element.floatLabel = true;
+
+      const { width } = harness.inputContainerElement.getBoundingClientRect();
+      expect(harness.inputContainerElement.style.width).to.equal(`${width}px`);
+    });
+
+    it('should unlock input container width after float label animation', async () => {
+      const harness = await createFixture({ labelPosition: 'inset', floatLabel: true });
+      harness.addSlottedContent('label');
+
+      expect(harness.inputContainerElement.style.width).to.equal('');
+
+      let animationComplete: Promise<void> = new Promise<void>(resolve => {
+        harness.rootElement.addEventListener('animationend', () => resolve());
+      });
+
+      harness.element.floatLabel = false;
+
+      const { width } = harness.inputContainerElement.getBoundingClientRect();
+      expect(harness.inputContainerElement.style.width).to.equal(`${width}px`);
+
+      await animationComplete;
+      await frame();
+
+      expect(harness.inputContainerElement.style.width).to.equal('');
+    });
+
+    it('should not lock input container width when no label is present', async () => {
+      const harness = await createFixture({ labelPosition: 'inset' });
+      harness.element.floatLabel = true;
+
+      expect(harness.inputContainerElement.style.width).to.equal('');
+    });
   });
 });
 
@@ -541,6 +578,7 @@ class FieldHarness extends TestHarness<IFieldComponent> {
   public rootElement: HTMLElement;
   public labelElement: HTMLElement;
   public containerElement: HTMLElement;
+  public inputContainerElement: HTMLElement;
   public popoverIconElement: HTMLElement;
 
   constructor(el: IFieldComponent) {
@@ -551,6 +589,7 @@ class FieldHarness extends TestHarness<IFieldComponent> {
     this.rootElement = getShadowElement(this.element, FIELD_CONSTANTS.selectors.ROOT);
     this.labelElement = getShadowElement(this.element, FIELD_CONSTANTS.selectors.LABEL);
     this.containerElement = getShadowElement(this.element, FIELD_CONSTANTS.selectors.CONTAINER);
+    this.inputContainerElement = getShadowElement(this.element, FIELD_CONSTANTS.selectors.INPUT_CONTAINER);
     this.popoverIconElement = getShadowElement(this.element, FIELD_CONSTANTS.selectors.POPOVER_ICON);
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The floating label animation does not need to execute if there are no slotted nodes in the `label` slot of a field. This change ensures that the floating label animation logic is skipped if there are no label elements to animate.

This fixes an issue where the `width` style would get orphaned on the input container element causing the clear button that is dynamically appended to inadvertently get pushed out of view.
