### PR TITLE
fix(button-area): force root element to match size of host

### DIFF
--- a/src/lib/button-area/_core.scss
+++ b/src/lib/button-area/_core.scss
@@ -10,11 +10,14 @@
 @mixin base {
   position: relative;
   overflow: hidden;
+  block-size: 100%;
+  inline-size: 100%;
 }
 
 @mixin enabled {
   cursor: #{token(cursor)};
 }
+
 @mixin disabled {
   cursor: #{token(disabled-cursor)};
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? &

## Describe the new behavior?
Set `block-size` and `inline-size` of the root element to 100% to force it to match the dimensions of the host element.

Fixes #808 
