### PR TITLE
fix(profile-card): focus profile button before sign out button if available

### DIFF
--- a/src/lib/profile-card/profile-card-core.ts
+++ b/src/lib/profile-card/profile-card-core.ts
@@ -41,10 +41,10 @@ export class ProfileCardCore implements IProfileCardCore {
   }
 
   public focus(options?: FocusOptions): void {
-    if (this._showSignOutButton) {
-      this._adapter.requestSignOutButtonFocus({ ...options, focusVisible: true });
-    } else if (this._showProfileButton) {
+    if (this._showProfileButton) {
       this._adapter.requestProfileButtonFocus({ ...options, focusVisible: true });
+    } else if (this._showSignOutButton) {
+      this._adapter.requestSignOutButtonFocus({ ...options, focusVisible: true });
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Will now focus the profile button element before the sign out button if it's visible, given that it's the least destructive action and it is rendered first in the DOM order.
