### PR TITLE
fix(field): ensure that enabled field inputs use the text cursor

### DIFF
--- a/src/lib/field/_core.scss
+++ b/src/lib/field/_core.scss
@@ -19,7 +19,7 @@
 
 @mixin base {
   /* Internal custom properties */
-  @include override(disableable-cursor, unset, value);
+  @include override(disableable-cursor, auto, value);
   @include override(disableable-opacity, 1, value);
   @include override(inner-border-block-size, 100%, value);
   @include override(inner-border-color, #{token(outline-color, custom)}, value);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
This fixes field components to use `auto` for the enabled cursor instead of `unset`. `unset` was causing slotted `<input>` elements to inherit their parent's cursor style, i.e. the default pointer, when they should use the text cursor.
