### PR TITLE
fix(field): only apply hover state when cursor is over container

### DIFF
--- a/src/lib/field/field.scss
+++ b/src/lib/field/field.scss
@@ -8,7 +8,6 @@
 @use './token-utils' as *;
 
 $focus: ':not([disabled]):focus-within';
-$hover: ':not([disabled]):hover';
 $invalid: ':not([disabled])[invalid]';
 
 $first-slotted-element: '::slotted(:is([data-forge-field-input], *:first-of-type:is(input, textarea)))';
@@ -158,12 +157,6 @@ $variants: (
 // State
 //
 
-:host(#{$hover}) {
-  .forge-field {
-    @include core.hover;
-  }
-}
-
 :host([disabled]) {
   .forge-field {
     @include core.disabled;
@@ -182,6 +175,10 @@ $variants: (
 }
 
 :host(:not([disabled])) {
+  .forge-field:has(.container:hover) {
+    @include core.hover;
+  }
+
   .forge-field:has(.input:focus-within) {
     @include core.focus;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Changed the CSS selector for the hover state to use `:hover` on the container element instead of the host.

Fixes #839 
