### PR TITLE
fix(dialog): reuse internal accessible elements if `label` or `description` change dynamically

### DIFF
--- a/src/lib/dialog/dialog-constants.ts
+++ b/src/lib/dialog/dialog-constants.ts
@@ -25,7 +25,7 @@ const observedAttributes = {
 const attributes = {
   ...observedAttributes,
   ARIA_LABEL_ID: 'forge-dialog-label',
-  ARIA_DESCIPTION_ID: 'forge-dialog-description'
+  ARIA_DESCRIPTION_ID: 'forge-dialog-description'
 };
 
 const classes = {

--- a/src/lib/dialog/dialog.test.ts
+++ b/src/lib/dialog/dialog.test.ts
@@ -404,14 +404,41 @@ describe('Dialog', () => {
 
       await harness.showAsync();
 
-      const descriptionElement = harness.nativeDialogElement.querySelector(`[id="${DIALOG_CONSTANTS.attributes.ARIA_DESCIPTION_ID}"]`) as HTMLElement;
+      const descriptionElement = harness.nativeDialogElement.querySelector(`[id="${DIALOG_CONSTANTS.attributes.ARIA_DESCRIPTION_ID}"]`) as HTMLElement;
 
       expect(descriptionElement).to.be.ok;
       expect(descriptionElement.isConnected).to.be.true;
       expect(descriptionElement.textContent).to.equal('My dialog description');
-      expect(descriptionElement.id).to.equal(DIALOG_CONSTANTS.attributes.ARIA_DESCIPTION_ID);
-      expect(harness.nativeDialogElement.getAttribute('aria-describedby')).to.equal(DIALOG_CONSTANTS.attributes.ARIA_DESCIPTION_ID);
+      expect(descriptionElement.id).to.equal(DIALOG_CONSTANTS.attributes.ARIA_DESCRIPTION_ID);
+      expect(harness.nativeDialogElement.getAttribute('aria-describedby')).to.equal(DIALOG_CONSTANTS.attributes.ARIA_DESCRIPTION_ID);
       await expect(harness.dialogElement).to.be.accessible();
+    });
+
+    it('should not add multiple visually hidden elements when label or description is updated dynamically', async () => {
+      const harness = await createFixture();
+
+      await harness.showAsync();
+
+      const labelElements = harness.nativeDialogElement.querySelectorAll<HTMLElement>(`[id="${DIALOG_CONSTANTS.attributes.ARIA_LABEL_ID}"]`);
+      const descriptionElements = harness.nativeDialogElement.querySelectorAll<HTMLElement>(`[id="${DIALOG_CONSTANTS.attributes.ARIA_DESCRIPTION_ID}"]`);
+
+      expect(labelElements.length).to.equal(1);
+      expect(descriptionElements.length).to.equal(1);
+      expect(labelElements[0].textContent).to.equal('My dialog title');
+      expect(descriptionElements[0].textContent).to.equal('My dialog description');
+
+      harness.dialogElement.label = 'My new dialog title';
+      harness.dialogElement.description = 'My new dialog description';
+
+      await elementUpdated(harness.dialogElement);
+
+      const newLabelElements = harness.nativeDialogElement.querySelectorAll<HTMLElement>(`[id="${DIALOG_CONSTANTS.attributes.ARIA_LABEL_ID}"]`);
+      const newDescriptionElements = harness.nativeDialogElement.querySelectorAll<HTMLElement>(`[id="${DIALOG_CONSTANTS.attributes.ARIA_DESCRIPTION_ID}"]`);
+
+      expect(newLabelElements.length).to.equal(1);
+      expect(newDescriptionElements.length).to.equal(1);
+      expect(newLabelElements[0].textContent).to.equal('My new dialog title');
+      expect(newDescriptionElements[0].textContent).to.equal('My new dialog description');
     });
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
A bug was found where changing the `label` or `description` property/attribute would cause multiple visually hidden accessibility-related elements to show up in the DOM. This just cleans that up to ensure the elements are reused/removed properly when the values change.
