### PR TITLE
feat(switch): add new `checked` property/attribute and deprecate `on` property

### DIFF
--- a/src/dev/pages/switch/switch.ejs
+++ b/src/dev/pages/switch/switch.ejs
@@ -36,7 +36,7 @@
   </div>
 
   <div>
-    <h3 class="forge-typography--heading2">Disabled (on)</h3>
+    <h3 class="forge-typography--heading2">Disabled (checked)</h3>
     <forge-switch disabled selected>off/on</forge-switch>
   </div>
 

--- a/src/dev/src/partials/controls/switch.ejs
+++ b/src/dev/src/partials/controls/switch.ejs
@@ -1,3 +1,3 @@
-<forge-switch label-position="start" id="<%= control.id %>" <%= control.defaultValue ? 'selected' : null %> <%= control.disabled ? 'disabled' : null %>>
+<forge-switch label-position="start" id="<%= control.id %>" <%= control.defaultValue ? 'checked' : null %> <%= control.disabled ? 'disabled' : null %>>
   <span><%= control.label %></span>
 </forge-switch>

--- a/src/lib/switch/switch-adapter.ts
+++ b/src/lib/switch/switch-adapter.ts
@@ -1,12 +1,12 @@
 import { getShadowElement, toggleClass } from '@tylertech/forge-core';
-import { internals, isFocusable, setDefaultAria, setValidity } from '../constants';
+import { isFocusable, setDefaultAria, setValidity } from '../constants';
 import { BaseAdapter, IBaseAdapter } from '../core';
 import { StateLayerComponent } from '../state-layer';
 import { ISwitchComponent } from './switch';
 import { SwitchIconVisibility, SwitchLabelPosition, SWITCH_CONSTANTS } from './switch-constants';
 
 export interface ISwitchAdapter extends IBaseAdapter {
-  setOn(value: boolean): void;
+  setChecked(value: boolean): void;
   setDisabled(value: boolean): void;
   setRequired(value: boolean): void;
   setReadonly(value: boolean): void;
@@ -18,8 +18,8 @@ export interface ISwitchAdapter extends IBaseAdapter {
 export class SwitchAdapter extends BaseAdapter<ISwitchComponent> implements ISwitchAdapter {
   private readonly _rootElement: HTMLElement;
   private readonly _labelElement: HTMLElement;
-  private readonly _iconOnElement: HTMLElement;
-  private readonly _iconOffElement: HTMLElement;
+  private readonly _iconCheckedElement: HTMLElement;
+  private readonly _iconUncheckedElement: HTMLElement;
   private readonly _stateLayerElement: StateLayerComponent;
 
   constructor(component: ISwitchComponent) {
@@ -27,12 +27,12 @@ export class SwitchAdapter extends BaseAdapter<ISwitchComponent> implements ISwi
 
     this._rootElement = getShadowElement(component, SWITCH_CONSTANTS.selectors.ROOT);
     this._labelElement = getShadowElement(component, SWITCH_CONSTANTS.selectors.LABEL);
-    this._iconOnElement = getShadowElement(component, SWITCH_CONSTANTS.selectors.ICON_ON);
-    this._iconOffElement = getShadowElement(component, SWITCH_CONSTANTS.selectors.ICON_OFF);
+    this._iconCheckedElement = getShadowElement(component, SWITCH_CONSTANTS.selectors.ICON_ON);
+    this._iconUncheckedElement = getShadowElement(component, SWITCH_CONSTANTS.selectors.ICON_OFF);
     this._stateLayerElement = getShadowElement(component, SWITCH_CONSTANTS.selectors.STATE_LAYER) as StateLayerComponent;
   }
 
-  public setOn(value: boolean): void {
+  public setChecked(value: boolean): void {
     this._component[setValidity]();
     this._component[setDefaultAria]({ ariaChecked: value ? 'true' : 'false' });
   }
@@ -56,8 +56,8 @@ export class SwitchAdapter extends BaseAdapter<ISwitchComponent> implements ISwi
   public setIconVisibility(value: SwitchIconVisibility): void {
     const hideOn = value === 'none' || value === 'off';
     const hideOff = value === 'none' || value === 'on';
-    toggleClass(this._iconOnElement, hideOn, SWITCH_CONSTANTS.classes.HIDDEN);
-    toggleClass(this._iconOffElement, hideOff, SWITCH_CONSTANTS.classes.HIDDEN);
+    toggleClass(this._iconCheckedElement, hideOn, SWITCH_CONSTANTS.classes.HIDDEN);
+    toggleClass(this._iconUncheckedElement, hideOff, SWITCH_CONSTANTS.classes.HIDDEN);
   }
 
   public setLabelPosition(value: SwitchLabelPosition): void {

--- a/src/lib/switch/switch-component-delegate.ts
+++ b/src/lib/switch/switch-component-delegate.ts
@@ -22,6 +22,14 @@ export class SwitchComponentDelegate extends FormFieldComponentDelegate<ISwitchC
     this._element.value = value;
   }
 
+  public get checked(): boolean {
+    return this._element.checked;
+  }
+  public set checked(value: boolean) {
+    this._element.checked = value;
+  }
+
+  /** @deprecated Use `checked` instead */
   public get on(): boolean {
     return this._element.on;
   }
@@ -29,6 +37,7 @@ export class SwitchComponentDelegate extends FormFieldComponentDelegate<ISwitchC
     this._element.on = value;
   }
 
+  /** @deprecated Use `checked` instead */
   public get selected(): boolean {
     return this._element.selected;
   }
@@ -36,6 +45,14 @@ export class SwitchComponentDelegate extends FormFieldComponentDelegate<ISwitchC
     this._element.selected = value;
   }
 
+  public get defaultChecked(): boolean {
+    return this._element.defaultChecked;
+  }
+  public set defaultChecked(value: boolean) {
+    this._element.defaultChecked = value;
+  }
+
+  /** @deprecated Use `defaultChecked` instead */
   public get defaultOn(): boolean {
     return this._element.defaultOn;
   }

--- a/src/lib/switch/switch-constants.ts
+++ b/src/lib/switch/switch-constants.ts
@@ -3,8 +3,13 @@ import { COMPONENT_NAME_PREFIX } from '../constants';
 const elementName: keyof HTMLElementTagNameMap = `${COMPONENT_NAME_PREFIX}switch`;
 
 const observedAttributes = {
+  CHECKED: 'checked',
+  /** @deprecated use `CHECKED` instead. */
   ON: 'on',
+  /** @deprecated use `CHECKED` instead. */
   SELECTED: 'selected',
+  DEFAULT_CHECKED: 'default-checked',
+  /** @deprecated use `DEFAULT_CHECKED` instead. */
   DEFAULT_ON: 'default-on',
   VALUE: 'value',
   DENSE: 'dense',

--- a/src/lib/switch/switch-core.ts
+++ b/src/lib/switch/switch-core.ts
@@ -2,8 +2,8 @@ import { ISwitchAdapter } from './switch-adapter';
 import { SWITCH_CONSTANTS, SwitchIconVisibility, SwitchLabelPosition } from './switch-constants';
 
 export interface ISwitchCore {
-  on: boolean;
-  defaultOn: boolean;
+  checked: boolean;
+  defaultChecked: boolean;
   value: string;
   dense: boolean;
   disabled: boolean;
@@ -15,8 +15,8 @@ export interface ISwitchCore {
 
 export class SwitchCore implements ISwitchCore {
   // State
-  private _on = false;
-  private _defaultOn = false;
+  private _checked = false;
+  private _defaultChecked = false;
   private _value = 'on';
   private _dense = false;
   private _disabled = false;
@@ -26,7 +26,7 @@ export class SwitchCore implements ISwitchCore {
   private _labelPosition: SwitchLabelPosition = 'end';
 
   private get _submittedValue(): string | null {
-    return this._on ? this._value : null;
+    return this._checked ? this._value : null;
   }
 
   // Listeners
@@ -61,10 +61,10 @@ export class SwitchCore implements ISwitchCore {
       return;
     }
 
-    const oldValue = this._on;
-    const newValue = !this._on;
+    const oldValue = this._checked;
+    const newValue = !this._checked;
 
-    this._on = newValue;
+    this._checked = newValue;
 
     const event = new Event('change', { cancelable: true, bubbles: true });
     const forgeEvent = new CustomEvent(SWITCH_CONSTANTS.events.CHANGE, {
@@ -74,39 +74,40 @@ export class SwitchCore implements ISwitchCore {
     });
     this._adapter.dispatchHostEvent(event);
     this._adapter.dispatchHostEvent(forgeEvent);
-    this._on = oldValue;
+    this._checked = oldValue;
     if (event.defaultPrevented || forgeEvent.defaultPrevented) {
       return;
     }
 
-    this.on = newValue;
+    this.checked = newValue;
   }
 
-  private _setOnAttribute(): void {
-    this._adapter.toggleHostAttribute(SWITCH_CONSTANTS.attributes.ON, this._on);
-    // Also set selected for backwards compatibility
-    this._adapter.toggleHostAttribute(SWITCH_CONSTANTS.attributes.SELECTED, this._on);
+  private _setCheckedAttribute(): void {
+    this._adapter.toggleHostAttribute(SWITCH_CONSTANTS.attributes.CHECKED, this._checked);
+    // Also set the following for backwards compatibility
+    this._adapter.toggleHostAttribute(SWITCH_CONSTANTS.attributes.ON, this._checked);
+    this._adapter.toggleHostAttribute(SWITCH_CONSTANTS.attributes.SELECTED, this._checked);
   }
 
-  public get on(): boolean {
-    return this._on;
+  public get checked(): boolean {
+    return this._checked;
   }
-  public set on(value: boolean) {
-    if (this._on !== value) {
-      this._on = value;
-      this._adapter.setOn(this._on);
+  public set checked(value: boolean) {
+    if (this._checked !== value) {
+      this._checked = value;
+      this._adapter.setChecked(this._checked);
       this._adapter.syncValue(this._submittedValue);
-      this._setOnAttribute();
+      this._setCheckedAttribute();
     }
   }
 
-  public get defaultOn(): boolean {
-    return this._defaultOn;
+  public get defaultChecked(): boolean {
+    return this._defaultChecked;
   }
-  public set defaultOn(value: boolean) {
-    if (this._defaultOn !== value) {
-      this._defaultOn = value;
-      this._adapter.toggleHostAttribute(SWITCH_CONSTANTS.attributes.DEFAULT_ON, this._defaultOn);
+  public set defaultChecked(value: boolean) {
+    if (this._defaultChecked !== value) {
+      this._defaultChecked = value;
+      this._adapter.toggleHostAttribute(SWITCH_CONSTANTS.attributes.DEFAULT_CHECKED, this._defaultChecked);
     }
   }
 

--- a/src/lib/switch/switch.test.ts
+++ b/src/lib/switch/switch.test.ts
@@ -73,8 +73,10 @@ describe('Switch', () => {
     const ctx = new SwitchHarness(el);
 
     await expect(el).not.to.be.accessible();
+    expect(el.checked).to.be.false;
     expect(el.on).to.be.false;
     expect(el.selected).to.be.false;
+    expect(el.defaultChecked).to.be.false;
     expect(el.defaultOn).to.be.false;
     expect(el.value).to.equal('on');
     expect(el.dense).to.be.false;
@@ -88,39 +90,53 @@ describe('Switch', () => {
     expect(ctx.rootElement.lastElementChild).to.equal(ctx.labelElement);
   });
 
-  it('should accept on', async () => {
-    const el = await fixture<ISwitchComponent>(html`<forge-switch on></forge-switch>`);
+  it('should accept checked', async () => {
+    const el = await fixture<ISwitchComponent>(html`<forge-switch checked></forge-switch>`);
     const ctx = new SwitchHarness(el);
 
+    expect(el.checked).to.be.true;
+    expect(el.on).to.be.true;
+    expect(el.selected).to.be.true;
+  });
+
+  it('should accept on', async () => {
+    const el = await fixture<ISwitchComponent>(html`<forge-switch on></forge-switch>`);
+
+    expect(el.checked).to.be.true;
     expect(el.on).to.be.true;
     expect(el.selected).to.be.true;
   });
 
   it('should accept selected', async () => {
     const el = await fixture<ISwitchComponent>(html`<forge-switch selected></forge-switch>`);
-    const ctx = new SwitchHarness(el);
 
+    expect(el.checked).to.be.true;
     expect(el.on).to.be.true;
     expect(el.selected).to.be.true;
   });
 
+  it('should accept default-checked', async () => {
+    const el = await fixture<ISwitchComponent>(html`<forge-switch default-checked></forge-switch>`);
+
+    expect(el.defaultChecked).to.be.true;
+    expect(el.defaultOn).to.be.true;
+  });
+
   it('should accept default-on', async () => {
     const el = await fixture<ISwitchComponent>(html`<forge-switch default-on></forge-switch>`);
-    const ctx = new SwitchHarness(el);
 
+    expect(el.defaultChecked).to.be.true;
     expect(el.defaultOn).to.be.true;
   });
 
   it('should accept value', async () => {
     const el = await fixture<ISwitchComponent>(html`<forge-switch value="test"></forge-switch>`);
-    const ctx = new SwitchHarness(el);
 
     expect(el.value).to.equal('test');
   });
 
   it('should accept disabled', async () => {
     const el = await fixture<ISwitchComponent>(html`<forge-switch disabled aria-label="Active"></forge-switch>`);
-    const ctx = new SwitchHarness(el);
 
     expect(el.disabled).to.be.true;
     await expect(el).to.be.accessible();
@@ -128,7 +144,6 @@ describe('Switch', () => {
 
   it('should accept required', async () => {
     const el = await fixture<ISwitchComponent>(html`<forge-switch required></forge-switch>`);
-    const ctx = new SwitchHarness(el);
 
     expect(el.required).to.be.true;
   });
@@ -201,26 +216,39 @@ describe('Switch', () => {
 
     el.toggle();
 
+    expect(el.checked).to.be.true;
     expect(el.on).to.be.true;
+    expect(el.selected).to.be.true;
   });
 
   it('should toggle on', async () => {
     const el = await fixture<ISwitchComponent>(html`<forge-switch aria-label="Active"></forge-switch>`);
-    const ctx = new SwitchHarness(el);
+
+    expect(el.checked).to.be.false;
+    expect(el.on).to.be.false;
+    expect(el.selected).to.be.false;
 
     el.toggle(true);
 
+    expect(el.checked).to.be.true;
     expect(el.on).to.be.true;
+    expect(el.selected).to.be.true;
     await expect(el).to.be.accessible();
   });
 
   it('should toggle off', async () => {
-    const el = await fixture<ISwitchComponent>(html`<forge-switch on></forge-switch>`);
-    const ctx = new SwitchHarness(el);
+    const el = await fixture<ISwitchComponent>(html`<forge-switch aria-label="Active" checked></forge-switch>`);
+
+    expect(el.checked).to.be.true;
+    expect(el.on).to.be.true;
+    expect(el.selected).to.be.true;
 
     el.toggle(false);
 
+    expect(el.checked).to.be.false;
     expect(el.on).to.be.false;
+    expect(el.selected).to.be.false;
+    await expect(el).to.be.accessible();
   });
 
   it('should set on when clicked', async () => {
@@ -231,7 +259,9 @@ describe('Switch', () => {
 
     await ctx.clickElement(el);
 
+    expect(el.checked).to.be.true;
     expect(el.on).to.be.true;
+    expect(el.selected).to.be.true;
     expect(changeSpy.calledWith(new CustomEvent('forge-switch-input', { detail: true }))).to.be.true;
   });
 
@@ -257,7 +287,9 @@ describe('Switch', () => {
 
     await ctx.clickElement(el);
 
+    expect(el.checked).to.be.false;
     expect(el.on).to.be.false;
+    expect(el.selected).to.be.false;
   });
 
   it('should return form element and name', async () => {
@@ -305,7 +337,7 @@ describe('Switch', () => {
     let formData = new FormData(form);
     expect(formData.get('test-switch')).to.be.null;
 
-    switchEl.on = true;
+    switchEl.checked = true;
     formData = new FormData(form);
     expect(formData.get('test-switch')).to.equal('on');
   });
@@ -317,14 +349,16 @@ describe('Switch', () => {
     switchEl.setAttribute('name', 'test-switch');
     form.appendChild(switchEl);
 
-    switchEl.on = true;
+    switchEl.checked = true;
     let formData = new FormData(form);
     expect(formData.get('test-switch')).to.equal('on');
 
     form.reset();
     formData = new FormData(form);
 
+    expect(switchEl.checked).to.be.false;
     expect(switchEl.on).to.be.false;
+    expect(switchEl.selected).to.be.false;
     expect(formData.get('test-switch')).to.be.null;
   });
 
@@ -334,7 +368,7 @@ describe('Switch', () => {
     const switchEl = document.createElement('forge-switch');
     const setFormValueSpy = spy(switchEl[internals], 'setFormValue');
     switchEl.name = 'test-switch';
-    switchEl.toggleAttribute('on', true);
+    switchEl.toggleAttribute('checked', true);
     form.appendChild(switchEl);
 
     const [value, state] = setFormValueSpy.args ?? [null, null];
@@ -349,7 +383,9 @@ describe('Switch', () => {
 
     (newSwitchEl as any).formStateRestoreCallback(restoreState, 'restore');
 
+    expect(switchEl.checked).to.be.true;
     expect(switchEl.on).to.be.true;
+    expect(switchEl.selected).to.be.true;
   });
 
   it('should validate', async () => {
@@ -360,7 +396,7 @@ describe('Switch', () => {
     expect(el[internals].checkValidity()).to.be.false;
     expect(el[internals].reportValidity()).to.be.false;
 
-    el.on = true;
+    el.checked = true;
 
     expect(el[internals].willValidate).to.be.true;
     expect(el[internals].validity.valid).to.be.true;

--- a/src/lib/switch/switch.ts
+++ b/src/lib/switch/switch.ts
@@ -17,11 +17,13 @@ import styles from './switch.scss';
 
 export interface ISwitchComponent extends IWithFormAssociation, IWithFocusable, IWithLabelAwareness, IWithElementInternals, IWithDefaultAria {
   value: string;
+  checked: boolean;
+  /** @deprecated use `checked` instead */
   on: boolean;
-  /**
-   * @deprecated use `on` instead
-   */
+  /** @deprecated use `on` instead */
   selected: boolean;
+  defaultChecked: boolean;
+  /** @deprecated use `defaultChecked` instead */
   defaultOn: boolean;
   required: boolean;
   dense: boolean;
@@ -165,7 +167,7 @@ export class SwitchComponent
     super.connectedCallback();
     this[setDefaultAria]({
       role: 'switch',
-      ariaChecked: this.on ? 'true' : 'false',
+      ariaChecked: this.checked ? 'true' : 'false',
       ariaDisabled: this.disabled ? 'true' : 'false',
       ariaRequired: this.required ? 'true' : 'false'
     });
@@ -174,12 +176,14 @@ export class SwitchComponent
 
   public attributeChangedCallback(name: string, oldValue: string, newValue: string): void {
     switch (name) {
+      case SWITCH_CONSTANTS.observedAttributes.CHECKED:
       case SWITCH_CONSTANTS.observedAttributes.ON:
       case SWITCH_CONSTANTS.observedAttributes.SELECTED:
-        this.on = coerceBoolean(newValue);
+        this.checked = coerceBoolean(newValue);
         break;
+      case SWITCH_CONSTANTS.observedAttributes.DEFAULT_CHECKED:
       case SWITCH_CONSTANTS.observedAttributes.DEFAULT_ON:
-        this.defaultOn = coerceBoolean(newValue);
+        this.defaultChecked = coerceBoolean(newValue);
         break;
       case SWITCH_CONSTANTS.observedAttributes.VALUE:
         this.value = newValue;
@@ -207,29 +211,29 @@ export class SwitchComponent
   }
 
   public override [getFormValue](): FormValue | null {
-    return this.on ? this.value : null;
+    return this.checked ? this.value : null;
   }
 
   public override [getFormState](): string {
-    return this.on ? SWITCH_CONSTANTS.state.ON : SWITCH_CONSTANTS.state.OFF;
+    return this.checked ? SWITCH_CONSTANTS.state.ON : SWITCH_CONSTANTS.state.OFF;
   }
 
   public [setValidity](): void {
     this[internals].setValidity(
-      { valueMissing: this.required && !this.on },
+      { valueMissing: this.required && !this.checked },
       this[getValidationMessage]({
-        checked: this.on,
+        checked: this.checked,
         required: this.required
       })
     );
   }
 
   public formResetCallback(): void {
-    this.on = this.defaultOn;
+    this.checked = this.defaultChecked;
   }
 
   public formStateRestoreCallback(state: string): void {
-    this.on = state === SWITCH_CONSTANTS.state.ON;
+    this.checked = state === SWITCH_CONSTANTS.state.ON;
   }
 
   public labelClickedCallback(): void {
@@ -248,42 +252,59 @@ export class SwitchComponent
 
     if (state) {
       const stateValue = isString(state) ? state : state[this.name];
-      this.on = stateValue === SWITCH_CONSTANTS.state.ON;
+      this.checked = stateValue === SWITCH_CONSTANTS.state.ON;
       return;
     }
 
     if (isString(value)) {
-      this.on = !!value;
+      this.checked = !!value;
     } else if (value?.[this.name]) {
-      this.on = !!value[this.name];
+      this.checked = !!value[this.name];
     } else {
-      this.on = false;
+      this.checked = false;
     }
   }
 
   /**
-   * Gets/sets whether the switch is on or off.
+   * Gets/sets whether the switch is checked or not.
    * @default false
    * @attribute
    */
   @coreProperty()
+  public declare checked: boolean;
+
+  /**
+   * Alias for `checked` _(deprecated)_. Gets/sets whether the switch is checked or not.
+   * @deprecated use `checked` instead.
+   * @default false
+   * @attribute
+   */
+  @coreProperty({ name: 'checked' })
   public declare on: boolean;
 
   /**
-   * Alias for `on` _(deprecated)_.
-   * @deprecated use `on` instead
+   * Alias for `checked` _(deprecated)_.
+   * @deprecated use `checked` instead
    * @default false
    * @attribute
    */
-  @coreProperty({ name: 'on' })
+  @coreProperty({ name: 'checked' })
   public declare selected: boolean;
 
   /**
-   * Gets/sets whether the switch is on or off by default.
+   * Gets/sets whether the switch is checked by default.
+   * @default false
+   * @attribute default-checked
+   */
+  @coreProperty()
+  public declare defaultChecked: boolean;
+
+  /**
+   * Alias for `defaultChecked` _(deprecated)_. Gets/sets whether the switch is checked by default.
    * @default false
    * @attribute default-on
    */
-  @coreProperty()
+  @coreProperty({ name: 'defaultChecked' })
   public declare defaultOn: boolean;
 
   /**
@@ -348,9 +369,9 @@ export class SwitchComponent
    */
   public toggle(force?: boolean): void {
     if (isDefined(force)) {
-      this._core.on = force as boolean;
+      this._core.checked = force as boolean;
     } else {
-      this._core.on = !this._core.on;
+      this._core.checked = !this._core.checked;
     }
   }
 }

--- a/src/stories/components/switch/Switch.mdx
+++ b/src/stories/components/switch/Switch.mdx
@@ -25,8 +25,8 @@ Use switches to:
 - Ensure that all of the controls that are accessible by a mouse are also accessible by keyboard.
 - Ensure the controls are reachable by the tab key.
 - Ensure each control can be updated or activated by the keyboard.
-- The input element will receive the proper ARIA attribute aria-checked.
-- The input element will receive the proper role attribute role="switch".
+- The input element will receive the proper ARIA attribute `aria-checked`.
+- The input element will receive the proper role attribute `role="switch"`.
 
 ## CSS-Only
 

--- a/src/stories/components/switch/Switch.stories.ts
+++ b/src/stories/components/switch/Switch.stories.ts
@@ -26,7 +26,7 @@ const meta = {
   argTypes: {
     ...generateCustomElementArgTypes({
       tagName: component,
-      exclude: ['icon', 'form', 'labels', 'name'],
+      exclude: ['icon', 'form', 'labels', 'name', 'on', 'defaultOn', 'selected'],
       controls: {
         labelPosition: {
           control: 'select',
@@ -48,11 +48,11 @@ export const CSSOnly: Story = {
     controls: { include: ['on', 'dense', 'disabled'] }
   },
   args: {
-    on: false,
+    checked: false,
     dense: false,
     disabled: false
   },
-  render: ({ on, dense, disabled }) => {
+  render: ({ checked, dense, disabled }) => {
     const classes = {
       'forge-switch': true,
       'forge-switch--dense': dense
@@ -60,7 +60,7 @@ export const CSSOnly: Story = {
     return html`
       <label class="forge-typography--label2" style="display: flex; align-items: center;">
         <div class=${classMap(classes)}>
-          <input type="checkbox" switch .checked=${on} ?disabled=${disabled} />
+          <input type="checkbox" switch .checked=${checked} ?disabled=${disabled} />
           <div class="forge-switch__thumb">
             <forge-icon name="close" class="forge-switch__icon forge-switch__icon--off"></forge-icon>
             <forge-icon name="check" class="forge-switch__icon forge-switch__icon--on"></forge-icon>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The switch currently supports a legacy `selected` property and a new `on` property that are aliases of each other. When we started Forge v3 we introduce `on` thinking it would give more semantic meaning, but we've learned that frameworks such as Angular do not place nice with this naming, and since then the spec moved forward with a built-in switch based using an `<input>` and this uses `checked`.

We are going to now deprecate the `on` property in favor of `checked` and this PR addresses those changes.
