### PR TITLE
fix(time-picker): remove extra icon margin

### DIFF
--- a/src/lib/time-picker/time-picker-adapter.ts
+++ b/src/lib/time-picker/time-picker-adapter.ts
@@ -137,7 +137,6 @@ export class TimePickerAdapter extends BaseAdapter<ITimePickerComponent> impleme
       iconButtonElement.density = 'medium';
       iconButtonElement.type = 'button';
       iconButtonElement.tabIndex = -1;
-      iconButtonElement.style.marginRight = '4px'; // Override default trailing slot margin in text-field
       iconButtonElement.setAttribute('aria-label', 'Toggle time dropdown');
 
       const iconElement = document.createElement(ICON_CONSTANTS.elementName) as IIconComponent;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Remove extra margin-right that was applied to the popover icon in this component but no other field components.

Fixes #852 