### PR TITLE
fix(autocomplete): fixed an issue where aria-controls attr was being removed when the popover closed

### DIFF
--- a/src/lib/autocomplete/autocomplete-adapter.ts
+++ b/src/lib/autocomplete/autocomplete-adapter.ts
@@ -119,8 +119,8 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
     this.setBusyVisibility(false);
     this._tryToggleDropdownIconRotation(false);
     this._inputElement?.removeAttribute('aria-activedescendant');
-    this._inputElement?.removeAttribute('aria-controls');
     this._inputElement?.setAttribute('aria-expanded', 'false');
+    setAriaControls(this._inputElement);
 
     if (!this._listDropdown) {
       return;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: [Y]
- Docs have been added/updated: [N]
- Does this PR introduce a breaking change? [N]
- I have linked any related GitHub issues to be closed when this PR is merged? [N]

## Describe the new behavior?
There was an issue with the autocomplete component where running ARC toolkit works fine on an initial page scan. But if you opened the dropdown and then closed it, the aria-controls attribute was being removed from the input element.
