### PR TITLE
fix(autocomplete): preventDefault on popover-icon mousedown instead of click

### DIFF
--- a/src/lib/autocomplete/autocomplete-adapter.ts
+++ b/src/lib/autocomplete/autocomplete-adapter.ts
@@ -196,9 +196,8 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
     window.requestAnimationFrame(() => {
       const textField = this._component.querySelector(TEXT_FIELD_CONSTANTS.elementName);
       if (textField && (textField.popoverIcon || textField.hasAttribute(FIELD_CONSTANTS.attributes.POPOVER_ICON))) {
-        // const eventType = type === 'mousedown' ? FIELD_CONSTANTS.events.POPOVER_ICON_MOUSEDOWN : FIELD_CONSTANTS.events.POPOVER_ICON_CLICK;
-        // this._component.addEventListener(eventType, listener);
-        this._component.addEventListener(FIELD_CONSTANTS.events.POPOVER_ICON_CLICK, listener);
+        const eventType = type === 'mousedown' ? FIELD_CONSTANTS.events.POPOVER_ICON_MOUSEDOWN : FIELD_CONSTANTS.events.POPOVER_ICON_CLICK;
+        this._component.addEventListener(eventType, listener);
       }
 
       const dropdownIcon = this._component.querySelector(AUTOCOMPLETE_CONSTANTS.selectors.DROPDOWN_ICON);

--- a/src/lib/autocomplete/autocomplete-adapter.ts
+++ b/src/lib/autocomplete/autocomplete-adapter.ts
@@ -196,6 +196,8 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
     window.requestAnimationFrame(() => {
       const textField = this._component.querySelector(TEXT_FIELD_CONSTANTS.elementName);
       if (textField && (textField.popoverIcon || textField.hasAttribute(FIELD_CONSTANTS.attributes.POPOVER_ICON))) {
+        // const eventType = type === 'mousedown' ? FIELD_CONSTANTS.events.POPOVER_ICON_MOUSEDOWN : FIELD_CONSTANTS.events.POPOVER_ICON_CLICK;
+        // this._component.addEventListener(eventType, listener);
         this._component.addEventListener(FIELD_CONSTANTS.events.POPOVER_ICON_CLICK, listener);
       }
 

--- a/src/lib/field/field-adapter.ts
+++ b/src/lib/field/field-adapter.ts
@@ -9,8 +9,8 @@ export interface IFieldAdapter extends IBaseAdapter<IFieldComponent> {
   readonly focusIndicator: IFocusIndicatorComponent;
   readonly hasSlottedLabel: boolean;
   addRootListener(name: keyof HTMLElementEventMap, listener: EventListener): void;
-  addPopoverIconClickListener(listener: EventListener): void;
-  removePopoverIconClickListener(listener: EventListener): void;
+  addPopoverIconListener(type: string, listener: EventListener): void;
+  removePopoverIconListener(type: string, listener: EventListener): void;
   setLabelPosition(value: FieldLabelPosition): void;
   setFloatingLabel(value: boolean): void;
   handleSlotChange(slot: HTMLSlotElement): void;
@@ -49,12 +49,12 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
     this._rootElement.addEventListener(name, listener);
   }
 
-  public addPopoverIconClickListener(listener: EventListener): void {
-    this._popoverIconElement.addEventListener('click', listener);
+  public addPopoverIconListener(type: string, listener: EventListener): void {
+    this._popoverIconElement.addEventListener(type, listener);
   }
 
-  public removePopoverIconClickListener(listener: EventListener): void {
-    this._popoverIconElement.removeEventListener('click', listener);
+  public removePopoverIconListener(type: string, listener: EventListener): void {
+    this._popoverIconElement.removeEventListener(type, listener);
   }
 
   /**

--- a/src/lib/field/field-constants.ts
+++ b/src/lib/field/field-constants.ts
@@ -53,7 +53,8 @@ const parts = {
 };
 
 const events = {
-  POPOVER_ICON_CLICK: `${elementName}-popover-icon-click`
+  POPOVER_ICON_CLICK: `${elementName}-popover-icon-click`,
+  POPOVER_ICON_MOUSEDOWN: `${elementName}-popover-icon-mousedown`
 };
 
 const defaults = {

--- a/src/lib/field/field-core.ts
+++ b/src/lib/field/field-core.ts
@@ -55,6 +55,7 @@ export class FieldCore implements IFieldCore {
 
   private _slotChangeListener: EventListener = this._onSlotChange.bind(this);
   private _popoverIconClickListener: EventListener = this._onPopoverIconClick.bind(this);
+  private _popoverIconMousedownListener: EventListener = this._onPopoverIconMousedown.bind(this);
 
   constructor(private _adapter: IFieldAdapter) {}
 
@@ -65,7 +66,8 @@ export class FieldCore implements IFieldCore {
     this._adapter.setLabelPosition(this._labelPosition);
 
     if (this._popoverIcon) {
-      this._adapter.addPopoverIconClickListener(this._popoverIconClickListener);
+      this._adapter.addPopoverIconListener('click', this._popoverIconClickListener);
+      this._adapter.addPopoverIconListener('mousedown', this._popoverIconMousedownListener);
     }
   }
 
@@ -75,6 +77,12 @@ export class FieldCore implements IFieldCore {
 
   private _onPopoverIconClick(): void {
     this._adapter.dispatchHostEvent(new CustomEvent(FIELD_CONSTANTS.events.POPOVER_ICON_CLICK, { bubbles: true, composed: true }));
+  }
+
+  private _onPopoverIconMousedown(evt: Event): void {
+    const popoverEvent = new CustomEvent(FIELD_CONSTANTS.events.POPOVER_ICON_MOUSEDOWN, { bubbles: true, composed: true, cancelable: true });
+    this._adapter.dispatchHostEvent(popoverEvent);
+    if (popoverEvent.defaultPrevented) evt.preventDefault();
   }
 
   public floatLabelWithoutAnimation(value: boolean): void {
@@ -227,9 +235,11 @@ export class FieldCore implements IFieldCore {
       }
 
       if (this._popoverIcon) {
-        this._adapter.addPopoverIconClickListener(this._popoverIconClickListener);
+        this._adapter.addPopoverIconListener('click', this._popoverIconClickListener);
+        this._adapter.addPopoverIconListener('mousedown', this._popoverIconMousedownListener);
       } else {
-        this._adapter.removePopoverIconClickListener(this._popoverIconClickListener);
+        this._adapter.removePopoverIconListener('click', this._popoverIconClickListener);
+        this._adapter.removePopoverIconListener('mousedown', this._popoverIconMousedownListener);
       }
     }
   }

--- a/src/lib/field/field.test.ts
+++ b/src/lib/field/field.test.ts
@@ -324,6 +324,37 @@ describe('Field', () => {
 
       expect(clickSpy.called).to.be.false;
     });
+
+    it('should dispatch popover icon mousedown event when popover icon receives mousedown event', async () => {
+      const harness = await createFixture({ popoverIcon: true });
+      const mousedownSpy = spy();
+      harness.element.addEventListener(FIELD_CONSTANTS.events.POPOVER_ICON_MOUSEDOWN, mousedownSpy);
+
+      harness.popoverIconElement.dispatchEvent(new MouseEvent('mousedown'));
+
+      expect(mousedownSpy.called).to.be.true;
+    });
+
+    it('should not dispatch popover icon mousedown event when popover icon is removed', async () => {
+      const harness = await createFixture({ popoverIcon: true });
+      const mousedownSpy = spy();
+      harness.element.addEventListener(FIELD_CONSTANTS.events.POPOVER_ICON_MOUSEDOWN, mousedownSpy);
+      harness.element.popoverIcon = false;
+
+      harness.popoverIconElement.dispatchEvent(new MouseEvent('mousedown'));
+
+      expect(mousedownSpy.called).to.be.false;
+    });
+
+    it('should prevent default on the original mousedown event if default prevented on popover icon mousedown event', async () => {
+      const harness = await createFixture({ popoverIcon: true });
+      harness.element.addEventListener(FIELD_CONSTANTS.events.POPOVER_ICON_MOUSEDOWN, evt => evt.preventDefault());
+
+      const mousedownEvent = new MouseEvent('mousedown', { cancelable: true });
+      harness.popoverIconElement.dispatchEvent(mousedownEvent);
+
+      expect(mousedownEvent.defaultPrevented).to.be.true;
+    });
   });
 
   describe('slots', () => {

--- a/src/lib/field/field.ts
+++ b/src/lib/field/field.ts
@@ -100,6 +100,7 @@ declare global {
  * @attribute {boolean} [focus-indicator-allow-focus=false] - Whether the focus indicator should render when the target element matches `:focus` instead of `:focus-visible`.
  *
  * @event {CustomEvent<void>} forge-field-popover-icon-click - Dispatches when the user clicks the popover icon.
+ * @event {CustomEvent<void>} forge-field-popover-icon-mousedown - Dispatches when the user presses the mouse button over the popover icon. Cancelable to prevent focus loss.
  *
  * @cssproperty --forge-field-background - The background of the field surface.
  * @cssproperty --forge-field-tonal-background - The background of the field surface in the tonal variant.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?
Fixes issue where autocomplete with text-field + popoverIcon (but not chip-field) would currently have issues with the dropdown when the icon was clicked directly:
![output](https://github.com/user-attachments/assets/9b622306-b7b0-4db6-98ac-3b2b55dae333)

## Additional information
<!-- Add any other context about the change here. -->
