### PR TITLE
fix(list-item): fixed a bug where the selected state overlay could render on top of slotted elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "storybook": "^8.4.7",
         "storybook-addon-tag-badges": "^1.2.1",
         "storybook-dark-mode": "^4.0.2",
-        "stylelint": "^16.12.0",
+        "stylelint": "^16.14.1",
         "stylelint-config-prettier": "^9.0.5",
         "typescript": "~5.4.5",
         "vite": "^5.4.11",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "storybook": "^8.4.7",
     "storybook-addon-tag-badges": "^1.2.1",
     "storybook-dark-mode": "^4.0.2",
-    "stylelint": "^16.12.0",
+    "stylelint": "^16.14.1",
     "stylelint-config-prettier": "^9.0.5",
     "typescript": "~5.4.5",
     "vite": "^5.4.11",

--- a/src/lib/list/list-item/_core.scss
+++ b/src/lib/list/list-item/_core.scss
@@ -89,6 +89,7 @@
     border-radius: inherit;
     opacity: #{token(selected-opacity)};
     background-color: #{token(selected-background)};
+    pointer-events: none;
   }
 }
 
@@ -106,6 +107,8 @@
 
 @mixin start-end-selected {
   color: #{token(selected-color)};
+
+  isolation: isolate;
 }
 
 @mixin text {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Fixes a layering problem where the selected state overlay in the list item (using the `::before` pseudo element) was covering the slotted elements causing issues with pointer events and tooltips.

This change makes sure the slotted elements are rendered above that overlay in their own stacking context, and disable pointer events on the overlay itself.

