### PR TITLE
docs: add support for grouped menu options in documentation and stories

### DIFF
--- a/src/stories/components/menu/Menu.mdx
+++ b/src/stories/components/menu/Menu.mdx
@@ -51,7 +51,7 @@ and its options.
 Below is an example of a basic array of menu options with groups:
 
 ```javascript
-let optionGroup: IMenuOptionGroup = [
+let optionGroup: IMenuOptionGroup[] = [
       {
         text: 'Group 1',
         options: [

--- a/src/stories/components/menu/Menu.mdx
+++ b/src/stories/components/menu/Menu.mdx
@@ -43,6 +43,32 @@ Cascading menus are used to display a hierarchical list of options. When a menu 
 
 <Canvas of={MenuStories.Cascading} />
 
+## Menu Groups
+
+Grouping menu items can be useful to visually separate different types of options. The menu options use the `IMenuOptionGroup` interface to define the group
+and its options.
+
+Below is an example of a basic array of menu options with groups:
+
+```javascript
+let optionGroup: IMenuOptionGroup = [
+      {
+        text: 'Group 1',
+        options: [
+          { label: 'Option 1', value: 'option1' },
+          { label: 'Option 2', value: 'option2' },
+        ]
+      },
+      {
+        text: 'Group 2',
+        options: [
+          { label: 'Option 3', value: 'option3' },
+          { label: 'Option 4', value: 'option4' }
+        ]
+      }
+    ];
+```
+<Canvas of={MenuStories.Grouped} />
 ## API
 
 <CustomArgTypes />

--- a/src/stories/components/menu/Menu.stories.ts
+++ b/src/stories/components/menu/Menu.stories.ts
@@ -1,8 +1,10 @@
 import { html, nothing } from 'lit';
 import { type Meta, type StoryObj } from '@storybook/web-components';
 import { OVERLAY_PLACEMENT_OPTIONS, generateCustomElementArgTypes, getCssVariableArgs } from '../../utils';
-import { IMenuOption, IOption } from '@tylertech/forge';
+import { IMenuComponent, IMenuOption, IMenuOptionGroup, IOption, IOptionGroup } from '@tylertech/forge';
 import { styleMap } from 'lit/directives/style-map.js';
+import { createRef, ref } from 'lit/directives/ref.js';
+import { standaloneStoryParams } from '../../utils';
 
 import '@tylertech/forge/menu';
 import '@tylertech/forge/button';
@@ -88,4 +90,36 @@ export const Demo: Story = {};
 
 export const Cascading: Story = {
   args: { mode: 'cascade' }
+};
+
+export const Grouped: Story = {
+  ...standaloneStoryParams,
+  render: () => {
+    const menuRef = createRef<IMenuComponent>();
+
+    window.requestAnimationFrame(() => {
+      menuRef.value!.options = [
+        {
+          text: 'Group 1',
+          options: [
+            { label: 'Option 1', value: 'option1' },
+            { label: 'Option 2', value: 'option2' }
+          ]
+        },
+        {
+          text: 'Group 2',
+          options: [
+            { label: 'Option 3', value: 'option3' },
+            { label: 'Option 4', value: 'option4' }
+          ]
+        }
+      ] as IMenuOptionGroup[];
+    });
+
+    return html`
+      <forge-menu ${ref(menuRef)}>
+        <forge-button type="button" variant="raised">Menu</forge-button>
+      </forge-menu>
+    `;
+  }
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Adds documentation of grouped options to `Menu`.  This functionality was existing, but was not documented on storybook

## Additional information
![image](https://github.com/user-attachments/assets/9f89c559-7b18-4263-8e32-ae4e95ec0c4f)

