### PR TITLE
fix(field): constrain input to grid area to prevent icons from being pushed out of view

### DIFF
--- a/src/lib/field/_core.scss
+++ b/src/lib/field/_core.scss
@@ -127,6 +127,7 @@
 
   block-size: 100%;
   inline-size: 100%;
+  min-inline-size: 0;
 
   color: theme.variable(text-high);
 }


### PR DESCRIPTION
Fixes #749 

## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: n/a (visual)
- Docs have been added/updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Because `min-inline-size` defaults to auto, the default size of the input can grow beyond the bounds of the CSS grid layout area assigned to it, pushing icon slots outside the bounds of the container.  By explicitly setting it to zero, the input will be sized based on available space as the assigned `1fr` intends.  

## Additional information
Long labels can still push the icons, though the behavior differs in Firefox vs Chrome.  This is a more complex problem with usability/accessibility concerns, and I have not attempted to resolve this.
