### PR TITLE
fix(autocomplete): traverse composed slots when locating input element

### DIFF
--- a/src/lib/autocomplete/autocomplete-adapter.ts
+++ b/src/lib/autocomplete/autocomplete-adapter.ts
@@ -1,4 +1,4 @@
-import { getActiveElement, toggleAttribute } from '@tylertech/forge-core';
+import { deepQuerySelectorAll, getActiveElement, toggleAttribute } from '@tylertech/forge-core';
 import { CHIP_FIELD_CONSTANTS, IChipFieldComponent } from '../chip-field';
 import { BaseAdapter, IBaseAdapter } from '../core/base/base-adapter';
 import { setAriaControls, tryCreateAriaControlsPlaceholder } from '../core/utils/utils';
@@ -68,7 +68,7 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
   }
 
   public setInputElement(): HTMLInputElement {
-    const inputElements = this._component.querySelectorAll(AUTOCOMPLETE_CONSTANTS.selectors.INPUT);
+    const inputElements = deepQuerySelectorAll(this._component, AUTOCOMPLETE_CONSTANTS.selectors.INPUT, false);
     if (inputElements.length) {
       this._inputElement = inputElements[0] as HTMLInputElement;
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
A regression was found between v2 and v3 where the autocomplete will no longer traverse composed `<slot>` attributes for the `<input>` element. This change reintroduces our custom utility `deepQuerySelectorAll()` which will handle the composition properly.
