### PR TITLE
chore: revert `eslint-config-prettier` version upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "commitlint": "^19.8.0",
         "cssbeautify": "^0.3.1",
         "custom-element-vs-code-integration": "^1.5.0",
-        "eslint-config-prettier": "^10.1.1",
+        "eslint-config-prettier": "^9.1.0",
         "eslint-formatter-codeframe": "^7.32.1",
         "eslint-plugin-prettier": "^5.2.3",
         "http-server": "^14.1.1",
@@ -9799,9 +9799,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.1.tgz",
-      "integrity": "sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "commitlint": "^19.8.0",
     "cssbeautify": "^0.3.1",
     "custom-element-vs-code-integration": "^1.5.0",
-    "eslint-config-prettier": "^10.1.1",
+    "eslint-config-prettier": "^9.1.0",
     "eslint-formatter-codeframe": "^7.32.1",
     "eslint-plugin-prettier": "^5.2.3",
     "http-server": "^14.1.1",


### PR DESCRIPTION
This was causing an issue with vscodes prettier plugin. Reverting temporarily until that is fixed.