### PR TITLE
fix(list-item): improve overflow handling on slotted `<button>` elements

### DIFF
--- a/src/lib/list/list-item/_core.scss
+++ b/src/lib/list/list-item/_core.scss
@@ -56,6 +56,10 @@
   display: block;
 }
 
+@mixin button-wrap {
+  white-space: normal;
+}
+
 @mixin anchor {
   outline: none;
   color: inherit !important;

--- a/src/lib/list/list-item/_core.scss
+++ b/src/lib/list/list-item/_core.scss
@@ -38,6 +38,7 @@
   padding-inline: 0;
   margin: 0;
   box-sizing: border-box;
+  width: 100%;
 
   background: transparent;
   color: inherit;
@@ -48,8 +49,11 @@
   text-align: inherit;
   letter-spacing: inherit;
   word-spacing: inherit;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 
-  display: inline;
+  display: block;
 }
 
 @mixin anchor {

--- a/src/lib/list/list-item/list-item.scss
+++ b/src/lib/list/list-item/list-item.scss
@@ -211,6 +211,10 @@ slot[name='tertiary-text'] {
     @include text-container-wrap;
   }
 
+  ::slotted(:is(button, [role='button'][tabindex], [forge-list-item-button])) {
+    @include button-wrap;
+  }
+
   slot[name='secondary-text'],
   slot[name='tertiary-text'] {
     &::slotted(*) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Ensure that the slotted `<button>` elements are properly styled to fill the available space to handle content overflowing, ellipseing, and wrapping.