### PR TITLE
fix(tab-bar): setting `activeTab` property will no longer focus the tab

### DIFF
--- a/src/lib/button/base/base-button-adapter.ts
+++ b/src/lib/button/base/base-button-adapter.ts
@@ -86,7 +86,7 @@ export abstract class BaseButtonAdapter<T extends IBaseButton> extends BaseAdapt
     } else {
       if (value) {
         this._component.removeAttribute('tabindex');
-      } else {
+      } else if (!this._component.hasAttribute('tabindex')) {
         this._component.setAttribute('tabindex', '0');
       }
       this._component[setDefaultAria]({ ariaDisabled: value ? 'true' : null });

--- a/src/lib/tabs/tab-bar/tab-bar-adapter.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-adapter.ts
@@ -153,6 +153,7 @@ export class TabBarAdapter extends BaseAdapter<ITabBarComponent> implements ITab
         this._forwardScrollButton?.focus();
       }
       this._backwardScrollButton.disabled = disabled;
+      this._backwardScrollButton.tabIndex = -1;
     }
 
     if (this._forwardScrollButton) {
@@ -161,6 +162,7 @@ export class TabBarAdapter extends BaseAdapter<ITabBarComponent> implements ITab
         this._backwardScrollButton?.focus();
       }
       this._forwardScrollButton.disabled = disabled;
+      this._forwardScrollButton.tabIndex = -1;
     }
   }
 

--- a/src/lib/tabs/tab-bar/tab-bar-core.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-core.ts
@@ -82,7 +82,7 @@ export class TabBarCore implements ITabBarCore {
   }
 
   private _onTabSelected(evt: CustomEvent<void>): void {
-    this._selectTab(evt.target as ITabComponent);
+    this._selectTab({ tab: evt.target as ITabComponent, focusTab: true });
   }
 
   private async _onKeydown(evt: KeyboardEvent): Promise<void> {
@@ -124,14 +124,14 @@ export class TabBarCore implements ITabBarCore {
     }
 
     if (this._autoActivate) {
-      this._selectTab(this._tabs[index]);
+      this._selectTab({ tab: this._tabs[index], focusTab: true });
     } else {
       this._tabs[index].focus({ preventScroll: true, focusVisible: true });
       await this._adapter.tryScrollTabIntoView(this._tabs[index]);
     }
   }
 
-  private async _selectTab(tab: ITabComponent, emitEvent = true): Promise<void> {
+  private async _selectTab({ tab, emitEvent = true, focusTab = false }: { tab: ITabComponent; emitEvent?: boolean; focusTab?: boolean }): Promise<void> {
     if (!tab || tab.disabled) {
       return;
     }
@@ -157,7 +157,9 @@ export class TabBarCore implements ITabBarCore {
 
     // Selecting a tab causes an animation of the indicator to start relative to the currently selected tab
     tab.selected = true;
-    tab.focus({ preventScroll: true });
+    if (focusTab) {
+      tab.focus({ preventScroll: true });
+    }
     await this._adapter.tryScrollTabIntoView(tab);
 
     // Always deselect the currently selected tab after selecting a new tab to allow
@@ -275,7 +277,7 @@ export class TabBarCore implements ITabBarCore {
 
       if (typeof this._activeTab === 'number') {
         const newSelectedTab = this._tabs[this._activeTab];
-        this._selectTab(newSelectedTab, false);
+        this._selectTab({ tab: newSelectedTab, emitEvent: false, focusTab: false });
         this._adapter.setHostAttribute(TAB_BAR_CONSTANTS.attributes.ACTIVE_TAB, String(this._activeTab));
       } else {
         this._tabs.forEach(tab => (tab.selected = false));

--- a/src/lib/tabs/tabs.test.ts
+++ b/src/lib/tabs/tabs.test.ts
@@ -45,6 +45,27 @@ describe('Tabs', () => {
     expect(ctx.selectedTabCount).to.be.equal(1);
   });
 
+  it('should not set focus on tab when active tab is set', async () => {
+    const el = await createFixture({ activeTab: 0 });
+    const ctx = new TabsHarness(el);
+
+    expect(ctx.tabs[0].matches(':focus')).to.be.false;
+
+    el.activeTab = 1;
+
+    expect(ctx.tabs[1].matches(':focus')).to.be.false;
+  });
+
+  it('should set focus on tab when user clicks on tab', async () => {
+    const el = await createFixture();
+    const ctx = new TabsHarness(el);
+
+    ctx.clickTab(0);
+    await elementUpdated(el);
+
+    expect(ctx.tabs[0].matches(':focus')).to.be.true;
+  });
+
   it('should deselect tab when active tab set to undefined', async () => {
     const el = await createFixture({ activeTab: 0 });
     const ctx = new TabsHarness(el);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The tab bar was setting focus to tabs when the `activeTab` property was being set, which is incorrect. We should only be setting focus if the tab was activated in response to a user interacting with the tab via mouse or keyboard.

Developers can now choose to set focus manually if they need to when switching the active tab.
