### PR TITLE
fix(button): use grid layout instead of flex to avoid text nodes collapsing

### DIFF
--- a/src/lib/button/_core.scss
+++ b/src/lib/button/_core.scss
@@ -16,6 +16,7 @@
 
   position: relative;
   display: #{token(display)};
+  grid-auto-flow: column;
   align-items: center;
   justify-content: #{token(justify)};
   gap: #{token(spacing)};

--- a/src/lib/core/styles/tokens/button/_tokens.scss
+++ b/src/lib/core/styles/tokens/button/_tokens.scss
@@ -14,7 +14,7 @@ $tokens: (
   text-color: utils.module-ref(button, text-color, primary-color),
   disabled-color: utils.module-val(button, disabled-color, theme.variable(surface-container)),
   padding: utils.module-val(button, padding, spacing.variable(medium)),
-  display: utils.module-val(button, display, inline-flex),
+  display: utils.module-val(button, display, inline-grid),
   justify: utils.module-val(button, justify, center),
   shape: utils.module-val(button, shape, shape.variable(medium)),
   // Base
@@ -28,7 +28,7 @@ $tokens: (
   shape-start-end-radius: utils.module-ref(button, shape-start-end-radius, shape),
   shape-end-start-radius: utils.module-ref(button, shape-end-start-radius, shape),
   shape-end-end-radius: utils.module-ref(button, shape-end-end-radius, shape),
-  padding-block: utils.module-ref(button, padding-block, padding),
+  padding-block: utils.module-ref(button, padding-block, 0),
   padding-inline: utils.module-ref(button, padding-inline, padding),
   background: utils.module-val(button, background, transparent),
   hover-background: utils.module-ref(button, hover-background, background),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Switch to a grid layout instead of flex to allow for the button to control its layout, rather than relying on slotted children for dimensions.

Additionally, now that grid is used, I've set the default block padding to `0` because it was interfering with the static height of the button in terms of content alignment.

## Additional information
This fixes a bug in Safari where the text nodes were collapsing due to the flex layout, and slotted selectors could not apply to text nodes to control the flex item dimensions... Using a grid layout should give more control regardless.
