### PR TITLE
chore: move `toggleState()` helper to general utils and export from lib

### DIFF
--- a/src/lib/core/utils/a11y-utils.ts
+++ b/src/lib/core/utils/a11y-utils.ts
@@ -371,26 +371,3 @@ export function setDefaultAria(
     }
   });
 }
-
-/**
- * Adds or removes a state from an element's custom state set.
- *
- * @param internals - The element's internals object.
- * @param state - The name of the custom state to toggle.
- * @param value - Whether to add or remove the state.
- */
-export function toggleState(internals: ElementInternals, state: string, value: boolean): void {
-  if (value) {
-    try {
-      internals.states.add(state);
-    } catch {
-      internals.states.add(`--${state}`);
-    }
-  } else {
-    try {
-      internals.states.delete(state);
-    } catch {
-      internals.states.delete(`--${state}`);
-    }
-  }
-}

--- a/src/lib/core/utils/utils.ts
+++ b/src/lib/core/utils/utils.ts
@@ -365,3 +365,26 @@ export function checkVisibility(element: HTMLElement): boolean {
     style.getPropertyValue('content-visibility') !== 'hidden'
   );
 }
+
+/**
+ * Adds or removes a state from an element's custom state set.
+ *
+ * @param internals - The element's internals object.
+ * @param state - The name of the custom state to toggle.
+ * @param value - Whether to add or remove the state.
+ */
+export function toggleState(internals: ElementInternals, state: string, value: boolean): void {
+  if (value) {
+    try {
+      internals.states.add(state);
+    } catch {
+      internals.states.add(`--${state}`);
+    }
+  } else {
+    try {
+      internals.states.delete(state);
+    } catch {
+      internals.states.delete(`--${state}`);
+    }
+  }
+}

--- a/src/lib/meter/meter-group/meter-group.ts
+++ b/src/lib/meter/meter-group/meter-group.ts
@@ -2,7 +2,8 @@ import { debounce } from '@tylertech/forge-core';
 import { html, LitElement, PropertyValues, TemplateResult, unsafeCSS } from 'lit';
 import { customElement, property, queryAssignedElements, queryAssignedNodes, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { setDefaultAria, toggleState } from '../../core/utils/a11y-utils';
+import { setDefaultAria } from '../../core/utils/a11y-utils';
+import { toggleState } from '../../core/utils/utils';
 import { MeterComponent, MeterDensity, MeterDirection, MeterInnerShape, MeterShape } from '../meter/meter';
 
 import styles from './meter-group.scss';

--- a/src/lib/meter/meter/meter.ts
+++ b/src/lib/meter/meter/meter.ts
@@ -3,7 +3,8 @@ import { customElement, property, queryAssignedNodes, state } from 'lit/decorato
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { Theme } from '../../constants';
-import { setDefaultAria, toggleState } from '../../core/utils/a11y-utils';
+import { setDefaultAria } from '../../core/utils/a11y-utils';
+import { toggleState } from '../../core/utils/utils';
 
 import styles from './meter.scss';
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Exposes the `toggleState()` helper and moves it from a11y-utils to generic utils.
