### PR TITLE
feat(typography): add new `label3` style

### DIFF
--- a/src/dev/pages/typography/typography.ejs
+++ b/src/dev/pages/typography/typography.ejs
@@ -49,6 +49,7 @@
 <div class="section">
   <div class="forge-typography--label1">Label 1</div>
   <div class="forge-typography--label2">Label 2</div>
+  <div class="forge-typography--label3">Label 3</div>
 </div>
 
 <div class="section">

--- a/src/lib/core/styles/tokens/typography/_tokens.label.scss
+++ b/src/lib/core/styles/tokens/typography/_tokens.label.scss
@@ -22,6 +22,15 @@ $label2: utils.inherit-map(
   )
 ) !default;
 
+$label3: utils.inherit-map(
+  core.$base,
+  (
+    font-size: type-utils.font-size-relative(label, font-size, '0875'),
+    line-height: type-utils.font-size-relative(label, line-height, '1250'),
+    letter-spacing: type-utils.calc-letter-spacing(0.125, scale.value('0875'))
+  )
+) !default;
+
 $button: utils.inherit-map(
   core.$base,
   (
@@ -45,6 +54,7 @@ $overline: utils.inherit-map(
 $tokens: (
   label1: $label1,
   label2: $label2,
+  label3: $label3,
   button: $button,
   overline: $overline
 ) !default;

--- a/src/stories/design-tokens/Typography.mdx
+++ b/src/stories/design-tokens/Typography.mdx
@@ -27,14 +27,14 @@ Each typography style also has its own set of tokens that define the font size, 
 
 For example, Forge will set the `<body>` element on your page to use the `body2` style by default. This style is defined by the following tokens:
 
-| Token  
+| Token
 | --------------------------------------------
-| `--forge-typography-body2-font-family`  
-| `--forge-typography-body2-font-size`  
-| `--forge-typography-body2-font-weight`  
-| `--forge-typography-body2-line-height`  
-| `--forge-typography-body2-letter-spacing`  
-| `--forge-typography-body2-text-transform`  
+| `--forge-typography-body2-font-family`
+| `--forge-typography-body2-font-size`
+| `--forge-typography-body2-font-weight`
+| `--forge-typography-body2-line-height`
+| `--forge-typography-body2-letter-spacing`
+| `--forge-typography-body2-text-transform`
 | `--forge-typography-body2-text-decoration`
 
 Each style has a similar set of tokens that allow for you to granularly customize the font styles used in your application.

--- a/src/stories/getting-started/Typography.mdx
+++ b/src/stories/getting-started/Typography.mdx
@@ -128,6 +128,7 @@ Label styles are used for small text such as form labels and captions.
 | :------------------------- | :------------------------------------------------------ |
 | `forge-typography--label1` | <div className="forge-typography--label1">Label 1</div> |
 | `forge-typography--label2` | <div className="forge-typography--label2">Label 2</div> |
+| `forge-typography--label3` | <div className="forge-typography--label3">Label 3</div> |
 
 </Unstyled>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Per discussion with the governance committee about #769 it was also decided that we should introduce a new label typography style called `label3` that uses a `14px` font size.

Currently this type style is unused within the library itself, but may be valuable for design purposes in the future.
