### PR TITLE
fix(avatar): hide text when image is rendered

### DIFF
--- a/src/lib/avatar/avatar.test.ts
+++ b/src/lib/avatar/avatar.test.ts
@@ -48,7 +48,7 @@ describe('Avatar', () => {
   it('should change background image when set via attribute', async () => {
     const el = await fixture<IAvatarComponent>(html`<forge-avatar text="Tyler Forge"></forge-avatar>`);
 
-    const url = 'https://empower.tylertech.com/rs/015-NUU-525/images/tyler-logo-color.svg';
+    const url = 'https://cdn.forge.tylertech.com/v1/images/branding/tyler/talking-t-logo.svg';
     el.setAttribute(AVATAR_CONSTANTS.attributes.IMAGE_URL, url);
     const root = getRootEl(el);
     // Give enough time for the image to load
@@ -56,6 +56,22 @@ describe('Avatar', () => {
 
     expect(root.hasAttribute('style')).to.be.true;
     expect(root.style.backgroundImage).to.equal(`url("${url}")`);
+  });
+
+  it('should hide text when image url is set', async () => {
+    const el = await fixture<IAvatarComponent>(
+      html`<forge-avatar text="Tyler Forge" image-url="https://cdn.forge.tylertech.com/v1/images/branding/tyler/talking-t-logo.svg"></forge-avatar>`
+    );
+
+    // Give enough time for the image to load
+    await task(1800);
+
+    expect(getDefaultSlotEl(el).textContent).to.equal('');
+
+    el.imageUrl = '';
+    await elementUpdated(el);
+
+    expect(getDefaultSlotEl(el).textContent).to.equal('TF');
   });
 
   it('should change text when set via attribute', async () => {

--- a/src/lib/avatar/avatar.ts
+++ b/src/lib/avatar/avatar.ts
@@ -91,7 +91,7 @@ export class AvatarComponent extends LitElement implements IAvatarComponent {
         part="root"
         class=${classMap({ 'forge-avatar': true, 'forge-avatar--image': !!this._image })}
         style=${this._image ? styleMap({ backgroundImage: `url(${this._image.src})` }) : nothing}>
-        <slot>${charsByLetterCount(this.text, this.letterCount ?? AVATAR_CONSTANTS.numbers.DEFAULT_LETTER_COUNT)}</slot>
+        <slot>${this._image ? nothing : charsByLetterCount(this.text, this.letterCount ?? AVATAR_CONSTANTS.numbers.DEFAULT_LETTER_COUNT)}</slot>
       </div>
     `;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated:N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Automatically hide the text if an image is rendered.

## Additional information
Fixes #862 
