### PR TITLE
fix(drawer): fixed a bug where the drawer would not repaint after transitioning in Safari

### DIFF
--- a/src/lib/drawer/base/_mixins.scss
+++ b/src/lib/drawer/base/_mixins.scss
@@ -50,8 +50,7 @@
 }
 
 @mixin host() {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   box-sizing: border-box;
   height: 100%;
   overflow: hidden !important; // Using important to ensure that it overrides the scaffold overflow style

--- a/src/lib/drawer/drawer/drawer.scss
+++ b/src/lib/drawer/drawer/drawer.scss
@@ -10,11 +10,7 @@
 /// 
 /// Safari fix for triggering reflow after transition completes (as of Safari 14)
 ///
-// stylelint-disable-next-line unit-allowed-list
-@media not all and (min-resolution: 0.001dpcm) {
-  @supports (-webkit-appearance:none) and (stroke-color: transparent) {
-    :host([open]) {
-      transform: translateZ(0);
-    }
-  }
+
+:host([open]) {
+  transform: translateZ(0);
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
A recent Safari update broke an `@supports` selector that was previously being used to fix a repaint problem occurring in Safari after the drawer open animation completes. This selector has been fixed to always apply now.

Included an additional adjustment to switch from flex to grid for the drawer host element to ensure that the container element properly fills the available space by default.