### PR TITLE
fix(split-view-panel): fixed a bug relating to the open animation direction

### DIFF
--- a/src/lib/split-view/split-view-panel/_mixins.scss
+++ b/src/lib/split-view/split-view-panel/_mixins.scss
@@ -1,3 +1,4 @@
+@use 'sass:string';
 @use '../../core/styles/animation';
 @use '../../core/styles/theme';
 @use './variables';
@@ -208,7 +209,7 @@
 @mixin closing-animation($direction: right) {
   @include animating-position($direction);
 
-  $animation-name: unique-id;
+  $animation-name: string.unique-id();
 
   animation-name: $animation-name;
   animation-duration: #{animation.variable(duration-medium2)};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Fixed a bug caused by the v2 to v3 migration to Sass modules where `unique-id` from the `sass:string` module was not being called, which caused the panel keyframes animation to be incorrect.
