### PR TITLE
fix(table): only apply `aria-hidden` on `<th>` elements if `headerTemplate` is not used

### DIFF
--- a/src/lib/table/table-utils.ts
+++ b/src/lib/table/table-utils.ts
@@ -255,7 +255,7 @@ export class TableUtils {
       span.classList.add(TABLE_CONSTANTS.classes.TABLE_HEAD_CELL_TEXT);
       span.textContent = columnConfig.header && typeof columnConfig.header === 'string' ? columnConfig.header.trim() : '';
 
-      if (span.textContent.trim().length === 0) {
+      if (span.textContent.trim().length === 0 && typeof columnConfig.headerTemplate !== 'function') {
         th.setAttribute('aria-hidden', 'true');
       }
 

--- a/src/lib/table/table-utils.ts
+++ b/src/lib/table/table-utils.ts
@@ -251,14 +251,6 @@ export class TableUtils {
         Object.assign(cellContainer.style, columnConfig.headerCellStyle);
       }
 
-      const span = document.createElement('span');
-      span.classList.add(TABLE_CONSTANTS.classes.TABLE_HEAD_CELL_TEXT);
-      span.textContent = columnConfig.header && typeof columnConfig.header === 'string' ? columnConfig.header.trim() : '';
-
-      if (span.textContent.trim().length === 0 && typeof columnConfig.headerTemplate !== 'function') {
-        th.setAttribute('aria-hidden', 'true');
-      }
-
       // Add the sort icon if this column is sortable
       if (columnConfig.sortable) {
         th.classList.add(TABLE_CONSTANTS.classes.TABLE_HEAD_CELL_SORTABLE);
@@ -309,6 +301,12 @@ export class TableUtils {
           }
         });
       } else {
+        const span = document.createElement('span');
+        span.classList.add(TABLE_CONSTANTS.classes.TABLE_HEAD_CELL_TEXT);
+        span.textContent = columnConfig.header && typeof columnConfig.header === 'string' ? columnConfig.header.trim() : '';
+        if (span.textContent.trim().length === 0) {
+          th.setAttribute('aria-hidden', 'true');
+        }
         TableUtils._prepend(span, cellContainer);
       }
 

--- a/src/test/spec/table/table.spec.ts
+++ b/src/test/spec/table/table.spec.ts
@@ -2011,6 +2011,23 @@ describe('TableComponent', function(this: ITestContext) {
       expect(firstCell.innerHTML).toContain('Hello Goodbye');
     });
 
+    it('should contain custom header template without a aria-hidden attribute', async function(this: ITestContext) {
+      this.context = setupTestContext();
+      const testColumns = deepCopy(columns);
+      testColumns[0].sortable = true;
+      testColumns[0].headerTemplate = () => '<span>Hello Goodbye</span>';
+
+      this.context.component.columnConfigurations = testColumns;
+      await frame();
+
+      const callback = jasmine.createSpy('callback');
+      this.context.component.addEventListener(TABLE_CONSTANTS.events.SORT, callback);
+
+      const headerRow = getTableHeaderRow(this.context.getTableElement());
+      const firstCell = headerRow.cells.item(0) as HTMLTableCellElement;
+      expect(firstCell.hasAttribute('aria-hidden')).toBeFalse();
+    });
+
     it('should contain custom header template with sort arrow', async function(this: ITestContext) {
       this.context = setupTestContext();
       const testColumns = deepCopy(columns);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: [Y]
- Docs have been added/updated: [N]
- Does this PR introduce a breaking change? [N]
- I have linked any related GitHub issues to be closed when this PR is merged? [N]

## Describe the new behavior?
The forge-table automatically adds an aria-hidden to any header cell that's empty. The problem was, the aria-hidden was being added to table headers that used a custom headerTemplate as well. If someone is using a custom headerTemplate we don't want to automatically assume it needs to be hidden from assistive technology, we'll leave that up to the consumer
