### PR TITLE
fix(field): set `aria-hidden="true"` on popover icon `<svg>`

### DIFF
--- a/src/lib/field/field.html
+++ b/src/lib/field/field.html
@@ -16,7 +16,7 @@
         <slot name="end"></slot>
       </div>
       <div id="popover-icon" class="popover-icon" part="popover-icon">
-        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" aria-hidden="true">
           <path d="M0 0h24v24H0z" fill="none" />
           <path d="M7 10l5 5 5-5z" id="popover-icon__arrow" />
         </svg>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Adds `aria-hidden="true"` to the internal `<svg>` element that renders the built-in "popover icon" within the `<forge-field>` to ensure that it is not read by assistive technology.

## Additional information
This was being flagged by Level Access.
