### PR TITLE
fix(popover): fixed a bug where the popover would stay connected if hidden at time of exit animation

### DIFF
--- a/src/lib/calendar/calendar-dropdown/calendar-dropdown.ts
+++ b/src/lib/calendar/calendar-dropdown/calendar-dropdown.ts
@@ -70,7 +70,7 @@ export class CalendarDropdown implements ICalendarDropdown {
       await this.dropdownElement.hideAsync();
     }
 
-    this.dropdownElement.remove();
+    this.dropdownElement?.remove();
     this.dropdownElement = undefined;
     this.calendar = undefined;
   }

--- a/src/lib/popover/popover-adapter.ts
+++ b/src/lib/popover/popover-adapter.ts
@@ -92,6 +92,12 @@ export class PopoverAdapter extends OverlayAwareAdapter<IPopoverComponent> imple
       return Promise.resolve();
     }
 
+    if (!this._surfaceElement.checkVisibility()) {
+      this._overlayElement.open = false;
+      this._updateAnchorExpandedState(false);
+      return Promise.resolve();
+    }
+
     return new Promise(resolve => {
       this._surfaceElement.addEventListener(
         'animationend',

--- a/src/lib/time-picker/time-picker-adapter.ts
+++ b/src/lib/time-picker/time-picker-adapter.ts
@@ -215,7 +215,9 @@ export class TimePickerAdapter extends BaseAdapter<ITimePickerComponent> impleme
       }
       this._listDropdown = undefined;
     }
-    setAriaControls(this._inputElement);
+    if (this._inputElement?.isConnected) {
+      setAriaControls(this._inputElement);
+    }
   }
 
   public propagateKey(key: string): void {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
This change introduces a check for surface element visibility before attempting to run the exit animation, if the element is not visible at this time, then it will immediately close without an animation.

This fixes a bug where the `animationend` listener would not execute because the browser has CSS applied that is hiding the element which means CSS animations do not run.

## Additional information
Fixes #755 
