### PR TITLE
fix: reduce usage of `contain` style to only required instances

### DIFF
--- a/src/lib/avatar/_core.scss
+++ b/src/lib/avatar/_core.scss
@@ -4,8 +4,6 @@
 @forward './token-utils';
 
 @mixin host() {
-  contain: content;
-
   display: inline-block;
 }
 

--- a/src/lib/backdrop/_core.scss
+++ b/src/lib/backdrop/_core.scss
@@ -9,7 +9,6 @@
 @mixin base {
   position: absolute;
   inset: 0;
-  contain: content;
 
   z-index: #{token(z-index)};
 

--- a/src/lib/divider/_core.scss
+++ b/src/lib/divider/_core.scss
@@ -4,7 +4,6 @@
 
 @mixin host {
   display: block;
-  contain: content;
   margin: #{token(margin)};
 }
 

--- a/src/lib/linear-progress/_core.scss
+++ b/src/lib/linear-progress/_core.scss
@@ -8,8 +8,11 @@
   position: relative;
   min-inline-size: 80px;
   block-size: #{token(track-height)};
-  content-visibility: auto;
+
+  // `contain` and `content-visibility` are performance optimizations important here because progress indicators
+  // are often used when a CPU=intensive task is underway so it's especially important to minimize their CPU consumption.
   contain: strict;
+  content-visibility: auto;
 }
 
 @mixin progress {

--- a/src/lib/split-view/split-view-panel/_mixins.scss
+++ b/src/lib/split-view/split-view-panel/_mixins.scss
@@ -127,7 +127,6 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  contain: paint size;
 }
 
 @mixin base-horizontal() {

--- a/src/lib/split-view/split-view/_mixins.scss
+++ b/src/lib/split-view/split-view/_mixins.scss
@@ -23,7 +23,6 @@
   height: 100%;
   width: 100%;
   overflow: hidden;
-  contain: paint size;
 }
 
 @mixin base() {

--- a/src/lib/toolbar/_core.scss
+++ b/src/lib/toolbar/_core.scss
@@ -9,7 +9,6 @@
 
 @mixin host {
   display: block;
-  contain: layout;
 }
 
 @mixin base {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The `contain` CSS style should be used in specific cases where it either improves performance or can fix a specific problem.

There were a few usages of this style across the library that were added as pre-optimizations and this PR removes those.

This will also fix a couple bugs related to the backdrop and split view components when used in layouts where layout shifts occur.

## Additional information
Fixes #783
