### PR TITLE
docs(button-area): add required slotted button to demo

### DIFF
--- a/src/stories/components/button-area/ButtonArea.stories.ts
+++ b/src/stories/components/button-area/ButtonArea.stories.ts
@@ -29,9 +29,10 @@ const meta = {
     return html`
       <forge-card>
         <forge-button-area ?disabled=${args.disabled} @click=${clickAction} style=${style}>
+          <button slot="button" aria-labelledby="button-heading"></button>
           <div class="content">
             <div>
-              <div>Heading</div>
+              <div id="button-heading">Heading</div>
               <div>Content</div>
             </div>
             <forge-icon-button>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N/A
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N/A

## Describe the new behavior?
Added a slotted `<button>` element to the button area demo. This is required to use the button area correctly but was missing before.
