### PR TITLE
feat(dialog): automatically apply `height: auto` to slotted `<forge-scaffold>`

### DIFF
--- a/src/dev/pages/dialog/dialog.scss
+++ b/src/dev/pages/dialog/dialog.scss
@@ -7,7 +7,6 @@ dialog.forge-dialog:not(.forge-dialog--fullscreen),
 .dialog:not([fullscreen]) {
   forge-scaffold {
     max-width: 500px;
-    height: auto;
   }
 }
 

--- a/src/lib/dialog/dialog.scss
+++ b/src/lib/dialog/dialog.scss
@@ -32,6 +32,14 @@ $can-animate: '[visible]:not([animation-type=none])';
   }
 
   //
+  // Slotted
+  //
+
+  ::slotted(forge-scaffold) {
+    height: auto;
+  }
+
+  //
   // Base
   //
 

--- a/src/lib/dialog/forge-dialog.scss
+++ b/src/lib/dialog/forge-dialog.scss
@@ -68,6 +68,10 @@
   transition-property: display, opacity, overlay, scale;
   transition-behavior: allow-discrete;
 
+  > forge-scaffold {
+    height: auto;
+  }
+
   &--fullscreen {
     @include core.fullscreen-dialog-base;
     @include core.fullscreen-surface;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
It's common to place a `<forge-scaffold>` as the first child within a `<forge-dialog>`. Safari has a problem with this because the scaffold is set to take up 100% of its height, but the dialog uses a flex layout for the container, which essentially collapses the scaffold down to 0 height.

This change sets `height: auto` by default on a slotted `<forge-scaffold>` element to avoid this problem, which also plays nice with all browsers.
