### PR TITLE
fix(dialog): fixed a bug where the dialog surface would render incorrectly if set to fullscreen after moving

### DIFF
--- a/src/lib/dialog/dialog-core.ts
+++ b/src/lib/dialog/dialog-core.ts
@@ -247,6 +247,14 @@ export class DialogCore implements IDialogCore {
     this._moveController = undefined;
   }
 
+  private _applyMoveable({ enabled } = { enabled: this._moveable }): void {
+    if (enabled) {
+      this._initializeMoveController();
+    } else {
+      this._destroyMoveController();
+    }
+  }
+
   public get open(): boolean {
     return this._open;
   }
@@ -318,6 +326,7 @@ export class DialogCore implements IDialogCore {
     value = Boolean(value);
     if (this._fullscreen !== value) {
       this._fullscreen = value;
+      this._applyMoveable({ enabled: !this._fullscreen });
       this._adapter.toggleHostAttribute(DIALOG_CONSTANTS.attributes.FULLSCREEN, this._fullscreen);
     }
   }
@@ -385,11 +394,7 @@ export class DialogCore implements IDialogCore {
       this._moveable = value;
 
       if (this._adapter.isConnected && this._open) {
-        if (this._moveable) {
-          this._initializeMoveController();
-        } else {
-          this._destroyMoveController();
-        }
+        this._applyMoveable();
       }
 
       this._adapter.toggleHostAttribute(DIALOG_CONSTANTS.attributes.MOVEABLE, this._moveable);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
When a moveable dialog is set to fullscreen after it has been moved, the position styles will now be removed so that the dialog can render fullscreen properly.

The previous position will **not** be preserved if turning off fullscreen mode. 
