### PR TITLE
feat(dialog): add "reason" for why dialog is about to close to event `detail`

### DIFF
--- a/src/lib/dialog/dialog-constants.ts
+++ b/src/lib/dialog/dialog-constants.ts
@@ -84,6 +84,9 @@ export interface IDialogMoveContext {
 }
 
 export interface IDialogMoveStartEventData extends IDialogMoveEventData {}
+export interface IDialogBeforeCloseEventData {
+  reason: DialogCloseReason;
+}
 
 export type DialogMode = 'modal' | 'inline-modal' | 'nonmodal';
 export type DialogType = 'dialog' | 'alertdialog';
@@ -92,6 +95,7 @@ export type DialogPositionStrategy = 'viewport' | 'container';
 export type DialogPlacement = 'custom' | 'center' | 'top' | 'right' | 'bottom' | 'left' | 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
 export type DialogSizeStrategy = 'content' | 'container-inline' | 'container-block';
 export type DialogPreset = 'dialog' | 'bottom-sheet' | 'top-sheet' | 'left-sheet' | 'right-sheet';
+export type DialogCloseReason = 'backdrop' | 'escape' | 'submit' | 'dismiss';
 
 export const hideBackdrop = Symbol('hideBackdrop');
 export const showBackdrop = Symbol('showBackdrop');

--- a/src/lib/dialog/dialog.test.ts
+++ b/src/lib/dialog/dialog.test.ts
@@ -512,6 +512,9 @@ describe('Dialog', () => {
     it('should close when button with formmethod="dialog" is clicked', async () => {
       const harness = await createFixture({ open: true });
 
+      const beforeCloseSpy = spy();
+      harness.dialogElement.addEventListener(DIALOG_CONSTANTS.events.BEFORE_CLOSE, beforeCloseSpy);
+
       const submitSpy = spy();
       const formEl = harness.dialogElement.querySelector('form') as HTMLFormElement;
       formEl.addEventListener('submit', submitSpy);
@@ -522,6 +525,8 @@ describe('Dialog', () => {
 
       expect(submitSpy).to.have.been.calledOnce;
       expect(harness.isOpen).to.be.false;
+      expect(beforeCloseSpy).to.have.been.calledOnce;
+      expect(beforeCloseSpy).to.have.been.calledWithMatch({ detail: { reason: 'submit' } });
     });
 
     it('should close when submit button is clicked within a form that has method="dialog"', async () => {
@@ -647,6 +652,7 @@ describe('Dialog', () => {
       await harness.pressEscapeKey();
 
       expect(beforeCloseSpy).to.have.been.calledOnce;
+      expect(beforeCloseSpy).to.have.been.calledWithMatch({ detail: { reason: 'escape' } });
     });
   });
 
@@ -701,6 +707,18 @@ describe('Dialog', () => {
       await harness.clickSurface();
 
       expect(harness.isOpen).to.be.true;
+    });
+
+    it('should fire before close event when closed via backdrop', async () => {
+      const harness = await createFixture({ open: true });
+
+      const beforeCloseSpy = spy();
+      harness.dialogElement.addEventListener(DIALOG_CONSTANTS.events.BEFORE_CLOSE, beforeCloseSpy);
+
+      await harness.clickOutside();
+
+      expect(beforeCloseSpy).to.have.been.calledOnce;
+      expect(beforeCloseSpy).to.have.been.calledWithMatch({ detail: { reason: 'backdrop' } });
     });
   });
 

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -268,7 +268,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  public declare open: boolean;
+  declare public open: boolean;
 
   /**
    * The mode of the dialog.
@@ -276,7 +276,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  public declare mode: DialogMode;
+  declare public mode: DialogMode;
 
   /**
    * The type of the dialog.
@@ -284,7 +284,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  public declare type: DialogType;
+  declare public type: DialogType;
 
   /**
    * The animation type of the dialog.
@@ -292,7 +292,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute animation-type
    */
   @coreProperty()
-  public declare animationType: DialogAnimationType;
+  declare public animationType: DialogAnimationType;
 
   /**
    * The preset design that the dialog will apply.
@@ -300,7 +300,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  public declare preset: DialogPreset;
+  declare public preset: DialogPreset;
 
   /**
    * Indicates whether the dialog is dismissible via escape and backdrop click or not.
@@ -308,7 +308,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  public declare persistent: boolean;
+  declare public persistent: boolean;
 
   /**
    * Indicates whether the dialog is fullscreen or not.
@@ -316,7 +316,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  public declare fullscreen: boolean;
+  declare public fullscreen: boolean;
 
   /**
    * The screen width at which the dialog will switch to fullscreen.
@@ -324,7 +324,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute fullscreen-threshold
    */
   @coreProperty()
-  public declare fullscreenThreshold: number;
+  declare public fullscreenThreshold: number;
 
   /**
    * The selector of the element that triggers the dialog.
@@ -332,14 +332,14 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  public declare trigger: string;
+  declare public trigger: string;
 
   /**
    * The element that triggers the dialog.
    * @default null
    */
   @coreProperty()
-  public declare triggerElement: HTMLElement | null;
+  declare public triggerElement: HTMLElement | null;
 
   /**
    * Indicates whether the dialog is moveable or not.
@@ -347,7 +347,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  public declare moveable: boolean;
+  declare public moveable: boolean;
 
   /**
    * Controls whether the dialog is rendered relative to the viewport or its nearest containing block.
@@ -355,7 +355,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute position-strategy
    */
   @coreProperty()
-  public declare positionStrategy: DialogPositionStrategy;
+  declare public positionStrategy: DialogPositionStrategy;
 
   /**
    * Controls the block and/or inline size of the dialog. Defaults to the size of the content it contains.
@@ -363,7 +363,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute size-strategy
    */
   @coreProperty()
-  public declare sizeStrategy: DialogSizeStrategy;
+  declare public sizeStrategy: DialogSizeStrategy;
 
   /**
    * The placement of the dialog.
@@ -371,7 +371,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  public declare placement: DialogPlacement;
+  declare public placement: DialogPlacement;
 
   /**
    * The accessible label of the dialog.
@@ -379,7 +379,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  public declare label: string;
+  declare public label: string;
 
   /**
    * The accessible description of the dialog.
@@ -387,7 +387,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  public declare description: string;
+  declare public description: string;
 
   /** Shows the dialog. */
   public show(): void {

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -14,6 +14,7 @@ import {
   DialogPreset,
   DialogSizeStrategy,
   DialogType,
+  IDialogBeforeCloseEventData,
   IDialogMoveEventData,
   IDialogMoveStartEventData,
   dialogStack,
@@ -59,7 +60,7 @@ declare global {
   interface HTMLElementEventMap {
     'forge-dialog-open': CustomEvent<void>;
     'forge-dialog-close': CustomEvent<void>;
-    'forge-dialog-before-close': CustomEvent<void>;
+    'forge-dialog-before-close': CustomEvent<IDialogBeforeCloseEventData>;
     'forge-dialog-move-start': CustomEvent<IDialogMoveStartEventData>;
     'forge-dialog-move': CustomEvent<IDialogMoveEventData>;
     'forge-dialog-move-end': CustomEvent<void>;
@@ -84,7 +85,7 @@ declare global {
  *
  * @event {CustomEvent<void>} forge-dialog-open - Dispatched when the dialog is opened.
  * @event {CustomEvent<void>} forge-dialog-close - Dispatched when the dialog is closed.
- * @event {CustomEvent<void>} forge-dialog-before-close - Dispatched before the dialog is closed. This event is cancelable.
+ * @event {CustomEvent<IDialogBeforeCloseEventData>} forge-dialog-before-close - Dispatched before the dialog is closed. This event is cancelable.
  * @event {CustomEvent<IDialogMoveStartEventData>} forge-dialog-move-start - Dispatched when the dialog is first moved.
  * @event {CustomEvent<IDialogMoveEventData>} forge-dialog-move - Dispatched when the dialog is being moved.
  * @event {CustomEvent<void>} forge-dialog-move-end - Dispatched when the dialog is done being moved.
@@ -194,7 +195,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
   }
 
   public [tryDismiss](_state?: IDismissibleStackState<string> | undefined): boolean {
-    return this._core.dispatchBeforeCloseEvent();
+    return this._core.dispatchBeforeCloseEvent('dismiss');
   }
 
   constructor() {
@@ -267,7 +268,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  declare public open: boolean;
+  public declare open: boolean;
 
   /**
    * The mode of the dialog.
@@ -275,7 +276,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  declare public mode: DialogMode;
+  public declare mode: DialogMode;
 
   /**
    * The type of the dialog.
@@ -283,7 +284,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  declare public type: DialogType;
+  public declare type: DialogType;
 
   /**
    * The animation type of the dialog.
@@ -291,7 +292,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute animation-type
    */
   @coreProperty()
-  declare public animationType: DialogAnimationType;
+  public declare animationType: DialogAnimationType;
 
   /**
    * The preset design that the dialog will apply.
@@ -299,7 +300,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  declare public preset: DialogPreset;
+  public declare preset: DialogPreset;
 
   /**
    * Indicates whether the dialog is dismissible via escape and backdrop click or not.
@@ -307,7 +308,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  declare public persistent: boolean;
+  public declare persistent: boolean;
 
   /**
    * Indicates whether the dialog is fullscreen or not.
@@ -315,7 +316,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  declare public fullscreen: boolean;
+  public declare fullscreen: boolean;
 
   /**
    * The screen width at which the dialog will switch to fullscreen.
@@ -323,7 +324,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute fullscreen-threshold
    */
   @coreProperty()
-  declare public fullscreenThreshold: number;
+  public declare fullscreenThreshold: number;
 
   /**
    * The selector of the element that triggers the dialog.
@@ -331,14 +332,14 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  declare public trigger: string;
+  public declare trigger: string;
 
   /**
    * The element that triggers the dialog.
    * @default null
    */
   @coreProperty()
-  declare public triggerElement: HTMLElement | null;
+  public declare triggerElement: HTMLElement | null;
 
   /**
    * Indicates whether the dialog is moveable or not.
@@ -346,7 +347,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  declare public moveable: boolean;
+  public declare moveable: boolean;
 
   /**
    * Controls whether the dialog is rendered relative to the viewport or its nearest containing block.
@@ -354,7 +355,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute position-strategy
    */
   @coreProperty()
-  declare public positionStrategy: DialogPositionStrategy;
+  public declare positionStrategy: DialogPositionStrategy;
 
   /**
    * Controls the block and/or inline size of the dialog. Defaults to the size of the content it contains.
@@ -362,7 +363,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute size-strategy
    */
   @coreProperty()
-  declare public sizeStrategy: DialogSizeStrategy;
+  public declare sizeStrategy: DialogSizeStrategy;
 
   /**
    * The placement of the dialog.
@@ -370,7 +371,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  declare public placement: DialogPlacement;
+  public declare placement: DialogPlacement;
 
   /**
    * The accessible label of the dialog.
@@ -378,7 +379,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  declare public label: string;
+  public declare label: string;
 
   /**
    * The accessible description of the dialog.
@@ -386,7 +387,7 @@ export class DialogComponent extends WithDefaultAria(WithElementInternals(BaseCo
    * @attribute
    */
   @coreProperty()
-  declare public description: string;
+  public declare description: string;
 
   /** Shows the dialog. */
   public show(): void {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The `forge-dialog-before-close` custom event will now contain an object in its `detail` property that provides the `reason` as to why the dialog is closing. This event will dispatch whenever a light dismiss action occurs (which will provide whether the escape key was pressed or the backdrop was clicked to trigger the light dismiss), or when the dialog is closed via `formmethod="dialog"` submission.

## Additional information
This primarily exposes the ability for developers to handle light dismiss actions differently whether that is triggered via escape key press or backdrop click, and potentially handle those to actions differently if desired.

Ideally light dismiss should be controlled via `persistent` as a whole, but there may be scenarios where handling each action differently is necessary.
