### PR TITLE
fix(file-picker): cleanup callback to avoid reference being held which can leak

### DIFF
--- a/src/lib/file-picker/file-picker-adapter.ts
+++ b/src/lib/file-picker/file-picker-adapter.ts
@@ -6,6 +6,7 @@ import { BaseAdapter, IBaseAdapter } from '../core';
 import { IButtonComponent } from '../button';
 
 export interface IFilePickerAdapter extends IBaseAdapter {
+  destroy(): void;
   registerButtonSlotListener(listener: (evt: Event) => void): void;
   registerInputChangeListener(listener: (evt: Event) => void): void;
   registerDragEnterListener(listener: (evt: DragEvent) => void): void;
@@ -31,7 +32,7 @@ export class FilePickerAdapter extends BaseAdapter<IFilePickerComponent> impleme
   private _buttonSlot: HTMLSlotElement;
   private _button: IButtonComponent | undefined;
   private _input: HTMLInputElement;
-  private _inputEventListener: () => void;
+  private _inputEventListener: EventListener | undefined;
 
   constructor(component: IFilePickerComponent) {
     super(component);
@@ -46,6 +47,13 @@ export class FilePickerAdapter extends BaseAdapter<IFilePickerComponent> impleme
     };
 
     this._container.addEventListener('click', this._inputEventListener);
+  }
+
+  public destroy(): void {
+    if (this._inputEventListener) {
+      this._container.removeEventListener('click', this._inputEventListener);
+      this._inputEventListener = undefined;
+    }
   }
 
   public registerButtonSlotListener(listener: (evt: Event) => void): void {
@@ -145,11 +153,11 @@ export class FilePickerAdapter extends BaseAdapter<IFilePickerComponent> impleme
    */
   public setDisabled(value: boolean): void {
     if (value) {
-      this._container.removeEventListener('click', this._inputEventListener);
+      this._container.removeEventListener('click', this._inputEventListener as EventListener);
       this._button?.setAttribute('disabled', '');
       this._container.setAttribute('disabled', '');
     } else {
-      this._container.addEventListener('click', this._inputEventListener);
+      this._container.addEventListener('click', this._inputEventListener as EventListener);
       this._button?.removeAttribute('disabled');
       this._container.removeAttribute('disabled');
     }

--- a/src/lib/file-picker/file-picker-core.ts
+++ b/src/lib/file-picker/file-picker-core.ts
@@ -49,6 +49,7 @@ export class FilePickerCore implements IFilePickerCore {
   }
 
   public destroy(): void {
+    this._adapter.destroy();
     this._isInitialized = false;
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The file picker creates a callback in its constructor that holds a reference to its `<input>`, but does not release resources when the element is disconnected. This change will just ensure that the callback is reset to `undefined` when the element is disconnected to ensure resources can be released.
