### PR TITLE
fix(text-field): fixed a bug where the internal value change listener was not safely guarding types

### DIFF
--- a/src/lib/core/utils/utils.ts
+++ b/src/lib/core/utils/utils.ts
@@ -333,3 +333,13 @@ export function task(duration = 0): Promise<void> {
 export function frame(): Promise<void> {
   return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
 }
+
+/**
+ * Determines if an object is an instance of a specific type.
+ * @param obj The object to test.
+ * @param name The name of the type to test against.
+ * @returns `true` if the object is an instance of the type, otherwise `false`.
+ */
+export function isInstanceOf<T>(obj: any, name: string): obj is T {
+  return Object.prototype.toString.call(obj) === `[object ${name}]`;
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The`_onValueChange()` method was overloaded for two different types of listeners that provide arguments with different types (`InputEvent` or `string | null`). This method was not properly typed to allow for this overload, and therefore caused a regression when #778 was introduced.

This PR separates these listeners to be more explicit about what type of change they are handling, as well as introduces a safety check for the `InputEvent` type to be even more explicit about the fix for #778.
