### PR TITLE
fix(text-field): label will now float when invalid chars are entered in number inputs

### DIFF
--- a/src/lib/text-field/text-field-core.ts
+++ b/src/lib/text-field/text-field-core.ts
@@ -82,8 +82,15 @@ export class TextFieldCore extends BaseFieldCore<ITextFieldAdapter> implements I
     }
   }
 
-  private _onValueChange(): void {
-    this._tryFloatLabel();
+  private _onValueChange(evt: InputEvent): void {
+    let force;
+
+    // Handle the special case where a number input allows invalid characters
+    if ((evt.target as HTMLInputElement | undefined)?.type === 'number' && (evt.data != null || (evt.target as HTMLInputElement).validity.badInput)) {
+      force = true;
+    }
+
+    this._tryFloatLabel(force);
     this._toggleClearButtonVisibility();
   }
 

--- a/src/lib/text-field/text-field.test.ts
+++ b/src/lib/text-field/text-field.test.ts
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { fixture, html } from '@open-wc/testing';
 import { getShadowElement } from '@tylertech/forge-core';
 import { frame } from '../core/utils/utils';
-import { sendMouse } from '@web/test-runner-commands';
+import { sendMouse, sendKeys } from '@web/test-runner-commands';
 import { spy } from 'sinon';
 import { ITextFieldComponent, TEXT_FIELD_CONSTANTS } from '../text-field';
 import { TestHarness } from '../../test/utils/test-harness';
@@ -236,6 +236,16 @@ describe('Text field', () => {
       expect(harness.fieldElement.floatLabel).to.be.true;
     });
 
+    it('should float label when input type number has non-numeric characters', async () => {
+      const harness = await createFixture({ type: 'number' });
+      harness.element.labelPosition = 'inset';
+      harness.inputElement.focus();
+      await sendKeys({ press: 'e' });
+      await frame();
+      expect(harness.inputElement.value).to.be.empty;
+      expect(harness.fieldElement.floatLabel).to.be.true;
+    });
+
     it('should not float label when input has no value or placeholder', async () => {
       const harness = await createFixture();
       harness.element.labelPosition = 'inset';
@@ -291,14 +301,15 @@ class TextFieldHarness extends TestHarness<ITextFieldComponent> {
 }
 
 interface TextFieldFixtureConfig {
+  type?: string;
   showClear?: boolean;
 }
 
-async function createFixture({ showClear }: TextFieldFixtureConfig = {}): Promise<TextFieldHarness> {
+async function createFixture({ type = 'text', showClear }: TextFieldFixtureConfig = {}): Promise<TextFieldHarness> {
   const el = await fixture<ITextFieldComponent>(html`
-    <forge-text-field .showClear=${showClear}>
+    <forge-text-field .showClear=${!!showClear}>
       <label slot="label" for="input">Label</label>
-      <input id="input" type="text" />
+      <input id="input" .type=${type} />
     </forge-text-field>
   `);
   return new TextFieldHarness(el);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The inset floating label will now float properly when invalid characters are entered in `<input type="number">` fields.

The characters themselves can technically be valid numbers such as "e", ".", "+", "-" but number inputs in browsers will often see characters such as "e" as bad/invalid input and therefore the `value` property doesn't reflect the visual value as a valid number. This was causing the label to not float in this scenario.

This change adds a special case to force the floating label state if these types of characters are entered in a number input.

It's important to note that this doesn't change how the native `<input type="number">` operates, only the floating label state. The underlying `value` may still be empty in these scenarios per the HTML spec and setting these values on reload will not be reflected as one may expect...

## Additional information
Fixes #772 
