### PR TITLE
fix(select): elementAttributes are now applied to select options

### DIFF
--- a/src/lib/select/core/base-select-adapter.ts
+++ b/src/lib/select/core/base-select-adapter.ts
@@ -268,6 +268,11 @@ export abstract class BaseSelectAdapter<T extends IBaseSelectComponent> extends 
     const optionElement = document.createElement('forge-option');
     Object.assign(optionElement, option);
     optionElement.textContent = option.label;
+    if (option.elementAttributes) {
+      option.elementAttributes.forEach((value: string, key: string) => {
+        optionElement.setAttribute(key, value);
+      });
+    }
     return optionElement;
   }
 }

--- a/src/lib/select/select/select.test.ts
+++ b/src/lib/select/select/select.test.ts
@@ -19,7 +19,7 @@ import {
   IFieldComponent
 } from '../../field';
 import { IPopoverComponent, POPOVER_CONSTANTS } from '../../popover';
-import { BASE_SELECT_CONSTANTS } from '../core';
+import { BASE_SELECT_CONSTANTS, ISelectOption } from '../core';
 import { ISelectComponent } from './select';
 import { SELECT_CONSTANTS } from './select-constants';
 
@@ -126,6 +126,18 @@ describe('Select', () => {
       await frame();
 
       expect(spyScrolledBottom.calledOnce).to.be.true;
+    });
+
+    it('should set element attributes on options', async () => {
+      const options: ISelectOption[] = [
+        { label: 'One', value: 1 },
+        { label: 'Two', value: 2 },
+        { label: 'Three', value: 3, elementAttributes: new Map<string, string>([['data-test-attr', 'test-value']]) }
+      ];
+      const harness = await createFixture();
+      harness.element.options = options;
+      console.log('hello options', harness.element.children[2].getAttribute('data-test-attr'));
+      expect(harness.element.children[2].getAttribute('data-test-attr')).to.equal('test-value');
     });
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Yes
- Docs have been added/updated: n/a
- Does this PR introduce a breaking change? No
- I have linked any related GitHub issues to be closed when this PR is merged? [Y/N]

## Describe the new behavior?
When creating a select element, passing in options that have elementAttributes will now apply those attributes to the select options.

## Additional information
Fixes #758 
