### PR TITLE
fix(drawer): fixed a bug where the drawer would not repaint after transitioning in Safari

### DIFF
--- a/src/dev/pages/drawer/drawer.ejs
+++ b/src/dev/pages/drawer/drawer.ejs
@@ -1,4 +1,4 @@
-<div class="vert">
+<div class="vert drawer-demo-container">
   <div>
     <%- include('./drawer-permanent.ejs') %>
   </div>

--- a/src/dev/pages/drawer/drawer.scss
+++ b/src/dev/pages/drawer/drawer.scss
@@ -1,4 +1,9 @@
 .drawer-demo {
   border: 1px solid var(--forge-theme-outline);
   background-color: var(--forge-theme-surface-dim);
+  height: 370px;
+}
+
+.drawer-demo-container {
+  overflow: clip;
 }

--- a/src/lib/core/styles/tokens/drawer/mini/_tokens.scss
+++ b/src/lib/core/styles/tokens/drawer/mini/_tokens.scss
@@ -7,6 +7,7 @@
 
 $tokens: (
   width: utils.module-val(mini-drawer, width, 56px),
+  min-width: utils.module-ref(mini-drawer, min-width, width),
   hover-width: utils.module-val(mini-drawer, hover-width, base-tokens.get(width)),
   transition-duration: utils.module-val(mini-drawer, transition-duration, animation.variable(duration-short4)),
   transition-easing: utils.module-val(mini-drawer, transition-easing, animation.variable(easing-standard)),

--- a/src/lib/drawer/base/_core.scss
+++ b/src/lib/drawer/base/_core.scss
@@ -55,8 +55,7 @@
 }
 
 @mixin host() {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   box-sizing: border-box;
   height: 100%;
   overflow: hidden !important; // Using important to ensure that it overrides the scaffold overflow style

--- a/src/lib/drawer/drawer/drawer.scss
+++ b/src/lib/drawer/drawer/drawer.scss
@@ -20,13 +20,7 @@
 
 @include base-core.core-styles;
 
-//
-// Safari fix for triggering reflow after transition completes (as of Safari 14)
-//
-@media not all and (min-resolution: 0.001dpcm) {
-  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
-    :host([open]) {
-      transform: translateZ(0);
-    }
-  }
+:host([open]) {
+  // Safari fix for triggering reflow after transition completes (as of Safari 17.6)
+  transform: translateZ(0);
 }

--- a/src/lib/drawer/mini-drawer/_core.scss
+++ b/src/lib/drawer/mini-drawer/_core.scss
@@ -22,6 +22,7 @@
 @mixin root() {
   z-index: #{elevation.z-index-variable(surface)};
   height: 100%;
+  min-width: #{token(min-width)};
 }
 
 @mixin hover() {

--- a/src/lib/drawer/mini-drawer/mini-drawer.ts
+++ b/src/lib/drawer/mini-drawer/mini-drawer.ts
@@ -23,6 +23,7 @@ declare global {
  * @attribute {boolean} [hover=false] - The drawer will expand open when hovered.
  *
  * @cssproperty --forge-mini-drawer-width - The width of the drawer.
+ * @cssproperty --forge-mini-drawer-min-width - The minimum width of the drawer. Defaults to match the width.
  * @cssproperty --forge-mini-drawer-hover-width - The width of the drawer when hovered.
  * @cssproperty --forge-mini-drawer-transition-duration - The transition duration of the drawer.
  * @cssproperty --forge-mini-drawer-transition-easing - The transition timing function of the drawer.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
A recent Safari update broke an `@supports` selector that was previously being used to fix a repaint problem occurring in Safari after the drawer open animation completes. This selector has been fixed to always apply now.

Included some additional cleanup on the drawer demo page and discovered a small bug relating to how mini-drawers affect their layout. Introduced a new min-width token and defaulted it to inherit the width token.
