### PR TITLE
feat(menu): added support for option tooltips

### DIFF
--- a/src/dev/pages/menu/menu.ts
+++ b/src/dev/pages/menu/menu.ts
@@ -73,7 +73,7 @@ const complexOptions: IMenuOption[] = [
 ];
 const simpleOptions: IMenuOption[] = [
   { value: 'back', label: 'Back' },
-  { value: 'forward', label: 'Forward' },
+  { value: 'forward', label: 'Forward', tooltip: { text: 'Custom option tooltip!', type: 'label' } },
   { value: 'reload', label: 'Reload' },
   { value: 'help', label: 'Help & Feedback' },
   { value: 'settings', label: 'Settings' }
@@ -83,7 +83,7 @@ menu.options = simpleOptions;
 menu.placement = 'bottom-start';
 
 menu.addEventListener('forge-menu-select', evt => {
-  if (cancelSelectToggle.selected) {
+  if (cancelSelectToggle.checked) {
     console.log('[forge-menu-select] default prevented', evt.detail);
     evt.preventDefault();
     return;

--- a/src/dev/src/partials/options-drawer.ejs
+++ b/src/dev/src/partials/options-drawer.ejs
@@ -1,9 +1,7 @@
 <aside slot="body-left">
   <forge-drawer>
-    <forge-toolbar slot="header">
-      <h2 slot="start" class="forge-typography--heading1">Options</h2>
-    </forge-toolbar>
     <div class="options-container">
+      <h2 class="forge-typography--overline">Options</h2>
       <% controls.forEach(control => { %>
         <% if (control.type === 'checkbox') { %>
           <%- include('controls/checkbox.ejs', { control }); %>

--- a/src/dev/src/styles/_options.scss
+++ b/src/dev/src/styles/_options.scss
@@ -1,7 +1,11 @@
 .options-container {
-  padding: 16px;
+  padding-inline: var(--forge-spacing-medium);
   display: flex;
   flex-direction: column;
+
+  h2 {
+    margin-block-end: 0;
+  }
 
   forge-drawer:has(.options-container) {
     --forge-drawer-width: 300px;

--- a/src/lib/list-dropdown/list-dropdown-constants.ts
+++ b/src/lib/list-dropdown/list-dropdown-constants.ts
@@ -1,6 +1,7 @@
 import type { IIconComponent } from '../icon';
 import type { IOverlayOffset } from '../overlay/overlay-constants';
 import { PositionPlacement } from '../core/utils/position-utils';
+import { TooltipPlacement, TooltipType } from '../tooltip';
 
 const attributes = {
   POPUP_CLASSES: 'popup-classes',
@@ -49,6 +50,7 @@ export interface IBaseListDropdownOption<T = any> {
   trailingIconComponentProps?: Partial<IIconComponent>;
   leadingBuilder?: () => HTMLElement;
   trailingBuilder?: () => HTMLElement;
+  tooltip?: ListDropdownTooltipConfig;
 }
 
 export interface IListDropdownOption<T = any> extends IBaseListDropdownOption<T> {
@@ -130,4 +132,14 @@ export enum ListDropdownType {
 export enum ListDropdownAsyncStyle {
   Spinner = 'spinner',
   Skeleton = 'skeleton'
+}
+
+export interface ListDropdownTooltipConfig {
+  text: string;
+  placement?: TooltipPlacement;
+  type?: TooltipType;
+  delay?: number;
+  offset?: number;
+  anchor?: string;
+  anchorElement?: HTMLElement;
 }

--- a/src/lib/list-dropdown/list-dropdown-utils.ts
+++ b/src/lib/list-dropdown/list-dropdown-utils.ts
@@ -239,6 +239,28 @@ export function createListItems(
         }
       }
 
+      // Check for a tooltip configuration
+      if (option.tooltip) {
+        const { text, type = 'presentation', ...restConfig } = option.tooltip;
+        const tooltipElement = document.createElement('forge-tooltip');
+        tooltipElement.id = `list-dropdown-option-${config.id}-${optionIdIndex++}-tooltip`;
+        tooltipElement.textContent = option.tooltip.text;
+
+        // We always anchor to the list item element unless an anchor element is provided
+        if (!option.tooltip.anchor && !option.tooltip.anchorElement) {
+          tooltipElement.anchorElement = listItemElement;
+        }
+
+        // We need to attach the tooltip ARIA attributes to the button element, not the anchor element
+        if (type === 'label' || type === 'description') {
+          const a11yAttr = type === 'label' ? 'aria-labelledby' : 'aria-describedby';
+          buttonElement.setAttribute(a11yAttr, tooltipElement.id);
+        }
+
+        Object.assign(tooltipElement, restConfig);
+        listItemElement.appendChild(tooltipElement);
+      }
+
       // Check for secondary (subtitle) text
       if (option.secondaryLabel) {
         const secondaryLabelElement = document.createElement('span');

--- a/src/lib/menu/menu-constants.ts
+++ b/src/lib/menu/menu-constants.ts
@@ -4,8 +4,7 @@ import { IListDropdownOption, IListDropdownOptionGroup } from '../list-dropdown'
 const elementName: keyof HTMLElementTagNameMap = `${COMPONENT_NAME_PREFIX}menu`;
 
 const classes = {
-  POPUP: 'forge-menu__popup',
-  MENU: 'mdc-menu'
+  POPUP: 'forge-menu__popup'
 };
 
 const selectors = {

--- a/src/lib/menu/menu-core.ts
+++ b/src/lib/menu/menu-core.ts
@@ -313,7 +313,7 @@ export class MenuCore extends CascadingListDropdownAwareCore<IMenuOption | IMenu
       popupPlacement: this._placement,
       popupFallbackPlacements: this._fallbackPlacements,
       activeStartIndex: fromKeyboard ? 0 : undefined,
-      popupClasses: [MENU_CONSTANTS.classes.POPUP, MENU_CONSTANTS.classes.MENU, ...(this._popupClasses as string[])],
+      popupClasses: [MENU_CONSTANTS.classes.POPUP, ...(this._popupClasses as string[])],
       syncWidth: this._syncPopupWidth,
       activeChangeCallback: this._activeChangeListener,
       selectCallback: this._selectListener,

--- a/src/lib/menu/menu.ts
+++ b/src/lib/menu/menu.ts
@@ -18,6 +18,7 @@ import {
   MENU_CONSTANTS
 } from './menu-constants';
 import { MenuCore } from './menu-core';
+import { TooltipComponent } from '../tooltip';
 
 import template from './menu.html';
 import styles from './menu.scss';
@@ -61,7 +62,7 @@ declare global {
  */
 @customElement({
   name: MENU_CONSTANTS.elementName,
-  dependencies: [PopoverComponent, ListComponent]
+  dependencies: [PopoverComponent, ListComponent, TooltipComponent]
 })
 export class MenuComponent extends ListDropdownAware implements IMenuComponent {
   public static get observedAttributes(): string[] {

--- a/src/lib/select/core/base-select-adapter.ts
+++ b/src/lib/select/core/base-select-adapter.ts
@@ -122,7 +122,8 @@ export abstract class BaseSelectAdapter<T extends IBaseSelectComponent> extends 
           : o.trailingIconType,
         trailingIconComponentProps: o.trailingIconComponentProps,
         leadingBuilder: o.leadingBuilder,
-        trailingBuilder: o.trailingBuilder
+        trailingBuilder: o.trailingBuilder,
+        tooltip: o.tooltip
       };
     });
   }

--- a/src/lib/select/option/option-constants.ts
+++ b/src/lib/select/option/option-constants.ts
@@ -14,6 +14,7 @@ const attributes = {
   TRAILING_ICON_CLASS: 'trailing-icon-class',
   TRAILING_ICON_TYPE: 'trailing-icon-type',
   TRAILING_ICON: 'trailing-icon',
+  TOOLTIP: 'tooltip',
   VALUE: 'value'
 };
 

--- a/src/lib/select/option/option-core.ts
+++ b/src/lib/select/option/option-core.ts
@@ -1,5 +1,5 @@
 import type { IIconComponent } from '../../icon/icon';
-import { IBaseListDropdownOption, ListDropdownIconType } from '../../list-dropdown/list-dropdown-constants';
+import { IBaseListDropdownOption, ListDropdownIconType, ListDropdownTooltipConfig } from '../../list-dropdown/list-dropdown-constants';
 import { IOptionAdapter } from './option-adapter';
 import { OPTION_CONSTANTS } from './option-constants';
 
@@ -22,6 +22,7 @@ export class OptionCore implements IOptionCore {
   private _trailingIconComponentProps: Partial<IIconComponent>;
   private _leadingBuilder: () => HTMLElement;
   private _trailingBuilder: () => HTMLElement;
+  private _tooltip: ListDropdownTooltipConfig;
 
   constructor(private _adapter: IOptionAdapter) {}
 
@@ -202,6 +203,15 @@ export class OptionCore implements IOptionCore {
   public set trailingBuilder(value: () => HTMLElement) {
     if (this._trailingBuilder !== value) {
       this._trailingBuilder = value;
+    }
+  }
+
+  public get tooltip(): ListDropdownTooltipConfig {
+    return this._tooltip;
+  }
+  public set tooltip(value: ListDropdownTooltipConfig) {
+    if (this._tooltip !== value) {
+      this._tooltip = value;
     }
   }
 }

--- a/src/lib/select/option/option.ts
+++ b/src/lib/select/option/option.ts
@@ -1,7 +1,7 @@
 import { coerceBoolean, customElement, coreProperty } from '@tylertech/forge-core';
 import { IIconComponent } from '../../icon';
 import { BaseComponent, IBaseComponent } from '../../core/base/base-component';
-import { IBaseListDropdownOption, ListDropdownIconType } from '../../list-dropdown/list-dropdown-constants';
+import { IBaseListDropdownOption, ListDropdownIconType, ListDropdownTooltipConfig } from '../../list-dropdown/list-dropdown-constants';
 import { OptionAdapter } from './option-adapter';
 import { OPTION_CONSTANTS } from './option-constants';
 import { OptionCore } from './option-core';
@@ -34,7 +34,8 @@ export class OptionComponent extends BaseComponent implements IOptionComponent {
       OPTION_CONSTANTS.attributes.LEADING_ICON_TYPE,
       OPTION_CONSTANTS.attributes.TRAILING_ICON,
       OPTION_CONSTANTS.attributes.TRAILING_ICON_CLASS,
-      OPTION_CONSTANTS.attributes.TRAILING_ICON_TYPE
+      OPTION_CONSTANTS.attributes.TRAILING_ICON_TYPE,
+      OPTION_CONSTANTS.attributes.TOOLTIP
     ];
   }
 
@@ -82,6 +83,9 @@ export class OptionComponent extends BaseComponent implements IOptionComponent {
         break;
       case OPTION_CONSTANTS.attributes.TRAILING_ICON_TYPE:
         this.trailingIconType = newValue as ListDropdownIconType;
+        break;
+      case OPTION_CONSTANTS.attributes.TOOLTIP:
+        this.tooltip = newValue ? { text: newValue } : (undefined as any);
         break;
     }
   }
@@ -197,4 +201,10 @@ export class OptionComponent extends BaseComponent implements IOptionComponent {
    */
   @coreProperty()
   public declare trailingBuilder: () => HTMLElement;
+
+  /**
+   * Gets/sets the tooltip configuration for this option.
+   */
+  @coreProperty()
+  public declare tooltip: ListDropdownTooltipConfig;
 }

--- a/src/lib/switch/switch.ts
+++ b/src/lib/switch/switch.ts
@@ -20,7 +20,7 @@ export interface ISwitchComponent extends IWithFormAssociation, IWithFocusable, 
   checked: boolean;
   /** @deprecated use `checked` instead */
   on: boolean;
-  /** @deprecated use `on` instead */
+  /** @deprecated use `checked` instead */
   selected: boolean;
   defaultChecked: boolean;
   /** @deprecated use `defaultChecked` instead */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Adds support for tooltip configuration to menu options (and other list dropdown-based components). This will allow developers to add tooltips to options via the `options` property on a menu.

```javascript
const options = [
  { label: 'Option', value: 'some-value', tooltip: { text: "My tooltip" } }
];
```
