### PR TITLE
fix: exposed `align` token and fixed layout bug with long labels for checkbox, radio, and switch

### DIFF
--- a/src/lib/checkbox/_core.scss
+++ b/src/lib/checkbox/_core.scss
@@ -12,8 +12,7 @@
 @mixin checkbox {
   position: relative;
   flex-direction: #{token(direction)};
-  flex-shrink: 0;
-  align-items: center;
+  align-items: #{token(align)};
   justify-content: #{token(justify)};
   gap: #{token(gap)};
 
@@ -34,6 +33,7 @@
   justify-content: center;
 
   display: flex;
+  flex-shrink: 0;
 
   border-radius: #{token(state-layer-shape)};
   inline-size: #{token(state-layer-width)};

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -56,6 +56,7 @@ declare global {
  * @cssproperty --forge-checkbox-elevation - The shadow of the checkbox.
  * @cssproperty --forge-checkbox-gap - The space between the checkbox and label.
  * @cssproperty --forge-checkbox-justify - How the checkbox and label are distributed along their main axis.
+ * @cssproperty --forge-checkbox-align - How the checkbox and label are distributed along their cross axis.
  * @cssproperty --forge-checkbox-direction - Whether the checkbox and label are arranged along the inline or block axis.
  * @cssproperty --forge-checkbox-checked-background - The color of the checkbox background when checked or indeterminate.
  * @cssproperty --forge-checkbox-checked-border-width - The width of the checkbox border when checked or indeterminate.

--- a/src/lib/core/styles/tokens/checkbox/_tokens.scss
+++ b/src/lib/core/styles/tokens/checkbox/_tokens.scss
@@ -33,6 +33,7 @@ $tokens: (
   // Label
   gap: utils.module-val(checkbox, gap, 0),
   justify: utils.module-val(checkbox, justify, start),
+  align: utils.module-val(checkbox, align, center),
   direction: utils.module-val(checkbox, direction, initial),
   // State layer
   state-layer-width: utils.module-ref(checkbox, state-layer-width, state-layer-size),

--- a/src/lib/core/styles/tokens/radio/_tokens.scss
+++ b/src/lib/core/styles/tokens/radio/_tokens.scss
@@ -28,6 +28,7 @@ $tokens: (
   // Label
   gap: utils.module-val(radio, gap, 0),
   justify: utils.module-val(radio, justify, start),
+  align: utils.module-val(radio, align, center),
   direction: utils.module-val(radio, direction, initial),
   // State layer
   state-layer-width: utils.module-ref(radio, state-layer-width, state-layer-size),

--- a/src/lib/core/styles/tokens/switch/_tokens.scss
+++ b/src/lib/core/styles/tokens/switch/_tokens.scss
@@ -47,6 +47,7 @@ $tokens: (
   // Label
   gap: utils.module-val(switch, gap, 0),
   justify: utils.module-val(switch, justify, start),
+  align: utils.module-val(switch, align, center),
   direction: utils.module-val(switch, direction, initial),
   // State layer
   state-layer-width: utils.module-ref(switch, state-layer-width, state-layer-size),

--- a/src/lib/radio/radio/_core.scss
+++ b/src/lib/radio/radio/_core.scss
@@ -11,8 +11,7 @@
 @mixin radio {
   position: relative;
   flex-direction: #{token(direction)};
-  flex-shrink: 0;
-  align-items: center;
+  align-items: #{token(align)};
   justify-content: #{token(justify)};
   gap: #{token(gap)};
 
@@ -29,6 +28,7 @@
   justify-content: center;
 
   display: flex;
+  flex-shrink: 0;
 
   border-radius: #{token(shape)};
   inline-size: #{token(state-layer-width)};

--- a/src/lib/radio/radio/radio.ts
+++ b/src/lib/radio/radio/radio.ts
@@ -54,6 +54,7 @@ declare global {
  * @cssproperty --forge-radio-mark-color - The color of the radio button's mark.
  * @cssproperty --forge-radio-gap - The gap between the radio button and its label.
  * @cssproperty --forge-radio-justify - The alignment of the radio button and its label in the inline direction.
+ * @cssproperty --forge-radio-align - The alignment of the radio button and its label in the block direction.
  * @cssproperty --forge-radio-direction - The direction of the radio button and its label.
  * @cssproperty --forge-radio-state-layer-size - The size of the radio button's state layer in the inline and block directions.
  * @cssproperty --forge-radio-state-layer-width - The width of the radio button's state layer.

--- a/src/lib/switch/_core.scss
+++ b/src/lib/switch/_core.scss
@@ -31,8 +31,7 @@ $_handle-on-translate: calc(#{token(track-width)} - #{$_track-border-radius} * 2
   position: relative;
 
   flex-direction: #{token(direction)};
-  flex-shrink: 0;
-  align-items: center;
+  align-items: #{token(align)};
   justify-content: #{token(justify)};
   gap: #{token(gap)};
 }
@@ -60,6 +59,7 @@ $_handle-on-translate: calc(#{token(track-width)} - #{$_track-border-radius} * 2
   align-items: center;
 
   display: flex;
+  flex-shrink: 0;
 
   block-size: #{$_container-block-size};
 

--- a/src/lib/switch/switch.ts
+++ b/src/lib/switch/switch.ts
@@ -109,6 +109,7 @@ declare global {
  * @cssproperty --forge-switch-icon-active-off-scale - The scale transformation applied to the handle icons when the switch is active (pressed) in its off state.
  * @cssproperty --forge-switch-gap - The space between the switch and label.
  * @cssproperty --forge-switch-justify - How the switch and label are distributed along their main axis.
+ * @cssproperty --forge-switch-align - How the switch and label are distributed along their cross axis.
  * @cssproperty --forge-switch-direction - Whether the switch and label are arranged along the inline or block axis.
  * @cssproperty --forge-switch-state-layer-size - The inline and block size of the handle's state layer.
  * @cssproperty --forge-switch-state-layer-width - The inline size of the handle's state layer.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Exposed `align` token similar to how we expose `justify` already to allow for devs to control the checkbox position when long/wrapping labels are used.

Additionally, fixed a layout bug where `flex-shrink` was use on the root flex container when instead it should be applied to the checkbox container element (flex item) instead to avoid reducing the checkbox size in small containers with wrapping label text.
