### PR TITLE
feat: enhance skip-link defaults

### DIFF
--- a/src/dev/pages/skip-link/skip-link.ejs
+++ b/src/dev/pages/skip-link/skip-link.ejs
@@ -2,8 +2,14 @@
   <section>
     <h3>Default</h3>
     <div tabindex="0">Tab past this</div>
-    <forge-skip-link id="skip-link" target="main"></forge-skip-link>
-    <div tabindex="-1" id="main" class="target-content">Main content</div>
+    <forge-skip-link></forge-skip-link>
+    <div class="target-content">Note: when the skip-link comp does not specify a target, it targets the first main element. So this is a pickle to demo since this app already has a main element. Look for that main element to gain focus.</div>
+  </section>
+  <section>
+    <h3>Specified target ID (side-panel controls pertain to this instance)</h3>
+    <div tabindex="0">Tab past this</div>
+    <forge-skip-link id="skip-link" target="main-specified-target"></forge-skip-link>
+    <div id="main-specified-target" class="target-content">Main content</div>
   </section>
   <section>
     <h3>CSS only</h3>
@@ -14,8 +20,8 @@
   <section style="position: relative;">
     <h3>Inline</h3>
     <div tabindex="0">Tab past this</div>
-    <forge-skip-link target="section" inline>Skip to section content</forge-skip-link>
-    <div tabindex="-1" id="section" class="target-content">Section content</div>
+    <forge-skip-link target="main-inline" inline>Skip to section content</forge-skip-link>
+    <div id="main-inline" class="target-content">Section content</div>
   </section>
 </div>
 

--- a/src/lib/skip-link/skip-link-constants.ts
+++ b/src/lib/skip-link/skip-link-constants.ts
@@ -19,11 +19,14 @@ const selectors = {
   ANCHOR: 'a'
 };
 
+const defaultMainContentId = 'main-content';
+
 export const SKIP_LINK_CONSTANTS = {
   elementName,
   observedAttributes,
   attributes,
-  selectors
+  selectors,
+  defaultMainContentId
 };
 
 export type SkipLinkTheme = Theme | 'default';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?

Summary: enhance the skip-link defaults to improve ease of use

- Auto add a `tabindex="-1"` to the target element if a tabindex does not already exist
- If a `target` is not supplied, automatically find and use the first main element as the target. This will use that element's ID, or add an ID if that element does not have one.

## Additional information

Looking for feedback before i try to take this any further. Maybe this approach, which includes setting attributes on external elements, is against the Forge ethos.

This assumes that there will only be a single main element present at a time. Maybe that's not a safe enough assumption.

**WIP - not in a state that I expect to merge.**
