### PR TITLE
chore(test): filter Lit dev mode warning from test output

### DIFF
--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -26,6 +26,8 @@ export const directoryGroup = source =>
     .filter(dirent => dirent.isDirectory())
     .map(dirent => dirent.name);
 
+export const FILTERED_LOGS = ['Lit is in dev mode'];
+
 /**
  * @type {import('@web/test-runner').TestRunnerConfig}
  */
@@ -33,6 +35,14 @@ export default {
   concurrentBrowsers: 1,
   concurrency: 1,
   nodeResolve: true,
+  filterBrowserLogs: ({ args }) => {
+    for (const arg of args) {
+      if (typeof arg === 'string' && FILTERED_LOGS.some(l => arg.includes(l))) {
+        return false;
+      }
+    }
+    return true;
+  },
   testsFinishTimeout: 60000,
   testFramework: {
     config: {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Added `filterBrowserLogs` to WTR config to remove Lit dev mode logs from output.