### PR TITLE
Fix/icon button badge dense

### DIFF
--- a/src/lib/core/styles/typography/index.scss
+++ b/src/lib/core/styles/typography/index.scss
@@ -161,7 +161,7 @@
     @if not map.get($style-tokens, $key) {
       @error 'Invalid token "#{$key}" for style "#{$style}"';
     }
-    --#{config.$prefix}-typography-#{$key}: #{$value};
+    --#{config.$prefix}-typography-#{$style}-#{$key}: #{$value};
   }
 }
 

--- a/src/lib/icon-button/icon-button.scss
+++ b/src/lib/icon-button/icon-button.scss
@@ -1,7 +1,9 @@
 @use './core' as *;
-@use '../core/styles/theme';
+@use '../theme';
+@use '../typography';
 @use '../state-layer';
 @use '../focus-indicator';
+@use '../badge';
 @use '../circular-progress';
 
 //
@@ -195,6 +197,23 @@ forge-state-layer {
 
   ::slotted(forge-badge[slot='badge'][dot]) {
     top: 0;
+  }
+}
+
+:host(:is([dense], [density='small'])) {
+  // We reduce the size of the badge when the density is small
+  ::slotted(forge-badge[slot='badge']) {
+    @include typography.provide(
+      label1,
+      (
+        line-height: normal
+      )
+    );
+    @include badge.provide-theme(
+      (
+        height: auto
+      )
+    );
   }
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The icon button will now override the badge tokens automatically when a `<forge-badge>` is slotted into the `badge` slot of a `<forge-icon-button>` that is using the small density. This ensures that the badge doesn't overlap the icon button itself, and can better fit the desired smaller density/size.
