### PR TITLE
fix(split-view): skip attempting to refit closed panels

### DIFF
--- a/src/lib/split-view/split-view/split-view-adapter.ts
+++ b/src/lib/split-view/split-view/split-view-adapter.ts
@@ -78,6 +78,7 @@ export class SplitViewAdapter extends BaseAdapter<ISplitViewComponent> implement
     panels
       .slice()
       .reverse()
+      .filter(panel => panel.open)
       .forEach(panel => {
         if (diff <= 0) {
           return;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N/A
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N/A

## Describe the new behavior?
Fixed a bug where closed panels may have their size set to `0px` when the parent split view attempts to refit its panels.
