### PR TITLE
fix(popover): enable compatibility with older browsers if `checkVisibility()` API is not available

### DIFF
--- a/src/lib/core/utils/utils.ts
+++ b/src/lib/core/utils/utils.ts
@@ -343,3 +343,25 @@ export function frame(): Promise<void> {
 export function isInstanceOf<T>(obj: any, name: string): obj is T {
   return Object.prototype.toString.call(obj) === `[object ${name}]`;
 }
+
+/**
+ * Determines if an element is visible based on its computed styles.
+ * @param element The element to check.
+ * @returns `true` if the element is visible, otherwise `false`.
+ */
+export function checkVisibility(element: HTMLElement): boolean {
+  // Use the `checkVisibility()` method on the element if available
+  if (typeof element.checkVisibility === 'function') {
+    return element.checkVisibility();
+  }
+
+  // Fall back to computed styles on older browsers
+  const style = window.getComputedStyle(element);
+  return (
+    style.display !== 'none' &&
+    style.visibility !== 'hidden' &&
+    style.visibility !== 'collapse' &&
+    style.opacity !== '0' &&
+    style.getPropertyValue('content-visibility') !== 'hidden'
+  );
+}

--- a/src/lib/popover/popover-adapter.ts
+++ b/src/lib/popover/popover-adapter.ts
@@ -1,7 +1,7 @@
 import { getShadowElement } from '@tylertech/forge-core';
 import { prefersReducedMotion } from '../core/utils/feature-detection';
 import { VirtualElement } from '../core/utils/position-utils';
-import { frame } from '../core/utils/utils';
+import { checkVisibility, frame } from '../core/utils/utils';
 import { IOverlayComponent, OVERLAY_CONSTANTS } from '../overlay';
 import { IOverlayAwareAdapter, OverlayAwareAdapter } from '../overlay/base/overlay-aware-adapter';
 import { IPopoverComponent } from './popover';
@@ -95,7 +95,7 @@ export class PopoverAdapter extends OverlayAwareAdapter<IPopoverComponent> imple
 
     await frame();
 
-    if (!this._surfaceElement.checkVisibility()) {
+    if (!checkVisibility(this._surfaceElement)) {
       this._overlayElement.open = false;
       this._updateAnchorExpandedState(false);
       return Promise.resolve();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Create helper for checking the visibility of an element that will use `HTMLElement.checkVisibility()` if available, otherwise fall back to manually checking computed styles via `getComputedStyle()`. Updated our only usage of this method within the `<forge-popover>` element to use the helper instead.

This is added to support older browsers (such as Safari 16.x) where the `HTMLElement.checkVisibility()` API doesn't exist.
