### PR TITLE
fix(popover): delay visibility check when hiding by a frame to ensure style calculation has enough time to execute

### DIFF
--- a/src/lib/popover/popover-adapter.ts
+++ b/src/lib/popover/popover-adapter.ts
@@ -1,6 +1,7 @@
 import { getShadowElement } from '@tylertech/forge-core';
 import { prefersReducedMotion } from '../core/utils/feature-detection';
 import { VirtualElement } from '../core/utils/position-utils';
+import { frame } from '../core/utils/utils';
 import { IOverlayComponent, OVERLAY_CONSTANTS } from '../overlay';
 import { IOverlayAwareAdapter, OverlayAwareAdapter } from '../overlay/base/overlay-aware-adapter';
 import { IPopoverComponent } from './popover';
@@ -84,13 +85,15 @@ export class PopoverAdapter extends OverlayAwareAdapter<IPopoverComponent> imple
     this._updateAnchorExpandedState(newState);
   }
 
-  public hide(): Promise<void> {
+  public async hide(): Promise<void> {
     if (prefersReducedMotion()) {
       this._surfaceElement.classList.remove(POPOVER_CONSTANTS.classes.EXITING);
       this._overlayElement.open = false;
       this._updateAnchorExpandedState(false);
       return Promise.resolve();
     }
+
+    await frame();
 
     if (!this._surfaceElement.checkVisibility()) {
       this._overlayElement.open = false;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Adds an animation frame delay to ensure styles are updated prior to checking surface visibility.

## Additional information
Fixes #755 for Firefox compatibility
