### PR TITLE
fix(app-bar-profile-button): adjust default tooltip placement

### DIFF
--- a/src/lib/app-bar/profile-button/app-bar-profile-button.html
+++ b/src/lib/app-bar/profile-button/app-bar-profile-button.html
@@ -2,5 +2,5 @@
   <forge-icon-button>
     <forge-avatar aria-hidden="true"></forge-avatar>
   </forge-icon-button>
-  <forge-tooltip type="label" placement="bottom">View profile</forge-tooltip>
+  <forge-tooltip type="label" placement="bottom-end">View profile</forge-tooltip>
 </template>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The `<forge-app-bar-profile-button>` component is intended to be the placed in the `end` slot of the `<forge-app-bar>` and therefore its default tooltip placement should reflect that and position itself to the `bottom-end` to avoid potential dynamic position updates from covering other app bar content.
