### PR TITLE
feat(tabs): deprecate `secondary` prop/attr and update default design to use full width tab indicator

### DIFF
--- a/src/dev/pages/tabs/tabs.ejs
+++ b/src/dev/pages/tabs/tabs.ejs
@@ -48,7 +48,7 @@
 </div>
 
 <div class="tabs-demo">
-  <h2 class="forge-typography--heading2">Primary tabs w/icons</h2>
+  <h2 class="forge-typography--heading2">Stacked Tabs w/icons</h2>
   <forge-tab-bar stacked active-tab="0" style="max-width: 512px;">
     <forge-tab>
       <forge-icon slot="leading" name="videocam"></forge-icon>

--- a/src/dev/pages/tabs/tabs.ejs
+++ b/src/dev/pages/tabs/tabs.ejs
@@ -65,14 +65,4 @@
   </forge-tab-bar>
 </div>
 
-<div class="tabs-demo">
-  <h2 class="forge-typography--heading2">Secondary tabs</h2>
-  <forge-tab-bar secondary active-tab="0">
-    <forge-tab>Overview</forge-tab>
-    <forge-tab>Specs</forge-tab>
-    <forge-tab>Guidelines</forge-tab>
-    <forge-tab>Accessibility</forge-tab>
-  </forge-tab-bar>
-</div>
-
 <script type="module" src="tabs.ts"></script>

--- a/src/dev/pages/tabs/tabs.html
+++ b/src/dev/pages/tabs/tabs.html
@@ -5,7 +5,6 @@ include('./src/partials/page.ejs', {
     includePath: './pages/tabs/tabs.ejs',
     options: [
       { type: 'switch', label: 'Vertical', id: 'opt-vertical' },
-      { type: 'switch', label: 'Secondary', id: 'opt-secondary' },
       { type: 'switch', label: 'Clustered', id: 'opt-clustered' },
       { type: 'switch', label: 'Stacked', id: 'opt-stacked' },
       { type: 'switch', label: 'Disabled', id: 'opt-disabled' },

--- a/src/dev/pages/tabs/tabs.ts
+++ b/src/dev/pages/tabs/tabs.ts
@@ -31,11 +31,6 @@ verticalToggle.addEventListener('forge-switch-change', ({ detail: selected }) =>
   container.classList.toggle('tabs-demo-container--vertical', selected);
 });
 
-const secondaryToggle = document.getElementById('opt-secondary') as ISwitchComponent;
-secondaryToggle.addEventListener('forge-switch-change', ({ detail: selected }) => {
-  tabBar.secondary = selected;
-});
-
 const clusteredToggle = document.getElementById('opt-clustered') as ISwitchComponent;
 clusteredToggle.addEventListener('forge-switch-change', ({ detail: selected }) => {
   if (selected) {

--- a/src/lib/core/styles/tokens/tabs/tab/_tokens.scss
+++ b/src/lib/core/styles/tokens/tabs/tab/_tokens.scss
@@ -31,7 +31,7 @@ $tokens: (
   container-shape: utils.module-val(tab, container-shape, 0),
   // Content
   content-height: utils.module-ref(tab, content-height, height),
-  content-spacing: utils.module-val(tab, content-spacing, spacing.variable(xxsmall)),
+  content-spacing: utils.module-val(tab, content-spacing, spacing.variable(xsmall)),
   content-padding: utils.module-val(tab, content-padding, spacing.variable(xxsmall)),
   content-padding-block: utils.module-ref(tab, content-padding-block, content-padding),
   content-padding-inline: utils.module-val(tab, content-padding-inline, spacing.variable(medium)),

--- a/src/lib/core/styles/tokens/tabs/tab/_tokens.scss
+++ b/src/lib/core/styles/tokens/tabs/tab/_tokens.scss
@@ -10,7 +10,7 @@ $tokens: (
   height: utils.module-val(tab, height, 48px),
   stacked-height: utils.module-val(tab, stacked-height, 64px),
   padding-block: utils.module-val(tab, padding-block, 0),
-  padding-inline: utils.module-val(tab, padding-inline, spacing.variable(medium)),
+  padding-inline: utils.module-val(tab, padding-inline, 0),
   // Disabled
   disabled-opacity: utils.module-val(tab, disabled-opacity, 0.38),
   // Indicator

--- a/src/lib/core/styles/tokens/tabs/tab/_tokens.scss
+++ b/src/lib/core/styles/tokens/tabs/tab/_tokens.scss
@@ -20,8 +20,8 @@ $tokens: (
   // Indicator (vertical)
   vertical-indicator-shape: utils.module-val(tab, vertical-indicator-shape, 3px 0 0 3px),
   // Indicator (secondary)
-  secondary-indicator-height: utils.module-val(tab, secondary-indicator-height, 2px),
-  secondary-indicator-shape: utils.module-val(tab, secondary-indicator-shape, 0),
+  /** @deprecated */ secondary-indicator-height: utils.module-val(tab, secondary-indicator-height, 2px),
+  /** @deprecated */ secondary-indicator-shape: utils.module-val(tab, secondary-indicator-shape, 0),
   // Indicator (inverted)
   inverted-indicator-shape: utils.module-val(tab, inverted-indicator-shape, 0 0 3px 3px),
   vertical-inverted-indicator-shape: utils.module-val(tab, vertical-inverted-indicator-shape, 0 3px 3px 0),
@@ -34,8 +34,8 @@ $tokens: (
   content-spacing: utils.module-val(tab, content-spacing, spacing.variable(xxsmall)),
   content-padding: utils.module-val(tab, content-padding, spacing.variable(xxsmall)),
   content-padding-block: utils.module-ref(tab, content-padding-block, content-padding),
-  content-padding-inline: utils.module-ref(tab, content-padding-inline, content-padding),
-  content-padding-inline-secondary: utils.module-val(tab, content-padding-inline-secondary, spacing.variable(medium)),
+  content-padding-inline: utils.module-val(tab, content-padding-inline, spacing.variable(medium)),
+  /** @deprecated */ content-padding-inline-secondary: utils.module-val(tab, content-padding-inline-secondary, spacing.variable(medium)),
   // Icon
   active-focus-icon-color: utils.module-ref(tab, active-focus-icon-color, active-color),
   active-hover-icon-color: utils.module-ref(tab, active-hover-icon-color, active-color),

--- a/src/lib/tabs/tab-bar/_core.scss
+++ b/src/lib/tabs/tab-bar/_core.scss
@@ -25,6 +25,7 @@
 
 @mixin slotted-base {
   flex: #{token(stretch)};
+  align-self: stretch;
 }
 
 @mixin slotted-selected {

--- a/src/lib/tabs/tab-bar/tab-bar-core.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-core.ts
@@ -128,7 +128,7 @@ export class TabBarCore implements ITabBarCore {
     if (this._autoActivate) {
       this._selectTab(this._tabs[index]);
     } else {
-      this._tabs[index].focus({ preventScroll: true });
+      this._tabs[index].focus({ preventScroll: true, focusVisible: true });
       await this._adapter.tryScrollTabIntoView(this._tabs[index]);
     }
   }

--- a/src/lib/tabs/tab-bar/tab-bar.ts
+++ b/src/lib/tabs/tab-bar/tab-bar.ts
@@ -17,6 +17,7 @@ export interface ITabBarComponent extends IBaseComponent {
   vertical: boolean;
   clustered: boolean;
   stacked: boolean;
+  /** @deprecated This will be removed in a future version */
   secondary: boolean;
   inverted: boolean;
   autoActivate: boolean;
@@ -52,7 +53,7 @@ declare global {
  * @property {boolean} [vertical=false] - Controls whether the tab bar is vertical or horizontal.
  * @property {boolean} [clustered=false] - Controls whether the tabs stretch the full width of their container or cluster together at their minimum width.
  * @property {boolean} [stacked=false] - Controls whether the tabs are taller to allow for slotted leading/trailing elements.
- * @property {boolean} [secondary=false] - Controls whether the tabs are styled as secondary tab navigation.
+ * @property {boolean} [secondary=false] - Deprecated. Controls whether the tabs are styled as secondary tab navigation.
  * @property {boolean} [inverted=false] - Controls whether the tabs are rendered inverted (tab indicator at top instead of bottom).
  * @property {boolean} [autoActivate=false] - Controls whether the tabs are automatically activated when receiving focus.
  * @property {boolean} [scrollButtons=false] - Controls whether scroll buttons are displayed when the tabs overflow their container.
@@ -62,7 +63,7 @@ declare global {
  * @attribute {boolean} [vertical=false] - Controls whether the tab bar is vertical or horizontal.
  * @attribute {boolean} [clustered=false] - Controls whether the tabs stretch the full width of their container or cluster together at their minimum width.
  * @attribute {boolean} [stacked=false] - Controls whether the tabs are taller to allow for slotted leading/trailing elements.
- * @attribute {boolean} [secondary=false] - Controls whether the tabs are styled as secondary tab navigation.
+ * @attribute {boolean} [secondary=false] - Deprecated. Controls whether the tabs are styled as secondary tab navigation.
  * @attribute {boolean} [auto-activate=false] - Controls whether the tabs are automatically activated when receiving focus.
  * @attribute {boolean} [scroll-buttons=false] - Controls whether scroll buttons are displayed when the tabs overflow their container.
  * @attribute {string} [data-aria-label] - The ARIA label to forward to the internal tablist element.
@@ -150,6 +151,7 @@ export class TabBarComponent extends BaseComponent implements ITabBarComponent {
   @coreProperty()
   public declare stacked: boolean;
 
+  /** @deprecated This will be removed in a future version */
   @coreProperty()
   public declare secondary: boolean;
 

--- a/src/lib/tabs/tab/_core.scss
+++ b/src/lib/tabs/tab/_core.scss
@@ -72,12 +72,6 @@
   }
 }
 
-@mixin tab-secondary {
-  @include override(indicator-height, secondary-indicator-height);
-  @include override(indicator-shape, secondary-indicator-shape);
-  @include override(padding-inline, 0, value);
-}
-
 @mixin focus {
   color: #{token(focus-label-text-color)};
 
@@ -126,6 +120,7 @@
   transition: 150ms color linear;
   max-height: calc(#{token(content-height)} + 2 * #{token(content-padding-block)});
   min-height: #{token(content-height)};
+  width: 100%;
   padding-block: #{token(content-padding-block)};
   padding-inline: #{token(content-padding-inline)};
   gap: #{token(content-spacing)};
@@ -144,18 +139,9 @@
   background: #{token(indicator-color)};
   border-radius: #{token(indicator-shape)};
   height: #{token(indicator-height)};
+  min-width: 100%;
   inset: auto 0 0;
   opacity: 0;
-}
-
-@mixin content-secondary {
-  @include override(content-padding-inline, content-padding-inline-secondary);
-
-  width: 100%;
-}
-
-@mixin indicator-secondary {
-  min-width: 100%;
 }
 
 @mixin vertical {
@@ -168,9 +154,6 @@
 
 @mixin vertical-content {
   width: 100%;
-}
-
-@mixin vertical-secondary-content {
   min-height: 100%;
 }
 

--- a/src/lib/tabs/tab/_core.scss
+++ b/src/lib/tabs/tab/_core.scss
@@ -168,7 +168,9 @@
 }
 
 @mixin content-stacked {
+  max-height: none;
   flex-direction: column;
+  height: 100%;
 }
 
 @mixin inverted-indicator {

--- a/src/lib/tabs/tab/tab-adapter.ts
+++ b/src/lib/tabs/tab/tab-adapter.ts
@@ -4,9 +4,11 @@ import { BaseAdapter, IBaseAdapter } from '../../core/base/base-adapter';
 import { TAB_BAR_CONSTANTS } from '../tab-bar/tab-bar-constants';
 import type { ITabComponent } from './tab';
 import { TAB_CONSTANTS } from './tab-constants';
+import { FOCUS_INDICATOR_CONSTANTS, IFocusIndicatorComponent } from '../../focus-indicator';
 
 export interface ITabAdapter extends IBaseAdapter {
   initialize(): void;
+  activateFocusIndicator(): void;
   addInteractionListener(type: string, listener: EventListener): void;
   setDisabled(value: boolean): void;
   setSelected(value: boolean): void;
@@ -16,11 +18,13 @@ export interface ITabAdapter extends IBaseAdapter {
 
 export class TabAdapter extends BaseAdapter<ITabComponent> implements ITabAdapter {
   private readonly _tabIndicatorElement: HTMLElement;
+  private readonly _focusIndicatorElement: IFocusIndicatorComponent;
   private readonly _stateLayerElement: IStateLayerComponent;
 
   constructor(component: ITabComponent) {
     super(component);
     this._tabIndicatorElement = getShadowElement(this._component, TAB_CONSTANTS.selectors.INDICATOR);
+    this._focusIndicatorElement = getShadowElement(this._component, FOCUS_INDICATOR_CONSTANTS.elementName) as IFocusIndicatorComponent;
     this._stateLayerElement = getShadowElement(this._component, STATE_LAYER_CONSTANTS.elementName) as IStateLayerComponent;
   }
 
@@ -28,6 +32,10 @@ export class TabAdapter extends BaseAdapter<ITabComponent> implements ITabAdapte
     this._component.tabIndex = this._component.selected ? 0 : -1;
     this._component.setAttribute('role', 'tab');
     this._component.setAttribute('aria-selected', this._component.selected ? 'true' : 'false');
+  }
+
+  public activateFocusIndicator(): void {
+    this._focusIndicatorElement.active = true;
   }
 
   public addInteractionListener(type: string, listener: EventListener): void {

--- a/src/lib/tabs/tab/tab-core.ts
+++ b/src/lib/tabs/tab/tab-core.ts
@@ -1,3 +1,4 @@
+import { ExperimentalFocusOptions } from '../../constants';
 import { ITabAdapter } from './tab-adapter';
 import { TAB_CONSTANTS } from './tab-constants';
 
@@ -8,6 +9,7 @@ export interface ITabCore {
   stacked: boolean;
   secondary: boolean;
   inverted: boolean;
+  setFocus(options?: ExperimentalFocusOptions): void;
 }
 
 export class TabCore implements ITabCore {
@@ -32,6 +34,12 @@ export class TabCore implements ITabCore {
     this._adapter.initialize();
     this._adapter.addInteractionListener('click', this._clickListener);
     this._adapter.addInteractionListener('keydown', this._keydownListener);
+  }
+
+  public setFocus(options?: ExperimentalFocusOptions): void {
+    if (options?.focusVisible) {
+      this._adapter.activateFocusIndicator();
+    }
   }
 
   private _onClick(): void {

--- a/src/lib/tabs/tab/tab.scss
+++ b/src/lib/tabs/tab/tab.scss
@@ -169,24 +169,6 @@ forge-state-layer {
 }
 
 //
-// Secondary
-//
-
-:host([secondary]) {
-  .forge-tab {
-    @include tab-secondary;
-  }
-
-  .content {
-    @include content-secondary;
-  }
-
-  .indicator {
-    @include indicator-secondary;
-  }
-}
-
-//
 // Vertical
 //
 
@@ -212,13 +194,7 @@ forge-state-layer {
   }
 }
 
-:host([vertical][secondary]) {
-  .content {
-    @include vertical-secondary-content;
-  }
-}
-
-:host([vertical]:not([secondary])) {
+:host([vertical]) {
   .forge-tab {
     @include override(indicator-shape, vertical-indicator-shape);
   }

--- a/src/lib/tabs/tab/tab.ts
+++ b/src/lib/tabs/tab/tab.ts
@@ -15,6 +15,7 @@ export interface ITabComponent extends IBaseComponent {
   selected: boolean;
   vertical: boolean;
   stacked: boolean;
+  /** @deprecated This will be removed in a future version */
   secondary: boolean;
   inverted: boolean;
 }
@@ -46,7 +47,7 @@ declare global {
  * @attribute [selected=false] - The selected state of the tab.
  * @attribute [vertical=false] - Controls whether the tab is vertical or horizontal.
  * @attribute [stacked=false] - Controls whether the tab is taller to allow for slotted leading/trailing elements.
- * @attribute [secondary=false] - Controls whether the tab is styled as secondary tab navigation.
+ * @attribute [secondary=false] - Deprecated. Controls whether the tab is styled as secondary tab navigation.
  * @attribute [inverted=false] - Controls whether the tab indicator is rendered on the opposite side of the tab.
  *
  * @event {CustomEvent<void>} forge-tab-select - Dispatched when the tab is selected. This event bubbles and it can be useful to capture it on the `<forge-tab-bar>` element.
@@ -62,8 +63,6 @@ declare global {
  * @cssproperty --forge-tab-indicator-height - The height of the active tab indicator.
  * @cssproperty --forge-tab-indicator-shape - The shape of the active tab indicator.
  * @cssproperty --forge-tab-vertical-indicator-shape - The shape of the active tab indicator when vertical.
- * @cssproperty --forge-tab-secondary-indicator-height - The height of the secondary tab indicator.
- * @cssproperty --forge-tab-secondary-indicator-shape - The shape of the secondary tab indicator.
  * @cssproperty --forge-tab-inverted-indicator-shape - The shape of the active tab indicator when inverted.
  * @cssproperty --forge-tab-vertical-inverted-indicator-shape - The shape of the active tab indicator when vertical and inverted.
  * @cssproperty --forge-tab-container-color - The color of the tab container.
@@ -74,7 +73,6 @@ declare global {
  * @cssproperty --forge-tab-content-padding - The padding value for both block and inline of the tab content.
  * @cssproperty --forge-tab-content-padding-block - The block padding of the tab content.
  * @cssproperty --forge-tab-content-padding-inline - The inline padding of the tab content.
- * @cssproperty --forge-tab-content-padding-inline-secondary - The inline padding of the tab content when secondary.
  * @cssproperty --forge-tab-active-focus-icon-color - The color of the icon when the tab is active and focused.
  * @cssproperty --forge-tab-active-hover-icon-color - The color of the icon when the tab is active and hovered.
  * @cssproperty --forge-tab-active-icon-color - The color of the icon when the tab is active.
@@ -158,6 +156,7 @@ export class TabComponent extends BaseComponent implements ITabComponent {
   @coreProperty()
   public declare stacked: boolean;
 
+  /** @deprecated This will be removed in a future version */
   @coreProperty()
   public declare secondary: boolean;
 

--- a/src/lib/tabs/tab/tab.ts
+++ b/src/lib/tabs/tab/tab.ts
@@ -6,6 +6,7 @@ import { TAB_CONSTANTS } from './tab-constants';
 import { BaseComponent, IBaseComponent } from '../../core/base/base-component';
 import { FocusIndicatorComponent } from '../../focus-indicator/focus-indicator';
 import { StateLayerComponent } from '../../state-layer/state-layer';
+import { ExperimentalFocusOptions } from '../../constants';
 
 import template from './tab.html';
 import styles from './tab.scss';
@@ -18,6 +19,7 @@ export interface ITabComponent extends IBaseComponent {
   /** @deprecated This will be removed in a future version */
   secondary: boolean;
   inverted: boolean;
+  focus(options?: ExperimentalFocusOptions): void;
 }
 
 declare global {
@@ -162,4 +164,9 @@ export class TabComponent extends BaseComponent implements ITabComponent {
 
   @coreProperty()
   public declare inverted: boolean;
+
+  public override focus(options?: ExperimentalFocusOptions): void {
+    super.focus(options);
+    this._core.setFocus(options);
+  }
 }

--- a/src/lib/tabs/tabs.test.ts
+++ b/src/lib/tabs/tabs.test.ts
@@ -127,15 +127,6 @@ describe('Tabs', () => {
     expect(ctx.tabs.every(tab => tab.stacked && tab.hasAttribute(TAB_CONSTANTS.attributes.STACKED))).to.be.true;
   });
 
-  it('should set secondary', async () => {
-    const el = await createFixture({ secondary: true });
-    const ctx = new TabsHarness(el);
-
-    expect(el.secondary).to.be.true;
-    expect(el.hasAttribute(TAB_BAR_CONSTANTS.attributes.SECONDARY)).to.be.true;
-    expect(ctx.tabs.every(tab => tab.secondary && tab.hasAttribute(TAB_CONSTANTS.attributes.SECONDARY))).to.be.true;
-  });
-
   it('should set clustered', async () => {
     const el = await createFixture({ clustered: true });
 
@@ -713,7 +704,6 @@ interface TabsFixtureConfig {
   clustered?: boolean;
   vertical?: boolean;
   stacked?: boolean;
-  secondary?: boolean;
   inverted?: boolean;
   scrollButtons?: boolean;
   autoActivate?: boolean;
@@ -728,7 +718,6 @@ async function createFixture({
   clustered,
   vertical,
   stacked,
-  secondary,
   inverted,
   scrollButtons,
   autoActivate,
@@ -740,13 +729,12 @@ async function createFixture({
     <forge-tab-bar
       .activeTab=${activeTab}
       ?disabled=${disabled}
-      .vertical=${vertical}
-      .clustered=${clustered}
-      .stacked=${stacked}
-      .secondary=${secondary}
-      .inverted=${inverted}
-      .autoActivate=${autoActivate}
-      .scrollButtons=${scrollButtons}
+      .vertical=${!!vertical}
+      .clustered=${!!clustered}
+      .stacked=${!!stacked}
+      .inverted=${!!inverted}
+      .autoActivate=${!!autoActivate}
+      .scrollButtons=${!!scrollButtons}
       style="width: ${width ?? 'auto'}; height: ${height ?? 'auto'}">
       <forge-tab ?disabled=${tabDisabled?.[0]}>First</forge-tab>
       <forge-tab ?disabled=${tabDisabled?.[1]}>Second</forge-tab>

--- a/src/stories/components/tabs/Tabs.mdx
+++ b/src/stories/components/tabs/Tabs.mdx
@@ -9,13 +9,49 @@ import * as TabsStories from './Tabs.stories';
 Tabs are used to quickly navigate between different views, and group related content any level of hierarchy. They may be used as primary
 or secondary navigation within a page.
 
+## Variants
+
+Tabs can be displayed in a number of different ways, including horizontal, vertical, and clustered layouts. The default layout is horizontal.
+
+### Default
+
+By default tabs are displayed in a horizontal layout. This is the most common use case for tabs:
+
 <Canvas of={TabsStories.Demo} />
 
-## Secondary
+### Clustered
 
-Secondary tabs are used within the main content of your page.
+Clustered tabs are displayed in a horizontal orientation, but instead of spanning the full width of their container, they are grouped together
+and can be aligned to the left, center, or right of the container:
 
-<Canvas of={TabsStories.Secondary} />
+<Canvas of={TabsStories.Clustered} />
+
+### Vertical
+
+Vertical tabs are displayed in a vertical orientation. This is useful when you have a large number of tabs, or when you want to save horizontal
+space:
+
+<Canvas of={TabsStories.Vertical} />
+
+### With Icons
+
+Tabs can also include icons to help users quickly identify the content of each tab. Icons can be displayed to the left (start) or right (end) of the tab label:
+
+<Canvas of={TabsStories.WithIcons} />
+
+## Scrolling
+
+The `<forge-tab-bar>` element supports scrolling when the tabs overflow the container. This is useful when you have a large number of tabs and
+want to ensure that all tabs are accessible to the user. The tabs will automatically scroll when the user switches tabs, or when the
+user clicks on the scroll buttons.
+
+<Canvas of={TabsStories.Scrolling} />
+
+## Disabled State
+
+When disabling tabs you should either choose to disable all tabs together through the `<forge-tab-bar>` element, or disable individual tabs for
+each `<forge-tab>` element. Do not mix the two approaches. This is recommended because if you attempt to use both at the same time, the two
+disabled states can conflict with each other leading to unexpected behavior.
 
 ## API
 

--- a/src/stories/components/tabs/Tabs.stories.ts
+++ b/src/stories/components/tabs/Tabs.stories.ts
@@ -1,7 +1,7 @@
 import { html, nothing } from 'lit';
 import { action } from '@storybook/addon-actions';
 import { type Meta, type StoryObj } from '@storybook/web-components';
-import { generateCustomElementArgTypes, getCssVariableArgs } from '../../utils';
+import { generateCustomElementArgTypes, getCssVariableArgs, standaloneStoryParams } from '../../utils';
 import { styleMap } from 'lit/directives/style-map.js';
 import { tylIconFavorite } from '@tylertech/tyler-icons/standard';
 import { tylIconForgeLogo } from '@tylertech/tyler-icons/custom';
@@ -45,7 +45,6 @@ const meta = {
         .vertical=${args.vertical}
         .clustered=${args.clustered}
         .stacked=${args.stacked}
-        .secondary=${args.secondary}
         .inverted=${args.inverted}
         .autoActivate=${args.autoActivate}
         .scrollButtons=${args.scrollButtons}
@@ -78,7 +77,6 @@ const meta = {
     vertical: false,
     clustered: false,
     stacked: false,
-    secondary: false,
     inverted: false,
     autoActivate: false,
     scrollButtons: false
@@ -91,8 +89,30 @@ type Story = StoryObj;
 
 export const Demo: Story = {};
 
-export const Secondary: Story = {
+export const Vertical: Story = {
+  ...standaloneStoryParams,
   args: {
-    secondary: true
+    vertical: true
+  }
+};
+
+export const Clustered: Story = {
+  ...standaloneStoryParams,
+  args: {
+    clustered: true
+  }
+};
+
+export const Scrolling: Story = {
+  ...standaloneStoryParams,
+  args: {
+    scrollButtons: true
+  }
+};
+
+export const WithIcons: Story = {
+  ...standaloneStoryParams,
+  args: {
+    startIcon: true
   }
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N (`secondary` APIs exist, but have no effect)
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
After discussion with the Forge design governance committee, it was determined that we should combine the "primary" (default) and "secondary" variants into a single design. This is purely related to the indicator, and the new (and only) default design can be seen below.

The `secondary` property and attribute still exist, as well as any related design tokens, but they have no effect on the design. I've marked them as deprecated. It was done this way to avoid breaking any existing code. We'll plan to remove them in a future version.

Indicator design updates:
- Expand indicator to be full width of tab (from "secondary" design)
- Use "primary" indicator height (`3px` by default)
- Use "primary" indicator shape (rounded corners)

These same changes will also been apply to the vertical and inverted variants.

Example of changes:

![image](https://github.com/user-attachments/assets/0b403844-a07c-49d9-9fde-deaa94d77606)
