### PR TITLE
fix(field): fix input size/animation when floating label with inset variant

### DIFF
--- a/src/dev/pages/text-field/text-field.ts
+++ b/src/dev/pages/text-field/text-field.ts
@@ -42,8 +42,19 @@ const optLabelAlignment = document.getElementById('opt-label-alignment') as ISel
 const optSupportTextInset = document.getElementById('opt-support-text-inset') as ISwitchComponent;
 
 optLabel.addEventListener('input', () => {
+  const hasValue = optLabel.value.length > 0;
   textFields.forEach(textField => {
-    textField.querySelector(':is(label, span, forge-label)').textContent = optLabel.value;
+    const labelEl = textField.querySelector(':is(label, span, forge-label)');
+    if (hasValue) {
+      if (!labelEl) {
+        const label = document.createElement('label');
+        label.textContent = optLabel.value;
+        textField.prepend(label);
+      }
+      textField.querySelector(':is(label, span, forge-label)').textContent = optLabel.value;
+    } else {
+      labelEl?.remove();
+    }
   });
 });
 

--- a/src/lib/field/_core.animation.scss
+++ b/src/lib/field/_core.animation.scss
@@ -36,26 +36,6 @@
       opacity: 100%;
     }
   }
-
-  @keyframes float-in-input-animation {
-    from {
-      translate: 0;
-    }
-
-    to {
-      translate: 0 $offset;
-    }
-  }
-
-  @keyframes float-out-input-animation {
-    from {
-      translate: 0 $offset;
-    }
-
-    to {
-      translate: 0;
-    }
-  }
 }
 
 @mixin multiline-inset-label-background-animation-keyframes {

--- a/src/lib/field/_core.layout.scss
+++ b/src/lib/field/_core.layout.scss
@@ -153,7 +153,6 @@
 //
 
 $multiline-input-offset-base: calc((token(height, custom) - typography.variable(body2, line-height)) / 2);
-$multiline-input-padding-block-end-base: 8px;
 
 @mixin multiline-container {
   align-items: start;
@@ -211,12 +210,12 @@ $multiline-input-padding-block-end-base: 8px;
 
 @mixin multiline-slotted-input {
   padding-block-start: $multiline-input-offset-base;
-  padding-block-end: calc($floating-offset + $multiline-input-padding-block-end-base);
+  padding-block-end: calc($floating-offset + $multiline-input-offset-base);
 }
 
 @mixin multiline-slotted-floating-input {
   padding-block-start: calc($floating-offset + ($multiline-input-offset-base)) !important; // TODO: find a way to remove this !important
-  padding-block-end: #{$multiline-input-padding-block-end-base} !important;
+  padding-block-end: #{$multiline-input-offset-base} !important;
 }
 
 //
@@ -253,11 +252,7 @@ $floating-offset: #{calc($floating-offset-base + $floating-offset-adjustment)};
 }
 
 @mixin float-in-input {
-  @include animation.floating-animation(float-in-input-animation);
-}
-
-@mixin float-out-input {
-  @include animation.floating-animation(float-out-input-animation);
+  padding-block-start: calc($floating-offset * 2) !important;
 }
 
 @mixin slotted-floating-input {

--- a/src/lib/field/_core.slotted.scss
+++ b/src/lib/field/_core.slotted.scss
@@ -19,18 +19,14 @@
   font: inherit;
   font-size: #{token(font-size)};
   text-overflow: ellipsis;
+
+  padding-block-start: 0;
+  padding-block-end: 0;
+  transition: padding-block #{token(floating-animation-duration)} #{token(floating-animation-timing)};
 }
 
 @mixin default-slot-textarea {
   resize: none;
-}
-
-@mixin default-slot-floating-in {
-  position: absolute;
-  inset-block-start: calc(#{token(height)} * -0.5);
-
-  block-size: 100%;
-  padding-block: #{token(height)};
 }
 
 @mixin slotted-inset-label {

--- a/src/lib/field/field-adapter.ts
+++ b/src/lib/field/field-adapter.ts
@@ -75,20 +75,11 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
    * Adds or removes animation classes on the root element.
    */
   public setFloatingLabel(value: boolean): void {
-    // Temporarily lock the input container element width to its current width before the animation starts
-    // to ensure that the element cannot collapse while the animation is executing. The width will be
-    // removed after the animation completes.
-    const { width: inputContainerWidth } = this._inputContainerElement.getBoundingClientRect();
-    if (inputContainerWidth > 0) {
-      this._inputContainerElement.style.setProperty('width', `${inputContainerWidth}px`);
-    }
-
     const className = value ? FIELD_CONSTANTS.classes.FLOATING_IN : FIELD_CONSTANTS.classes.FLOATING_OUT;
     const animationName = value ? FIELD_CONSTANTS.animations.FLOAT_IN_LABEL : FIELD_CONSTANTS.animations.FLOAT_OUT_LABEL;
     const animationEndListener: EventListener = (evt: AnimationEvent) => {
       if (evt.animationName === animationName) {
         removeClass(className, this._rootElement);
-        this._inputContainerElement.style.removeProperty('width');
         this._rootElement.removeEventListener('animationend', animationEndListener);
       }
     };

--- a/src/lib/field/field.scss
+++ b/src/lib/field/field.scss
@@ -442,10 +442,8 @@ $variants: (
       }
 
       .input {
-        @include core.float-in-input;
-
         ::slotted(:is(input, [data-forge-field-input], [data-forge-multi-input-separator])) {
-          @include core.default-slot-floating-in;
+          @include core.float-in-input;
         }
       }
     }
@@ -465,15 +463,11 @@ $variants: (
     .label {
       @include core.float-out-label;
     }
-
-    .input {
-      @include core.float-out-input;
-    }
   }
 }
 
 :host(#{map.get($label-positions, inset)}[float-label][multiline]) {
-  .has-label:not(.floating-in) {
+  .has-label {
     ::slotted(textarea) {
       @include core.multiline-slotted-floating-input;
     }
@@ -529,6 +523,12 @@ $variants: (
 
     &::after {
       @include core.multiline-inset-label-background;
+    }
+  }
+
+  .forge-field:not(.has-label) {
+    .label::after {
+      display: none;
     }
   }
 }

--- a/src/lib/field/field.test.ts
+++ b/src/lib/field/field.test.ts
@@ -565,43 +565,6 @@ describe('Field', () => {
 
       expect(animationSpy.called).to.be.false;
     });
-
-    it('should lock input container width during float label animation', async () => {
-      const harness = await createFixture({ labelPosition: 'inset' });
-      harness.addSlottedContent('label');
-      harness.element.floatLabel = true;
-
-      const { width } = harness.inputContainerElement.getBoundingClientRect();
-      expect(harness.inputContainerElement.style.width).to.equal(`${width}px`);
-    });
-
-    it('should unlock input container width after float label animation', async () => {
-      const harness = await createFixture({ labelPosition: 'inset', floatLabel: true });
-      harness.addSlottedContent('label');
-
-      expect(harness.inputContainerElement.style.width).to.equal('');
-
-      let animationComplete: Promise<void> = new Promise<void>(resolve => {
-        harness.rootElement.addEventListener('animationend', () => resolve());
-      });
-
-      harness.element.floatLabel = false;
-
-      const { width } = harness.inputContainerElement.getBoundingClientRect();
-      expect(harness.inputContainerElement.style.width).to.equal(`${width}px`);
-
-      await animationComplete;
-      await frame();
-
-      expect(harness.inputContainerElement.style.width).to.equal('');
-    });
-
-    it('should not lock input container width when no label is present', async () => {
-      const harness = await createFixture({ labelPosition: 'inset' });
-      harness.element.floatLabel = true;
-
-      expect(harness.inputContainerElement.style.width).to.equal('');
-    });
   });
 });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
This change removes the internal `width` being set while the inset floating label animation is running, but instead switches the `<input>` styles to use a simpler `padding-block-start` transition. This ensures that the input container doesn't use `position: absolute` any longer, but does come with the caveat of animating padding which is less performant.

## Additional information
Fixes #752 
