### PR TITLE
fix(toolbar): move internal `tablist` role to host element

### DIFF
--- a/src/lib/tabs/tab-bar/tab-bar-adapter.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-adapter.ts
@@ -6,11 +6,8 @@ import { ITabComponent } from '../tab/tab';
 import { TAB_CONSTANTS } from '../tab/tab-constants';
 import { ITabBarComponent } from './tab-bar';
 import { TAB_BAR_CONSTANTS } from './tab-bar-constants';
-import { forwardAttributes } from '../../core/utils/reflect-utils';
 
 export interface ITabBarAdapter extends IBaseAdapter {
-  initialize(): void;
-  destroy(): void;
   initializeContainerSizeObserver(listener: () => void): void;
   destroyContainerSizeObserver(): void;
   initializeScrollObserver(listener: EventListener): void;
@@ -46,7 +43,6 @@ export class TabBarAdapter extends BaseAdapter<ITabBarComponent> implements ITab
   private _resizeObserver: ResizeObserver | undefined;
   private _backwardScrollButton: IIconButtonComponent | undefined;
   private _forwardScrollButton: IIconButtonComponent | undefined;
-  private _forwardObserver?: MutationObserver;
 
   constructor(component: ITabBarComponent) {
     super(component);
@@ -54,17 +50,6 @@ export class TabBarAdapter extends BaseAdapter<ITabBarComponent> implements ITab
     this._defaultSlotElement = getShadowElement(this._component, TAB_BAR_CONSTANTS.selectors.DEFAULT_SLOT) as HTMLSlotElement;
     this._rootElement = getShadowElement(this._component, TAB_BAR_CONSTANTS.selectors.ROOT);
     this._scrollContainer = getShadowElement(this._component, TAB_BAR_CONSTANTS.selectors.SCROLL_CONTAINER);
-  }
-
-  public initialize(): void {
-    this._forwardObserver = forwardAttributes(this._component, Object.keys(TAB_BAR_CONSTANTS.forwardedAttributes), (name, value) => {
-      toggleAttribute(this._scrollContainer, !!value, TAB_BAR_CONSTANTS.forwardedAttributes[name], value ?? undefined);
-    });
-  }
-
-  public destroy(): void {
-    this._forwardObserver?.disconnect();
-    this._forwardObserver = undefined;
   }
 
   public initializeContainerSizeObserver(listener: () => void): void {
@@ -86,7 +71,7 @@ export class TabBarAdapter extends BaseAdapter<ITabBarComponent> implements ITab
   }
 
   public setVertical(value: boolean): void {
-    toggleAttribute(this._scrollContainer, !!value, 'aria-orientation', 'vertical');
+    toggleAttribute(this._component, !!value, 'aria-orientation', 'vertical');
   }
 
   public setScrollBackwardButtonListener(listener: EventListener): void {

--- a/src/lib/tabs/tab-bar/tab-bar-constants.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-constants.ts
@@ -18,10 +18,6 @@ const attributes = {
   ...observedAttributes
 };
 
-const forwardedAttributes = {
-  'data-aria-label': 'aria-label'
-};
-
 const selectors = {
   ROOT: '.forge-tab-bar',
   SCROLL_CONTAINER: '.scroll-container',
@@ -44,7 +40,6 @@ export const TAB_BAR_CONSTANTS = {
   elementName,
   observedAttributes,
   attributes,
-  forwardedAttributes,
   events,
   selectors,
   classes,

--- a/src/lib/tabs/tab-bar/tab-bar-core.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-core.ts
@@ -54,7 +54,6 @@ export class TabBarCore implements ITabBarCore {
   }
 
   public initialize(): void {
-    this._adapter.initialize();
     this._adapter.addSlotListener(this._tabsChangedListener);
     this._adapter.addHostListener(TAB_CONSTANTS.events.SELECT, this._tabSelectedListener);
     this._adapter.addHostListener('keydown', this._keydownListener);
@@ -71,7 +70,6 @@ export class TabBarCore implements ITabBarCore {
   }
 
   public destroy(): void {
-    this._adapter.destroy();
     this._adapter.destroyContainerSizeObserver();
     this._adapter.destroyScrollObserver(this._scrollListener);
     this._isInitialized = false;

--- a/src/lib/tabs/tab-bar/tab-bar.html
+++ b/src/lib/tabs/tab-bar/tab-bar.html
@@ -1,6 +1,6 @@
 <template>
   <div class="forge-tab-bar" part="container">
-    <div role="tablist" class="scroll-container" part="scroll-container">
+    <div class="scroll-container" part="scroll-container">
       <slot></slot>
     </div>
   </div>

--- a/src/lib/tabs/tab-bar/tab-bar.ts
+++ b/src/lib/tabs/tab-bar/tab-bar.ts
@@ -69,7 +69,6 @@ declare global {
  * @attribute {boolean} [secondary=false] - Deprecated. Controls whether the tabs are styled as secondary tab navigation.
  * @attribute {boolean} [auto-activate=false] - Controls whether the tabs are automatically activated when receiving focus.
  * @attribute {boolean} [scroll-buttons=false] - Controls whether scroll buttons are displayed when the tabs overflow their container.
- * @attribute {string} [data-aria-label] - The ARIA label to forward to the internal tablist element.
  *
  * @event {CustomEvent<ITabBarChangeEventData>} forge-tab-bar-change - Dispatches when the active tab changes.
  *

--- a/src/lib/tabs/tab-bar/tab-bar.ts
+++ b/src/lib/tabs/tab-bar/tab-bar.ts
@@ -7,11 +7,14 @@ import { TabBarAdapter } from './tab-bar-adapter';
 import { ITabBarChangeEventData, TAB_BAR_CONSTANTS } from './tab-bar-constants';
 import { TabBarCore } from './tab-bar-core';
 import { tylIconKeyboardArrowLeft, tylIconKeyboardArrowRight, tylIconKeyboardArrowUp, tylIconKeyboardArrowDown } from '@tylertech/tyler-icons/standard';
+import { IWithElementInternals, WithElementInternals } from '../../core/mixins/internals/with-element-internals';
+import { IWithDefaultAria, WithDefaultAria } from '../../core/mixins/internals/with-default-aria';
+import { setDefaultAria } from '../../constants';
 
 import template from './tab-bar.html';
 import styles from './tab-bar.scss';
 
-export interface ITabBarComponent extends IBaseComponent {
+export interface ITabBarComponent extends IBaseComponent, IWithDefaultAria, IWithElementInternals {
   disabled: boolean;
   activeTab: number | null | undefined;
   vertical: boolean;
@@ -82,7 +85,7 @@ declare global {
   name: TAB_BAR_CONSTANTS.elementName,
   dependencies: [TabComponent, IconButtonComponent, IconComponent]
 })
-export class TabBarComponent extends BaseComponent implements ITabBarComponent {
+export class TabBarComponent extends WithDefaultAria(WithElementInternals(BaseComponent)) implements ITabBarComponent {
   public static get observedAttributes(): string[] {
     return Object.values(TAB_BAR_CONSTANTS.observedAttributes);
   }
@@ -97,6 +100,7 @@ export class TabBarComponent extends BaseComponent implements ITabBarComponent {
   }
 
   public connectedCallback(): void {
+    this[setDefaultAria]({ role: 'tablist' }, { setAttribute: true });
     this._core.initialize();
   }
 

--- a/src/lib/tabs/tabs.test.ts
+++ b/src/lib/tabs/tabs.test.ts
@@ -24,19 +24,6 @@ describe('Tabs', () => {
     await expect(el).to.be.accessible();
   });
 
-  it('should forward aria-label to internal tablist element', async () => {
-    const el = await createFixture();
-    const scrollContainerEl = getShadowElement(el, TAB_BAR_CONSTANTS.selectors.SCROLL_CONTAINER);
-
-    expect(scrollContainerEl.hasAttribute('aria-label')).to.be.false;
-
-    el.setAttribute('data-aria-label', 'Test');
-    await elementUpdated(el);
-
-    expect(scrollContainerEl.getAttribute('aria-label')).to.equal('Test');
-    await expect(el).to.be.accessible();
-  });
-
   it('should set default active tab', async () => {
     const el = await createFixture({ activeTab: 1 });
     const ctx = new TabsHarness(el);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? Partially, the `data-aria-label` attribute no longer has any effect but won't break code.
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
This change moves the `tablist` role from the internal container element to the host element to ensure that developers can supply their own necessary ARIA attributes directly, while also allowing audit and scanning tools to properly test for the tablist and tab composition.

The custom `data-aria-label` attribute that was previously available on the component as an attribute only has been removed and developers can now just use `aria-label` and `aria-labelledby` directly, which is more intuitive. This change should not have any adverse effects aside from developers needing to switch to `aria-label` if their tablists had a label.
