### PR TITLE
fix(app-bar-search): fixed a color contrast issue by increasing the color emphasis on the placeholder text due to the transparent background

### DIFF
--- a/src/lib/core/styles/tokens/app-bar/search/_tokens.scss
+++ b/src/lib/core/styles/tokens/app-bar/search/_tokens.scss
@@ -11,7 +11,7 @@ $tokens: (
   shape: utils.module-val(app-bar-search, shape, shape.variable(small)),
   gap: utils.module-val(app-bar-search, gap, 4px),
   input-placeholder-color: utils.module-ref(app-bar-search, input-placeholder-color, color),
-  input-placeholder-opacity: utils.module-val(app-bar-search, input-placeholder-opacity, theme.emphasis(medium-low)),
+  input-placeholder-opacity: utils.module-val(app-bar-search, input-placeholder-opacity, theme.emphasis(higher)),
   background-color: utils.module-ref(app-bar-search, background-color, color),
   background-color-opacity: utils.module-val(app-bar-search, background-color-opacity, theme.emphasis(lowest)),
   border-color: utils.module-ref(app-bar-search, border-color, color),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: [Y/N]
- Docs have been added/updated: [Y/N]
- Does this PR introduce a breaking change? [Y/N]
- I have linked any related GitHub issues to be closed when this PR is merged? [Y/N]

## Describe the new behavior?
Increased the placeholder color emphasis (opacity) to the "higher" token (70%) to fix color contrast on top of the semi-opaque background color applied to the background of container.

Old (not passing):
<img width="943" alt="image" src="https://github.com/user-attachments/assets/0a53d823-90e9-482d-98b5-1b37fcff0464" />

New (passing):
<img width="946" alt="image" src="https://github.com/user-attachments/assets/ccdbc19b-9664-4b53-b5c9-032b01f69b84" />

## Additional information
Fixes #796 
