### PR TITLE
fix(dialog): only force-capture focus when modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@types/karma-fixture": "^0.2.8",
         "@types/node": "^20.14.2",
         "@types/webpack-env": "^1.18.5",
+        "@ungap/structured-clone": "^1.3.0",
         "@web/dev-server-esbuild": "1.0.2",
         "@web/dev-server-rollup": "^0.6.4",
         "@web/test-runner": "0.19.0",
@@ -4642,10 +4643,11 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@vitest/expect": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@types/karma-fixture": "^0.2.8",
     "@types/node": "^20.14.2",
     "@types/webpack-env": "^1.18.5",
+    "@ungap/structured-clone": "^1.3.0",
     "@web/dev-server-esbuild": "1.0.2",
     "@web/dev-server-rollup": "^0.6.4",
     "@web/test-runner": "0.19.0",

--- a/src/lib/dialog/dialog-adapter.ts
+++ b/src/lib/dialog/dialog-adapter.ts
@@ -146,7 +146,9 @@ export class DialogAdapter extends BaseAdapter<IDialogComponent> implements IDia
       window.requestAnimationFrame(() => {
         const alreadyHasFocus = this._component.matches(':focus-within');
         if (!alreadyHasFocus) {
-          this._dialogElement.focus();
+          if (this._component.mode === 'modal') {
+            this._dialogElement.focus();
+          }
 
           if (this._component.open && this._dialogElement.isConnected) {
             const autofocusElement = this._component.querySelector<HTMLElement>(DIALOG_CONSTANTS.selectors.AUTOFOCUS);

--- a/src/lib/dialog/dialog-constants.ts
+++ b/src/lib/dialog/dialog-constants.ts
@@ -19,7 +19,8 @@ const observedAttributes = {
   PLACEMENT: 'placement',
   SIZE_STRATEGY: 'size-strategy',
   LABEL: 'label',
-  DESCRIPTION: 'description'
+  DESCRIPTION: 'description',
+  FOCUS_MODE: 'focus-mode'
 };
 
 const attributes = {
@@ -92,6 +93,7 @@ export type DialogPositionStrategy = 'viewport' | 'container';
 export type DialogPlacement = 'custom' | 'center' | 'top' | 'right' | 'bottom' | 'left' | 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
 export type DialogSizeStrategy = 'content' | 'container-inline' | 'container-block';
 export type DialogPreset = 'dialog' | 'bottom-sheet' | 'top-sheet' | 'left-sheet' | 'right-sheet';
+export type DialogFocusMode = 'auto' | 'manual';
 
 export const hideBackdrop = Symbol('hideBackdrop');
 export const showBackdrop = Symbol('showBackdrop');

--- a/src/lib/dialog/dialog-constants.ts
+++ b/src/lib/dialog/dialog-constants.ts
@@ -19,8 +19,7 @@ const observedAttributes = {
   PLACEMENT: 'placement',
   SIZE_STRATEGY: 'size-strategy',
   LABEL: 'label',
-  DESCRIPTION: 'description',
-  FOCUS_MODE: 'focus-mode'
+  DESCRIPTION: 'description'
 };
 
 const attributes = {
@@ -93,7 +92,6 @@ export type DialogPositionStrategy = 'viewport' | 'container';
 export type DialogPlacement = 'custom' | 'center' | 'top' | 'right' | 'bottom' | 'left' | 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
 export type DialogSizeStrategy = 'content' | 'container-inline' | 'container-block';
 export type DialogPreset = 'dialog' | 'bottom-sheet' | 'top-sheet' | 'left-sheet' | 'right-sheet';
-export type DialogFocusMode = 'auto' | 'manual';
 
 export const hideBackdrop = Symbol('hideBackdrop');
 export const showBackdrop = Symbol('showBackdrop');

--- a/src/lib/dialog/dialog-core.ts
+++ b/src/lib/dialog/dialog-core.ts
@@ -10,7 +10,8 @@ import {
   DialogSizeStrategy,
   DialogType,
   DIALOG_CONSTANTS,
-  IDialogMoveEventData
+  IDialogMoveEventData,
+  DialogFocusMode
 } from './dialog-constants';
 
 export interface IDialogCore {
@@ -30,6 +31,7 @@ export interface IDialogCore {
   moveable: boolean;
   label: string;
   description: string;
+  focusMode: DialogFocusMode;
   hideBackdrop(): void;
   showBackdrop(): void;
   dispatchBeforeCloseEvent(): boolean;
@@ -49,6 +51,7 @@ export class DialogCore implements IDialogCore {
   private _moveable = false;
   private _label = '';
   private _description = '';
+  private _focusMode: DialogFocusMode = 'auto';
   private _sizeStrategy: DialogSizeStrategy = DIALOG_CONSTANTS.defaults.SIZE_STRATEGY;
   private _placement: DialogPlacement = DIALOG_CONSTANTS.defaults.PLACEMENT;
   private _positionStrategy: DialogPositionStrategy = DIALOG_CONSTANTS.defaults.POSITION_STRATEGY;
@@ -166,7 +169,9 @@ export class DialogCore implements IDialogCore {
   private async _applyOpen(): Promise<void> {
     if (this._open) {
       this._show();
-      this._adapter.tryAutofocus();
+      if (this._focusMode === 'auto') {
+        this._adapter.tryAutofocus();
+      }
     } else {
       await this._hide();
     }
@@ -453,6 +458,15 @@ export class DialogCore implements IDialogCore {
     if (this._placement !== value) {
       this._placement = value;
       this._adapter.setHostAttribute(DIALOG_CONSTANTS.attributes.PLACEMENT, this._placement);
+    }
+  }
+
+  public get focusMode(): DialogFocusMode {
+    return this._focusMode;
+  }
+  public set focusMode(value: DialogFocusMode) {
+    if (this._focusMode !== value) {
+      this._focusMode = value;
     }
   }
 }

--- a/src/lib/dialog/dialog-core.ts
+++ b/src/lib/dialog/dialog-core.ts
@@ -2,6 +2,7 @@ import { MoveController } from '../core/controllers/move-controller';
 import { DismissibleStack } from '../core/utils/dismissible-stack';
 import { IDialogAdapter } from './dialog-adapter';
 import {
+  DIALOG_CONSTANTS,
   DialogAnimationType,
   DialogMode,
   DialogPlacement,
@@ -9,9 +10,7 @@ import {
   DialogPreset,
   DialogSizeStrategy,
   DialogType,
-  DIALOG_CONSTANTS,
-  IDialogMoveEventData,
-  DialogFocusMode
+  IDialogMoveEventData
 } from './dialog-constants';
 
 export interface IDialogCore {
@@ -31,7 +30,6 @@ export interface IDialogCore {
   moveable: boolean;
   label: string;
   description: string;
-  focusMode: DialogFocusMode;
   hideBackdrop(): void;
   showBackdrop(): void;
   dispatchBeforeCloseEvent(): boolean;
@@ -51,7 +49,6 @@ export class DialogCore implements IDialogCore {
   private _moveable = false;
   private _label = '';
   private _description = '';
-  private _focusMode: DialogFocusMode = 'auto';
   private _sizeStrategy: DialogSizeStrategy = DIALOG_CONSTANTS.defaults.SIZE_STRATEGY;
   private _placement: DialogPlacement = DIALOG_CONSTANTS.defaults.PLACEMENT;
   private _positionStrategy: DialogPositionStrategy = DIALOG_CONSTANTS.defaults.POSITION_STRATEGY;
@@ -169,9 +166,7 @@ export class DialogCore implements IDialogCore {
   private async _applyOpen(): Promise<void> {
     if (this._open) {
       this._show();
-      if (this._focusMode === 'auto') {
-        this._adapter.tryAutofocus();
-      }
+      this._adapter.tryAutofocus();
     } else {
       await this._hide();
     }
@@ -458,15 +453,6 @@ export class DialogCore implements IDialogCore {
     if (this._placement !== value) {
       this._placement = value;
       this._adapter.setHostAttribute(DIALOG_CONSTANTS.attributes.PLACEMENT, this._placement);
-    }
-  }
-
-  public get focusMode(): DialogFocusMode {
-    return this._focusMode;
-  }
-  public set focusMode(value: DialogFocusMode) {
-    if (this._focusMode !== value) {
-      this._focusMode = value;
     }
   }
 }

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -18,7 +18,8 @@ import {
   hideBackdrop,
   IDialogMoveEventData,
   IDialogMoveStartEventData,
-  showBackdrop
+  showBackdrop,
+  DialogFocusMode
 } from './dialog-constants';
 import { IDismissible, IDismissibleStackState, tryDismiss } from '../core/utils/dismissible-stack';
 
@@ -42,6 +43,7 @@ export interface IDialogProperties {
   moveable: boolean;
   label: string;
   description: string;
+  focusMode: DialogFocusMode;
 }
 
 export interface IDialogComponent extends IDialogProperties, IWithDefaultAria, IWithElementInternals, IDismissible {
@@ -256,6 +258,9 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
       case DIALOG_CONSTANTS.observedAttributes.DESCRIPTION:
         this.description = newValue;
         break;
+      case DIALOG_CONSTANTS.observedAttributes.FOCUS_MODE:
+        this.focusMode = newValue as DialogFocusMode;
+        break;
     }
   }
 
@@ -385,6 +390,16 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    */
   @coreProperty()
   public declare description: string;
+
+  /**
+   * Configures how the dialog manages focus.
+   * - `auto`: The dialog will automatically capture focus.
+   * - `manual`: The dialog will not manage focus.
+   * @default 'auto'
+   * @attribute focus-mode
+   */
+  @coreProperty()
+  public declare focusMode: DialogFocusMode;
 
   /** Shows the dialog. */
   public show(): void {

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -1,27 +1,26 @@
-import { attachShadowTemplate, coerceBoolean, customElement, coreProperty, coerceNumber } from '@tylertech/forge-core';
+import { attachShadowTemplate, coerceBoolean, coerceNumber, coreProperty, customElement } from '@tylertech/forge-core';
 import { BackdropComponent } from '../backdrop';
 import { BaseComponent } from '../core/base/base-component';
 import { IWithDefaultAria, WithDefaultAria } from '../core/mixins/internals/with-default-aria';
 import { IWithElementInternals, WithElementInternals } from '../core/mixins/internals/with-element-internals';
+import { IDismissible, IDismissibleStackState, tryDismiss } from '../core/utils/dismissible-stack';
 import { DialogAdapter } from './dialog-adapter';
-import { DialogCore } from './dialog-core';
 import {
+  DIALOG_CONSTANTS,
   DialogAnimationType,
   DialogMode,
   DialogPlacement,
   DialogPositionStrategy,
   DialogPreset,
   DialogSizeStrategy,
-  dialogStack,
   DialogType,
-  DIALOG_CONSTANTS,
-  hideBackdrop,
   IDialogMoveEventData,
   IDialogMoveStartEventData,
-  showBackdrop,
-  DialogFocusMode
+  dialogStack,
+  hideBackdrop,
+  showBackdrop
 } from './dialog-constants';
-import { IDismissible, IDismissibleStackState, tryDismiss } from '../core/utils/dismissible-stack';
+import { DialogCore } from './dialog-core';
 
 import template from './dialog.html';
 import styles from './dialog.scss';
@@ -43,7 +42,6 @@ export interface IDialogProperties {
   moveable: boolean;
   label: string;
   description: string;
-  focusMode: DialogFocusMode;
 }
 
 export interface IDialogComponent extends IDialogProperties, IWithDefaultAria, IWithElementInternals, IDismissible {
@@ -258,9 +256,6 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
       case DIALOG_CONSTANTS.observedAttributes.DESCRIPTION:
         this.description = newValue;
         break;
-      case DIALOG_CONSTANTS.observedAttributes.FOCUS_MODE:
-        this.focusMode = newValue as DialogFocusMode;
-        break;
     }
   }
 
@@ -390,16 +385,6 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    */
   @coreProperty()
   public declare description: string;
-
-  /**
-   * Configures how the dialog manages focus.
-   * - `auto`: The dialog will automatically capture focus.
-   * - `manual`: The dialog will not manage focus.
-   * @default 'auto'
-   * @attribute focus-mode
-   */
-  @coreProperty()
-  public declare focusMode: DialogFocusMode;
 
   /** Shows the dialog. */
   public show(): void {

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -32,7 +32,11 @@ export const FILTERED_LOGS = ['Lit is in dev mode'];
  * @type {import('@web/test-runner').TestRunnerConfig}
  */
 export default {
-  concurrentBrowsers: 1,
+  // Workaround until https://github.com/modernweb-dev/web/issues/2772 is resolved
+  // Remove the @ungap/structured-clone dependency once the issue is resolved
+  testRunnerHtml(testFramework) {
+    return `<html><body><script type="module">import structuredClone from '@ungap/structured-clone';window.structuredClone = (value) => structuredClone(value, { lossy: true });</script><script type="module" src="${testFramework}"></script></body></html>`;
+  },
   concurrency: 1,
   nodeResolve: true,
   filterBrowserLogs: ({ args }) => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Currently the `<forge-dialog>` captures and sets focus on the native `<dialog>` internally, and then will also check for an `autofocus` attribute and attempt to set focus to an element with that attribute. This works great and is expected for modal dialogs, but for non-modal dialogs it can be problematic moving focus automatically which could be unexpected.

This change will now only set focus to the `<dialog>` element if it is modal. The inline-modal and nonmodal modes will not do this by default. The `autofocus` attribute support is available regardless of mode.
