### PR TITLE
fix(select): elementAttributes are now applied to select options

### DIFF
--- a/src/lib/select/core/base-select-adapter.ts
+++ b/src/lib/select/core/base-select-adapter.ts
@@ -238,6 +238,11 @@ export abstract class BaseSelectAdapter extends BaseAdapter<IBaseSelectComponent
     const optionElement = document.createElement('forge-option');
     Object.assign(optionElement, option);
     optionElement.textContent = option.label;
+    if (option.elementAttributes) {
+      option.elementAttributes.forEach((value: string, key: string) => {
+        optionElement.setAttribute(key, value);
+      });
+    }
     return optionElement;
   }
 }

--- a/src/test/spec/select/select.spec.ts
+++ b/src/test/spec/select/select.spec.ts
@@ -1203,6 +1203,24 @@ describe('SelectComponent', function(this: ITestContext) {
       
       expect(this.context.component.observeScroll).toBeTrue();
     });
+
+    it('should set custom option attributes via elementAttributes', async function(this: ITestContext) {
+      this.context = setupTestContext(true);
+      await tick();
+
+      const opts = [
+        { label: 'Option 1', value: 'new-1', elementAttributes: new Map([['data-testid', 'some-id']])},
+        { label: 'Option 2', value: 'new-2', elementAttributes: new Map([['data-testid', 'some-other-id'], ['data-test-attr', 'some-value']])}
+      ];
+      this.context.component.options = opts;
+      await tick();
+
+      const optionElements = this.context.component.querySelectorAll('forge-option');
+      expect(optionElements[0].label).toBe('Option 1');
+      expect(optionElements[0].getAttribute('data-testid')).toBe('some-id');
+      expect(optionElements[1].getAttribute('data-testid')).toBe('some-other-id');
+      expect(optionElements[1].getAttribute('data-test-attr')).toBe('some-value');
+    });
   });
 
   describe('static with default value', function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: No
- Docs have been added/updated: n/a
- Does this PR introduce a breaking change? No
- I have linked any related GitHub issues to be closed when this PR is merged? No

## Describe the new behavior?
When creating a select element, passing in options that have elementAttributes will now apply those attributes to the select options.

## Additional information
Kieran was going to look at at a test for this.
I also linked the issue to a separate PR for v3
