### PR TITLE
fix(field): apply default min height to slotted support text elements

### DIFF
--- a/src/lib/field/_core.slotted.scss
+++ b/src/lib/field/_core.slotted.scss
@@ -54,3 +54,8 @@
 @mixin slotted-placeholder {
   color: #{token(placeholder-color)};
 }
+
+@mixin slotted-support-text {
+  display: block;
+  min-height: 0.875rem;
+}

--- a/src/lib/field/field.scss
+++ b/src/lib/field/field.scss
@@ -597,6 +597,10 @@ $variants: (
       @include core.item-padding(end, inner);
     }
   }
+
+  ::slotted(:where([slot='support-text'], [slot='helper-text'])) {
+    @include core.slotted-support-text;
+  }
 }
 
 /* Add padding between the end and accessory elements in the plain variant */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Adds a default min height of `0.875rem` to any elements slotted into the `support-text` or legacy `helper-text` slots. This allows for adding a placeholder element into the slot without any text content to reserve space for the potential future text. This aids in alignment with other fields that use dynamic slotted text content.
