### PR TITLE
fix: update checkbox, radio, switch label typography to use `label2` (13px) typography by default

### DIFF
--- a/src/dev/pages/checkbox/checkbox.ejs
+++ b/src/dev/pages/checkbox/checkbox.ejs
@@ -6,7 +6,7 @@
 
   <div>
     <h3 class="forge-typography--heading2">CSS-based Checkbox</h3>
-    <label class="forge-typography--label1" style="display: flex; align-items: center;">
+    <label class="forge-typography--label2" style="display: flex; align-items: center;">
       <div class="forge-checkbox">
         <input type="checkbox" id="css-checkbox" />
         <div class="forge-checkbox__icon"></div>

--- a/src/dev/pages/radio/radio.ejs
+++ b/src/dev/pages/radio/radio.ejs
@@ -14,15 +14,15 @@
       <div class="forge-radio">
         <input type="radio" name="css" id="css-radio-1" />
       </div>
-      <label class="forge-typography--label1" for="css-radio-1">Option 1</label>
+      <label class="forge-typography--label2" for="css-radio-1">Option 1</label>
       <div class="forge-radio">
         <input type="radio" name="css" id="css-radio-2" />
       </div>
-      <label class="forge-typography--label1" for="css-radio-2">Option 2</label>
+      <label class="forge-typography--label2" for="css-radio-2">Option 2</label>
       <div class="forge-radio">
         <input type="radio" name="css" id="css-radio-3" />
       </div>
-      <label class="forge-typography--label1" for="css-radio-3">Option 3</label>
+      <label class="forge-typography--label2" for="css-radio-3">Option 3</label>
     </div>
   </form>
 

--- a/src/dev/pages/switch/switch.ejs
+++ b/src/dev/pages/switch/switch.ejs
@@ -8,7 +8,7 @@
 
   <div>
     <h3 class="forge-typography--heading2">CSS-based Switch</h3>
-    <label class="forge-typography--label1" style="display: flex; align-items: center;">
+    <label class="forge-typography--label2" style="display: flex; align-items: center;">
       <div class="forge-switch">
         <input type="checkbox" switch />
         <div class="forge-switch__thumb">

--- a/src/lib/checkbox/_core.scss
+++ b/src/lib/checkbox/_core.scss
@@ -138,7 +138,7 @@
 }
 
 @mixin label {
-  @include typography.style(label1);
+  @include typography.style(label2);
 
   cursor: default;
 }

--- a/src/lib/radio/radio/_core.scss
+++ b/src/lib/radio/radio/_core.scss
@@ -111,7 +111,7 @@
 }
 
 @mixin label {
-  @include typography.style(label1);
+  @include typography.style(label2);
 
   cursor: default;
 

--- a/src/lib/switch/_core.scss
+++ b/src/lib/switch/_core.scss
@@ -243,7 +243,7 @@ $_handle-on-translate: calc(#{token(track-width)} - #{$_track-border-radius} * 2
 }
 
 @mixin label {
-  @include typography.style(label1);
+  @include typography.style(label2);
 
   &:empty {
     display: none;

--- a/src/stories/components/checkbox/Checkbox.stories.ts
+++ b/src/stories/components/checkbox/Checkbox.stories.ts
@@ -77,7 +77,7 @@ export const CSSOnly: Story = {
       'forge-checkbox--dense': dense
     });
     return html`
-      <label class="forge-typography--label1" style="display: flex; align-items: center;">
+      <label class="forge-typography--label2" style="display: flex; align-items: center;">
         <div class=${classes}>
           <input type="checkbox" .checked=${checked} .indeterminate=${indeterminate} ?disabled=${disabled} />
           <div class="forge-checkbox__icon"></div>

--- a/src/stories/components/radio/Radio.stories.ts
+++ b/src/stories/components/radio/Radio.stories.ts
@@ -101,15 +101,15 @@ export const CSSOnly: Story = {
         <div class=${classMap(classes)}>
           <input type="radio" name="css-radio" ?disabled=${disabled} id="css-radio-1" />
         </div>
-        <label class="forge-typography--label1" for="css-radio-1">Option 1</label>
+        <label class="forge-typography--label2" for="css-radio-1">Option 1</label>
         <div class=${classMap(classes)}>
           <input type="radio" name="css-radio" ?disabled=${disabled} id="css-radio-2" />
         </div>
-        <label class="forge-typography--label1" for="css-radio-2">Option 2</label>
+        <label class="forge-typography--label2" for="css-radio-2">Option 2</label>
         <div class=${classMap(classes)}>
           <input type="radio" name="css-radio" ?disabled=${disabled} id="css-radio-3" />
         </div>
-        <label class="forge-typography--label1" for="css-radio-3">Option 3</label>
+        <label class="forge-typography--label2" for="css-radio-3">Option 3</label>
       </div>
     `;
   }

--- a/src/stories/components/switch/Switch.stories.ts
+++ b/src/stories/components/switch/Switch.stories.ts
@@ -58,7 +58,7 @@ export const CSSOnly: Story = {
       'forge-switch--dense': dense
     };
     return html`
-      <label class="forge-typography--label1" style="display: flex; align-items: center;">
+      <label class="forge-typography--label2" style="display: flex; align-items: center;">
         <div class=${classMap(classes)}>
           <input type="checkbox" switch .checked=${on} ?disabled=${disabled} />
           <div class="forge-switch__thumb">


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The checkbox, radio, and switch will now use the larger `label2` typography style. This is an increase from `12px` to `13px` which is considered to be more readable in terms of accessibility.


