### PR TITLE
feat(field): expose `class="outline"` element as a CSS part

### DIFF
--- a/src/lib/field/base/base-field.ts
+++ b/src/lib/field/base/base-field.ts
@@ -117,6 +117,7 @@ export interface IBaseField extends IWithLabelAwareness {
  * @csspart accessory - The element containing the accessory slot.
  * @csspart support-text - The support text element.
  * @csspart support-text-end - The element containing the support text end slot.
+ * @csspart outline - The element containing the forge-focus-indicator element.
  * @csspart focus-indicator - The focus indicator element.
  *
  * @slot - The default/unnamed slot for the field's input.

--- a/src/lib/field/field-constants.ts
+++ b/src/lib/field/field-constants.ts
@@ -49,6 +49,7 @@ const parts = {
   ACCESSORY: 'accessory',
   SUPPORT_TEXT: 'support-text',
   SUPPORT_TEXT_END: 'support-text-end',
+  OUTLINE: 'outline',
   FOCUS_INDICATOR: 'focus-indicator'
 };
 

--- a/src/lib/field/field.html
+++ b/src/lib/field/field.html
@@ -33,7 +33,7 @@
         <slot name="support-text-end"></slot>
       </div>
     </div>
-    <div class="outline">
+    <div class="outline" part="outline">
       <forge-focus-indicator target="input" part="focus-indicator"></forge-focus-indicator>
     </div>
   </div>

--- a/src/lib/field/field.ts
+++ b/src/lib/field/field.ts
@@ -151,6 +151,7 @@ declare global {
  * @csspart accessory - The element containing the accessory slot.
  * @csspart support-text - The element containing the support text slot.
  * @csspart support-text-end - The element containing the support text end slot.
+ * @csspart outline - The element containing the forge-focus-indicator element.
  * @csspart focus-indicator - The focus indicator element.
  *
  * @cssclass forge-field - The field container that wraps an `<input>` or `<textarea>`.

--- a/src/lib/select/select/select.ts
+++ b/src/lib/select/select/select.ts
@@ -144,6 +144,7 @@ declare global {
  * @csspart support-text - The support text element.
  * @csspart support-text - The element containing the support text slot.
  * @csspart support-text-end - The element containing the support text end slot.
+ * @csspart outline - The element containing the forge-focus-indicator element.
  * @csspart focus-indicator - The focus indicator element.
  *
  * @slot value - The selected text to display

--- a/src/lib/text-field/text-field.ts
+++ b/src/lib/text-field/text-field.ts
@@ -57,6 +57,7 @@ declare global {
  * @csspart support-text - The support text element.
  * @csspart support-text - The element containing the support text slot.
  * @csspart support-text-end - The element containing the support text end slot.
+ * @csspart outline - The element containing the forge-focus-indicator element.
  * @csspart focus-indicator - The focus indicator element.
  *
  * @slot - The default/unnamed slot for the field's input.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y
   - https://github.com/tyler-technologies-oss/forge/issues/845

## Describe the new behavior?
The `class="outline"` element of the forge-field is exposed as a CSS part.

## Additional information
<!-- Add any other context about the change here. -->
