### PR TITLE
feat(dialog): adjust default a11y semantics and add new `label` and `description` APIs for providing ARIA info

### DIFF
--- a/src/dev/pages/dialog/dialog-template-basic.ejs
+++ b/src/dev/pages/dialog/dialog-template-basic.ejs
@@ -1,11 +1,11 @@
 <forge-scaffold>
   <forge-toolbar slot="header" class="header-toolbar" no-border>
-    <h1 id="dialog-title" slot="start" class="forge-typography--heading4">Dialog title</h1>
+    <h1 slot="start" class="forge-typography--heading4">Dialog title</h1>
     <forge-icon-button slot="end" id="close-button" aria-label="Close">
       <forge-icon name="close"></forge-icon>
     </forge-icon-button>
   </forge-toolbar>
-  <div slot="body" id="dialog-desc" class="dialog-body" tabindex="0">
+  <div slot="body" class="dialog-body" role="region" tabindex="0">
     <p class="forge-typography--body2">
       Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia eaque illum itaque.
       Quas, libero eaque veniam et voluptatem quod natus fugit! Nihil consequatur quo
@@ -25,13 +25,13 @@
   </div>
   <forge-toolbar slot="footer" no-border class="footer-toolbar">
     <div slot="end">
-      <forge-button variant="outlined" id="cancel-button" autofocus>Cancel</forge-button>
+      <forge-button variant="outlined" id="cancel-button">Cancel</forge-button>
       <forge-button variant="raised" id="save-button">Save</forge-button>
     </div>
   </forge-toolbar>
 </forge-scaffold>
 
-<forge-dialog type="alertdialog" persistent id="confirm-save-dialog" aria-labelledby="confirm-title" aria-describedby="confirm-msg">
+<forge-dialog type="alertdialog" persistent id="confirm-save-dialog" label="My alert dialog" description="This is an alert dialog.">
   <div>
     <forge-toolbar no-border>
       <h1 id="confirm-title" slot="start" class="forge-typography--heading4">Save changes?</h1>

--- a/src/dev/pages/dialog/dialog.ejs
+++ b/src/dev/pages/dialog/dialog.ejs
@@ -4,7 +4,7 @@
   <forge-button variant="raised" id="show-css-dialog-button">Show CSS-only dialog</forge-button>
 </div>
 
-<forge-dialog trigger="show-inline-dialog-button" id="inline-dialog" class="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-desc">
+<forge-dialog trigger="show-inline-dialog-button" id="inline-dialog" class="dialog" label="My dialog title" description="My dialog description">
   <%- include('./dialog-template-basic.ejs') %>
 </forge-dialog>
 
@@ -15,12 +15,12 @@
 <dialog class="forge-dialog" id="css-only-dialog">
   <forge-scaffold>
     <forge-toolbar slot="header" class="header-toolbar" no-border>
-      <h1 id="dialog-title" slot="start" class="forge-typography--heading4">Dialog title</h1>
+      <h1 slot="start" class="forge-typography--heading4">Dialog title</h1>
       <forge-icon-button slot="end" id="close-button" aria-label="Close">
         <forge-icon name="close"></forge-icon>
       </forge-icon-button>
     </forge-toolbar>
-    <div slot="body" id="dialog-desc" class="dialog-body" tabindex="0">
+    <div slot="body" class="dialog-body" role="region" tabindex="0">
       <p class="forge-typography--body2">
         Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia eaque illum itaque.
         Quas, libero eaque veniam et voluptatem quod natus fugit! Nihil consequatur quo

--- a/src/lib/dialog/dialog-adapter.ts
+++ b/src/lib/dialog/dialog-adapter.ts
@@ -217,7 +217,7 @@ export class DialogAdapter extends BaseAdapter<IDialogComponent> implements IDia
 
   public setAccessibleLabel(label: string): void {
     if (label?.trim()) {
-      this._accessibleLabelElement = this._createVisuallyHiddenElement('forge-dialog-label', label);
+      this._accessibleLabelElement = this._createVisuallyHiddenElement(DIALOG_CONSTANTS.attributes.ARIA_LABEL_ID, label);
       this._dialogElement.appendChild(this._accessibleLabelElement);
       this._dialogElement.setAttribute('aria-labelledby', this._accessibleLabelElement.id);
     } else {
@@ -228,7 +228,7 @@ export class DialogAdapter extends BaseAdapter<IDialogComponent> implements IDia
 
   public setAccessibleDescription(description: string): void {
     if (description?.trim()) {
-      this._accessibleDescriptionElement = this._createVisuallyHiddenElement('forge-dialog-description', description);
+      this._accessibleDescriptionElement = this._createVisuallyHiddenElement(DIALOG_CONSTANTS.attributes.ARIA_DESCIPTION_ID, description);
       this._dialogElement.appendChild(this._accessibleDescriptionElement);
       this._dialogElement.setAttribute('aria-describedby', this._accessibleDescriptionElement.id);
     } else {

--- a/src/lib/dialog/dialog-constants.ts
+++ b/src/lib/dialog/dialog-constants.ts
@@ -23,7 +23,9 @@ const observedAttributes = {
 };
 
 const attributes = {
-  ...observedAttributes
+  ...observedAttributes,
+  ARIA_LABEL_ID: 'forge-dialog-label',
+  ARIA_DESCIPTION_ID: 'forge-dialog-description'
 };
 
 const classes = {

--- a/src/lib/dialog/dialog-constants.ts
+++ b/src/lib/dialog/dialog-constants.ts
@@ -17,7 +17,9 @@ const observedAttributes = {
   MOVE_TARGET: 'move-target',
   POSITION_STRATEGY: 'position-strategy',
   PLACEMENT: 'placement',
-  SIZE_STRATEGY: 'size-strategy'
+  SIZE_STRATEGY: 'size-strategy',
+  LABEL: 'label',
+  DESCRIPTION: 'description'
 };
 
 const attributes = {

--- a/src/lib/dialog/dialog-core.ts
+++ b/src/lib/dialog/dialog-core.ts
@@ -28,6 +28,8 @@ export interface IDialogCore {
   sizeStrategy: DialogSizeStrategy;
   placement: DialogPlacement;
   moveable: boolean;
+  label: string;
+  description: string;
   hideBackdrop(): void;
   showBackdrop(): void;
   dispatchBeforeCloseEvent(): boolean;
@@ -45,6 +47,8 @@ export class DialogCore implements IDialogCore {
   private _originalFullscreenValue: boolean | undefined;
   private _trigger = '';
   private _moveable = false;
+  private _label = '';
+  private _description = '';
   private _sizeStrategy: DialogSizeStrategy = DIALOG_CONSTANTS.defaults.SIZE_STRATEGY;
   private _placement: DialogPlacement = DIALOG_CONSTANTS.defaults.PLACEMENT;
   private _positionStrategy: DialogPositionStrategy = DIALOG_CONSTANTS.defaults.POSITION_STRATEGY;
@@ -398,6 +402,26 @@ export class DialogCore implements IDialogCore {
       }
 
       this._adapter.toggleHostAttribute(DIALOG_CONSTANTS.attributes.MOVEABLE, this._moveable);
+    }
+  }
+
+  public get label(): string {
+    return this._label;
+  }
+  public set label(value: string) {
+    if (this._label !== value) {
+      this._label = value;
+      this._adapter.setAccessibleLabel(this._label);
+    }
+  }
+
+  public get description(): string {
+    return this._description;
+  }
+  public set description(value: string) {
+    if (this._description !== value) {
+      this._description = value;
+      this._adapter.setAccessibleDescription(this._description);
     }
   }
 

--- a/src/lib/dialog/dialog.scss
+++ b/src/lib/dialog/dialog.scss
@@ -1,4 +1,5 @@
 @use './core' as *;
+@use '../utils/mixins' as utils;
 @use './animations';
 @use '../backdrop';
 @use '../core/styles/theme';
@@ -48,6 +49,10 @@ $can-animate: '[visible]:not([animation-type=none])';
 
   .surface {
     @include surface;
+  }
+
+  .visually-hidden {
+    @include utils.visually-hidden;
   }
 
   //

--- a/src/lib/dialog/dialog.test.ts
+++ b/src/lib/dialog/dialog.test.ts
@@ -1098,8 +1098,8 @@ async function createFixture({
       <button type="button" id="alt-test-trigger">Dialog Trigger</button>
       <forge-dialog
         trigger="test-trigger"
-        aria-labelledby="dialog-title"
-        aria-describedby="dialog-desc"
+        label="My dialog title"
+        description="My dialog description"
         ?open=${open}
         type=${type ?? nothing}
         mode=${mode ?? nothing}

--- a/src/lib/dialog/dialog.test.ts
+++ b/src/lib/dialog/dialog.test.ts
@@ -371,23 +371,47 @@ describe('Dialog', () => {
 
       await harness.showAsync();
 
+      expect(harness.nativeDialogElement.role).to.equal('alertdialog');
       await expect(harness.dialogElement).to.be.accessible();
     });
 
-    it('should not set role when role="presentation" is set', async () => {
-      const el = await fixture(html`<forge-dialog role="presentation"></forge-dialog>`);
+    it('should be accessible when mode is set to nonmodal', async () => {
+      const harness = await createFixture({ mode: 'nonmodal' });
 
-      expect(el.getAttribute('role')).to.equal('presentation');
-      expect(el.hasAttribute('aria-modal')).to.be.false;
-      await expect(el).to.be.accessible();
+      await harness.showAsync();
+
+      expect(harness.nativeDialogElement.getAttribute('aria-modal')).to.equal('false');
+      await expect(harness.dialogElement).to.be.accessible();
     });
 
-    it('should not set role when role="none" is set', async () => {
-      const el = await fixture(html`<forge-dialog role="none"></forge-dialog>`);
+    it('should be accessible when label is set', async () => {
+      const harness = await createFixture();
 
-      expect(el.getAttribute('role')).to.equal('none');
-      expect(el.hasAttribute('aria-modal')).to.be.false;
-      await expect(el).to.be.accessible();
+      await harness.showAsync();
+
+      const labelElement = harness.nativeDialogElement.querySelector(`[id="${DIALOG_CONSTANTS.attributes.ARIA_LABEL_ID}"]`) as HTMLElement;
+
+      expect(labelElement).to.be.ok;
+      expect(labelElement.isConnected).to.be.true;
+      expect(labelElement.textContent).to.equal('My dialog title');
+      expect(labelElement.id).to.equal(DIALOG_CONSTANTS.attributes.ARIA_LABEL_ID);
+      expect(harness.nativeDialogElement.getAttribute('aria-labelledby')).to.equal(DIALOG_CONSTANTS.attributes.ARIA_LABEL_ID);
+      await expect(harness.dialogElement).to.be.accessible();
+    });
+
+    it('should be accessible when description is set', async () => {
+      const harness = await createFixture();
+
+      await harness.showAsync();
+
+      const descriptionElement = harness.nativeDialogElement.querySelector(`[id="${DIALOG_CONSTANTS.attributes.ARIA_DESCIPTION_ID}"]`) as HTMLElement;
+
+      expect(descriptionElement).to.be.ok;
+      expect(descriptionElement.isConnected).to.be.true;
+      expect(descriptionElement.textContent).to.equal('My dialog description');
+      expect(descriptionElement.id).to.equal(DIALOG_CONSTANTS.attributes.ARIA_DESCIPTION_ID);
+      expect(harness.nativeDialogElement.getAttribute('aria-describedby')).to.equal(DIALOG_CONSTANTS.attributes.ARIA_DESCIPTION_ID);
+      await expect(harness.dialogElement).to.be.accessible();
     });
   });
 

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -40,6 +40,8 @@ export interface IDialogProperties {
   sizeStrategy: DialogSizeStrategy;
   placement: DialogPlacement;
   moveable: boolean;
+  label: string;
+  description: string;
 }
 
 export interface IDialogComponent extends IDialogProperties, IWithDefaultAria, IWithElementInternals, IDismissible {
@@ -247,6 +249,12 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
       case DIALOG_CONSTANTS.observedAttributes.PLACEMENT:
         this.placement = (newValue as DialogPlacement) ?? DIALOG_CONSTANTS.defaults.PLACEMENT;
         break;
+      case DIALOG_CONSTANTS.observedAttributes.LABEL:
+        this.label = newValue;
+        break;
+      case DIALOG_CONSTANTS.observedAttributes.DESCRIPTION:
+        this.description = newValue;
+        break;
     }
   }
 
@@ -360,6 +368,22 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    */
   @coreProperty()
   public declare placement: DialogPlacement;
+
+  /**
+   * The accessible label of the dialog.
+   * @default ''
+   * @attribute
+   */
+  @coreProperty()
+  public declare label: string;
+
+  /**
+   * The accessible description of the dialog.
+   * @default ''
+   * @attribute
+   */
+  @coreProperty()
+  public declare description: string;
 
   /** Shows the dialog. */
   public show(): void {

--- a/src/stories/components/dialog/Dialog.mdx
+++ b/src/stories/components/dialog/Dialog.mdx
@@ -20,18 +20,18 @@ When creating a dialog it is important to consider the following:
 
 - **Content**: The content of the dialog should be clear and concise. Use semantic elements to structure the content.
 - **Actions**: Provide clear actions for the user to take. Use buttons to provide actions such as "Cancel" or "Save".
-- **Accessibility**: Ensure that the dialog is accessible to all users. Use the `aria-labelledby` and `aria-describedby` attributes to provide context to screen readers.
+- **Accessibility**: Ensure that the dialog is accessible to all users. Use the `label` and `description` attributes to provide context to screen readers.
 
 The `<forge-dialog>` will size itself based on the content that it contains. You should always use a single root element within the dialog to ensure proper sizing. It is
 common to compose the `<forge-dialog>` together with the `<forge-scaffold>` to provide a consistent layout.
 
 ```html
-<forge-dialog aria-labelledby="dialog-title" aria-describedby="dialog-description">
+<forge-dialog label="My dialog title" description="My dialog description">
   <forge-scaffold>
     <forge-toolbar slot="header">
-      <h2 slot="start id="dialog-title">Dialog Title</h2>
+      <h2 slot="start">Dialog Title</h2>
     </forge-toolbar>
-    <p id="dialog-description">Dialog Description</p>
+    <p>Dialog Description</p>
     <forge-toolbar slot="footer">
       <forge-button slot="end">Close</forge-button>
     </forge-toolbar>
@@ -102,9 +102,9 @@ While dialogs are typically created dynamically and appended to the document, yo
 ```html
 <button id="open-dialog">Open dialog</button>
 
-<forge-dialog trigger="open-dialog" aria-labelledby="dialog-title" aria-describedby="dialog-description">
-  <h2 id="dialog-title">Dialog Title</h2>
-  <p id="dialog-description">Dialog Description</p>
+<forge-dialog trigger="open-dialog" label="My dialog title" description="My dialog description">
+  <h2>Dialog Title</h2>
+  <p>Dialog Description</p>
 </forge-dialog>
 ```
 
@@ -129,10 +129,8 @@ export class MyComponent {
     // Configuration to pass to the `<forge-dialog>` element
     const options: IDialogOptions = {
       preset: 'right-sheet',
-      attributes: new Map([
-        ['aria-labelledby', 'dialog-title'],
-        ['aria-describedby', 'dialog-description']
-      ])
+      label: 'My dialog title',
+      description: 'My dialog description',
     };
 
     // Data to inject into your Angular component via the `@Inject(DIALOG_DATA)` provider
@@ -169,8 +167,8 @@ export interface IConfirmDialogData {
   '],
   template: `
     <div class="container">
-      <h2 id="dialog-title">{{ data.title }}</h2>
-      <p id="dialog-description">{{ data.description }}</p>
+      <h2>{{ data.title }}</h2>
+      <p>{{ data.description }}</p>
       <button (click)="onClose()">Close</button>
     </div>
   `
@@ -198,8 +196,9 @@ export class MyDialogComponent {
   - When the dialog is closed, return focus to a logical element on the page.
 - Ensure that if there is a way to close the dialog via a mouse click, that there is also a way to close the dialog via keyboard.
 - The dialog component will add the `role="dialog"` and `aria-modal="true"` attribute for you.
-- Be sure to set the `aria-labelledby` and `aria-describedby` attributes on the `<forge-dialog>` element.
+- Be sure to set the `label` and `description` attributes on the `<forge-dialog>` element.
   - This will allow for a screen reader to properly announce the dialog title and description when it opens.
+  - The `aria-labelledby` and `aria-describedby` attributes will be set automatically for you based on the `label` and `description` attributes.
 
 ## CSS-Only
 

--- a/src/stories/components/dialog/Dialog.mdx
+++ b/src/stories/components/dialog/Dialog.mdx
@@ -21,6 +21,9 @@ When creating a dialog it is important to consider the following:
 - **Content**: The content of the dialog should be clear and concise. Use semantic elements to structure the content.
 - **Actions**: Provide clear actions for the user to take. Use buttons to provide actions such as "Cancel" or "Save".
 - **Accessibility**: Ensure that the dialog is accessible to all users. Use the `label` and `description` attributes to provide context to screen readers.
+  - You can not use the standard `aria-labelledby` and `aria-describedby` attributes on the `<forge-dialog>` element as they cannot be set on the internal native `<dialog>` element
+    due to browser limitations. Instead, use the `label` and `description` attributes to provide the same functionality and we'll add the necessary ARIA attributes for you.
+  - When the browsers support ARIA attributes across shadow boundaries in the future, we will update the component to use the standard attributes and make an announcement.
 
 The `<forge-dialog>` will size itself based on the content that it contains. You should always use a single root element within the dialog to ensure proper sizing. It is
 common to compose the `<forge-dialog>` together with the `<forge-scaffold>` to provide a consistent layout.

--- a/src/stories/components/dialog/Dialog.stories.ts
+++ b/src/stories/components/dialog/Dialog.stories.ts
@@ -53,6 +53,8 @@ const meta = {
     moveable: false,
     mode: DIALOG_CONSTANTS.defaults.MODE,
     type: DIALOG_CONSTANTS.defaults.TYPE,
+    label: 'My dialog title',
+    description: 'My dialog description',
     animationType: DIALOG_CONSTANTS.defaults.ANIMATION_TYPE,
     preset: DIALOG_CONSTANTS.defaults.PRESET,
     sizeStrategy: DIALOG_CONSTANTS.defaults.SIZE_STRATEGY,

--- a/src/stories/components/dialog/Dialog.ts
+++ b/src/stories/components/dialog/Dialog.ts
@@ -34,8 +34,8 @@ export const Dialog = (args: ArgTypes) => {
   container.appendChild(button);
 
   const dialog = customElementStoryRenderer('forge-dialog', args);
-  dialog.setAttribute('aria-labelledby', 'dialog-title');
-  dialog.setAttribute('aria-describedby', 'dialog-message');
+  dialog.label = 'My dialog title';
+  dialog.description = 'My dialog description';
   dialog.addEventListener('forge-dialog-close', evt => {
     closeEventAction(evt);
     dialog.open = false;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? Partially, but is required to allow for proper accessibility (won't break code).
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The current state of the `<forge-dialog>` is not accessible in that it doesn't announce the dialog label and description unless an element is focused within the native `<dialog>`. Also, this presents a situation where we semantically had two `dialog` roles in the DOM at the same time, but the native `<dialog>` was making the `<forge-dialog role="dialog">` inert (removing it from the accessibility tree). This was also causing auditing tools such as ARC Toolkit to report a false positive in scanning which we want. to avoid.

This change instead removes all ARIA attributes from the `<forge-dialog>` element, and fully relies on the internal native `<dialog>` element for accessibility. Additionally, the native `<dialog>` will now receive focus automatically when opened unless another child element is supposed to get focus via the `autofocus` attribute.

However, this presents an issue with `aria-labelledby` and `aria-describedby`. Developers can no longer pass these attributes to the `<forge-dialog>` because the IDREFs cannot be linked across the shadow root boundary... We're waiting for the browsers vendors to implement the reference target proposal for cross-root ARIA support, but until then we need to rely on custom APIs to set these ARIA values internally (not idea, but it's the best interim state we can provide for now). Developers should now use the new `label` and `description` to set the internal `aria-labelledby` and `aria-describedby` respectively on the internal `<dialog>` element now.

## Additional information
Documentation has been updated to reflect this new expectation, and we'll be able to safely deprecated these APIs in the future when cross-root ARIA support is avaialable. 
