### PR TITLE
fix(field): do not show required asterisk if no label is present

### DIFF
--- a/src/lib/field/field.scss
+++ b/src/lib/field/field.scss
@@ -236,7 +236,7 @@ $variants: (
 //
 
 :host([required]) {
-  .label::before {
+  .has-label .label::before {
     @include core.label-before;
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The required asterisk will no longer apply to the internal label container element if there is no `<label>` element slotted.
