### PR TITLE
fix(select): fixed a bug where the inset label would not float if the value was set while the dropdown is open

### DIFF
--- a/src/lib/select/select/select-core.ts
+++ b/src/lib/select/select/select-core.ts
@@ -149,9 +149,7 @@ export class SelectCore extends BaseSelectCore<ISelectAdapter> implements ISelec
     // Update the state of the component based on the existence of a selected value
     const text = this._getSelectedText();
     this._adapter.setSelectedText(text);
-    if (!this._open) {
-      this._tryFloatLabel();
-    }
+    this._tryFloatLabel();
   }
 
   /** Gets/sets the label text. */

--- a/src/lib/select/select/select.test.ts
+++ b/src/lib/select/select/select.test.ts
@@ -706,6 +706,21 @@ describe('Select', () => {
       expect(harness.fieldElement.floatLabel).to.be.true;
     });
 
+    it('should float label when value is set while dropdown is open', async () => {
+      const harness = await createFixture();
+
+      harness.element.labelPosition = 'inset';
+      await harness.clickElement(harness.element);
+
+      expect(harness.element.open).to.be.true;
+      expect(harness.fieldElement.floatLabel).to.be.false;
+
+      harness.element.value = 'one';
+      await frame();
+
+      expect(harness.fieldElement.floatLabel).to.be.true;
+    });
+
     it('should not float label when select has no value or placeholder', async () => {
       const harness = await createFixture();
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y
   Fixes #847 

## Describe the new behavior?
This was an oversight, probably caused from the migration from v2 to v3 where an if statement was blocking the label float logic if the dropdown was open. Simply removing the if statement fixes the issue so that it can attempt to float the label regardless of the open state.
