### PR TITLE
fix(label-value): allow for content to wrap long words without overflowing

### DIFF
--- a/src/lib/label-value/_core.scss
+++ b/src/lib/label-value/_core.scss
@@ -37,6 +37,7 @@
 
   line-height: normal;
   text-align: #{token(align)};
+  overflow-wrap: anywhere;
 
   color: #{token(label-color)};
 }
@@ -51,6 +52,7 @@
 
   line-height: normal;
   text-align: #{token(align)};
+  overflow-wrap: anywhere;
 }
 
 @mixin value-empty {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Adds `overflow-wrap: anywhere` to the label and value container elements to automatically break long words when wrapping to avoid overflowing content.
