### PR TITLE
fix(tabs): fixed a bug where the scroll buttons were not being shown/hidden when tabs are dynamically added/removed

### DIFF
--- a/src/lib/tabs/tab-bar/tab-bar-core.ts
+++ b/src/lib/tabs/tab-bar/tab-bar-core.ts
@@ -78,6 +78,9 @@ export class TabBarCore implements ITabBarCore {
   private async _onTabsChanged(): Promise<void> {
     this._tabs = this._adapter.getTabs();
     this._syncTabState();
+    if (this._scrollButtons) {
+      this._detectScrollableStatus();
+    }
     this._tryScrollActiveTabIntoView();
   }
 

--- a/src/lib/tabs/tabs.test.ts
+++ b/src/lib/tabs/tabs.test.ts
@@ -614,6 +614,36 @@ describe('Tabs', () => {
       expect(ctx.forwardScrollButton).not.to.be.ok;
     });
 
+    it('should show scroll buttons when new tabs are added that cause scrolling', async () => {
+      const el = await createFixture({ scrollButtons: true, clustered: true, width: '250px' });
+      const ctx = new TabsHarness(el);
+
+      await elementUpdated(el);
+      expect(ctx.hasScrollButtons).to.be.false;
+
+      const tab = document.createElement('forge-tab');
+      tab.textContent = 'Fourth';
+      el.appendChild(tab);
+      await elementUpdated(el);
+
+      expect(ctx.hasScrollButtons).to.be.true;
+    });
+
+    it('should hide scroll buttons when scrollable tabs are removed causing no overflow', async () => {
+      const el = await createFixture({ scrollButtons: true, clustered: true, width: '215px' });
+      const ctx = new TabsHarness(el);
+
+      await elementUpdated(el);
+      expect(ctx.hasScrollButtons).to.be.true;
+
+      // Removing two tabs because the visibility of the scroll buttons causes the scrollable area to decrease
+      ctx.tabs[0].remove();
+      ctx.tabs[0].remove();
+      await elementUpdated(el);
+
+      expect(ctx.hasScrollButtons).to.be.false;
+    });
+
     it('should scroll forward when forward scroll button is clicked', async () => {
       const el = await createFixture({ scrollButtons: true, width: '150px' });
       const ctx = new TabsHarness(el);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Added a call to the internal scroll button detection logic whenever the default slot changes.
