### PR TITLE
chore(eslint): remove duplicate eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,24 +28,7 @@
           {
             "endOfLine": "auto"
           }
-        ],
-        "@typescript-eslint/indent": "off",
-        "@typescript-eslint/no-empty-interface": ["error", { "allowSingleExtends": true }],
-        "@typescript-eslint/explicit-function-return-type": ["error", { "allowExpressions": true }],
-        "@typescript-eslint/comma-dangle": ["error"],
-        "@typescript-eslint/comma-spacing": "error",
-        "@typescript-eslint/explicit-member-accessibility": ["error", { "overrides": { "constructors": "no-public" } }],
-        "@typescript-eslint/arrow-body-style": "off",
-        "@typescript-eslint/no-require-imports": "error",
-        "explicit-function-return-type": "off",
-        "no-trailing-spaces": ["error", { "ignoreComments": true, "skipBlankLines": true }],
-        "quote-props": ["error", "as-needed", { "unnecessary": false }],
-        "comma-dangle": "error",
-        "comma-spacing": "off",
-        "no-extra-parens": "off",
-        "max-len": "off",
-        "arrow-body-style": "off",
-        "eqeqeq": ["error", "always", { "null": "ignore" }]
+        ]
       }
     }
   ]


### PR DESCRIPTION
These eslint rules were overrides that we previously had in place on this repo until they were pushed into the shared eslint rules package, they were just never removed from this repo when we upgraded the dependency...