### PR TITLE
fix: updated how overlay positioning is handled when overflowing the viewport bounds

### DIFF
--- a/src/lib/core/utils/position-utils.ts
+++ b/src/lib/core/utils/position-utils.ts
@@ -1,38 +1,24 @@
 import {
+  arrow as arrowMiddleware,
+  ArrowOptions,
   computePosition,
   flip as flipMiddleware,
-  hide as hideMiddleware,
-  shift as shiftMiddleware,
-  offset as offsetMiddleware,
-  arrow as arrowMiddleware,
   FlipOptions,
-  ShiftOptions,
+  hide as hideMiddleware,
   HideOptions,
   Middleware,
-  Placement,
-  Strategy,
-  OffsetOptions,
   MiddlewareData,
-  ArrowOptions,
-  MiddlewareState
+  offset as offsetMiddleware,
+  OffsetOptions,
+  Placement,
+  shift as shiftMiddleware,
+  ShiftOptions,
+  Strategy
 } from '@floating-ui/dom';
-import { getContainingBlock, isContainingBlock, getWindow } from '@floating-ui/utils/dom';
 import { roundByDPR } from './utils';
 
 export type PositionPlacement = Placement;
 export type PositionStrategy = Strategy;
-
-export const DEFAULT_FALLBACK_PLACEMENTS: PositionPlacement[] = [
-  'top-start',
-  'top',
-  'top-end',
-  'left-start',
-  'left',
-  'left-end',
-  'right-start',
-  'right',
-  'right-end'
-];
 
 export interface IPositionElementResult {
   x: number;
@@ -129,10 +115,7 @@ export async function positionElementAsync({
   strategy = 'fixed',
   apply = true,
   flip = true,
-  flipOptions = {
-    fallbackPlacements: DEFAULT_FALLBACK_PLACEMENTS,
-    fallbackStrategy: 'initialPlacement'
-  },
+  flipOptions,
   shift = true,
   shiftOptions,
   hide = false,
@@ -149,11 +132,11 @@ export async function positionElementAsync({
   if (offset) {
     middleware.push(offsetMiddleware(offsetOptions));
   }
-  if (shift) {
-    middleware.push(shiftMiddleware(shiftOptions));
-  }
   if (flip) {
     middleware.push(flipMiddleware(flipOptions));
+  }
+  if (shift) {
+    middleware.push(shiftMiddleware(shiftOptions));
   }
   if (hide) {
     middleware.push(hideMiddleware(hideOptions));
@@ -175,11 +158,10 @@ export async function positionElementAsync({
 
     Object.assign(element.style, styles);
 
-    // We use `display` here to ensure that any child overlays are also hidden
     if (middlewareData.hide?.referenceHidden) {
-      element.style.display = 'none';
+      element.style.visibility = 'hidden';
     } else {
-      element.style.removeProperty('display');
+      element.style.removeProperty('visibility');
     }
   }
 

--- a/src/lib/overlay/base/base-overlay-core.ts
+++ b/src/lib/overlay/base/base-overlay-core.ts
@@ -1,6 +1,6 @@
 import { IBaseAdapter } from '../../core';
 import { PositionPlacement, VirtualElement } from '../../core/utils/position-utils';
-import { IOverlayOffset, OverlayFlipState, OverlayHideState, OverlayPlacement, OverlayPositionStrategy } from '../overlay-constants';
+import { IOverlayOffset, OverlayFlipState, OverlayHideState, OverlayPlacement, OverlayPositionStrategy, OverlayShiftState } from '../overlay-constants';
 
 export interface IBaseOverlayCore {
   initialize(): void;
@@ -15,7 +15,7 @@ export interface IBaseOverlayCore {
   offset: IOverlayOffset;
   hide: OverlayHideState;
   persistent: boolean;
-  shift: boolean;
+  shift: OverlayShiftState;
   flip: OverlayFlipState;
   boundary: string | null;
   boundaryElement: HTMLElement | null;
@@ -39,7 +39,7 @@ export abstract class BaseOverlayCore<T extends IBaseAdapter> implements IBaseOv
   public abstract offset: IOverlayOffset;
   public abstract hide: OverlayHideState;
   public abstract persistent: boolean;
-  public abstract shift: boolean;
+  public abstract shift: OverlayShiftState;
   public abstract flip: OverlayFlipState;
   public abstract boundary: string | null;
   public abstract boundaryElement: HTMLElement | null;

--- a/src/lib/overlay/base/base-overlay.ts
+++ b/src/lib/overlay/base/base-overlay.ts
@@ -1,7 +1,15 @@
 import { coerceBoolean, coreProperty } from '@tylertech/forge-core';
 import { BaseComponent, IBaseComponent } from '../../core/base/base-component';
 import { IBaseOverlayCore } from './base-overlay-core';
-import { IOverlayOffset, OverlayFlipState, OverlayHideState, OverlayPlacement, OverlayPositionStrategy, OVERLAY_CONSTANTS } from '../overlay-constants';
+import {
+  IOverlayOffset,
+  OverlayFlipState,
+  OverlayHideState,
+  OverlayPlacement,
+  OverlayPositionStrategy,
+  OVERLAY_CONSTANTS,
+  OverlayShiftState
+} from '../overlay-constants';
 import { coerceStringToArray } from '../../core/utils';
 import { PositionPlacement, VirtualElement } from '../../core/utils/position-utils';
 
@@ -14,7 +22,7 @@ export interface IBaseOverlay extends IBaseComponent {
   placement: OverlayPlacement;
   positionStrategy: OverlayPositionStrategy;
   offset: IOverlayOffset;
-  shift: boolean;
+  shift: OverlayShiftState;
   hide: OverlayHideState;
   persistent: boolean;
   flip: OverlayFlipState;
@@ -62,7 +70,15 @@ export abstract class BaseOverlay<T extends IBaseOverlayCore> extends BaseCompon
         this.persistent = coerceBoolean(newValue);
         break;
       case OVERLAY_CONSTANTS.observedAttributes.SHIFT:
-        this.shift = coerceBoolean(newValue);
+        // Handle legacy boolean attributes for shift by converting to corresponding type values
+        // TODO: Remove support for boolean attribute conversion in v4
+        if (newValue === '' || newValue?.trim() === 'true') {
+          this.shift = 'auto';
+        } else if (newValue == null || newValue?.trim() === 'false') {
+          this.shift = 'never';
+        } else {
+          this.shift = newValue as OverlayShiftState;
+        }
         break;
       case OVERLAY_CONSTANTS.observedAttributes.FLIP:
         this.flip = newValue as OverlayFlipState;
@@ -101,7 +117,7 @@ export abstract class BaseOverlay<T extends IBaseOverlayCore> extends BaseCompon
   declare public offset: IOverlayOffset;
 
   @coreProperty()
-  declare public shift: boolean;
+  declare public shift: OverlayShiftState;
 
   @coreProperty()
   declare public hide: OverlayHideState;

--- a/src/lib/overlay/base/overlay-aware-core.ts
+++ b/src/lib/overlay/base/overlay-aware-core.ts
@@ -1,8 +1,17 @@
 import { IBaseOverlayCore } from './base-overlay-core';
 import { IOverlayComponent } from '../overlay';
 import { IOverlayAwareAdapter } from './overlay-aware-adapter';
-import { IOverlayOffset, OverlayFlipState, OverlayHideState, OverlayPlacement, OverlayPositionStrategy, OVERLAY_CONSTANTS } from '../overlay-constants';
+import {
+  IOverlayOffset,
+  OverlayFlipState,
+  OverlayHideState,
+  OverlayPlacement,
+  OverlayPositionStrategy,
+  OVERLAY_CONSTANTS,
+  OverlayShiftState
+} from '../overlay-constants';
 import { PositionPlacement, VirtualElement } from '../../core/utils/position-utils';
+import { toggleAttribute } from '@tylertech/forge-core';
 
 export interface IOverlayAwareCore extends IBaseOverlayCore {
   readonly overlayElement: IOverlayComponent;
@@ -135,13 +144,18 @@ export abstract class OverlayAwareCore<T extends IOverlayAwareAdapter> implement
     }
   }
 
-  public get shift(): boolean {
+  public get shift(): OverlayShiftState {
     return this._adapter.overlayElement.shift;
   }
-  public set shift(value: boolean) {
+  public set shift(value: OverlayShiftState) {
     if (this._adapter.overlayElement.shift !== value) {
       this._adapter.overlayElement.shift = value;
-      this._adapter.toggleHostAttribute(OVERLAY_CONSTANTS.attributes.SHIFT, this._adapter.overlayElement.shift);
+      toggleAttribute(
+        this._adapter.hostElement,
+        this._adapter.overlayElement.shift !== OVERLAY_CONSTANTS.defaults.SHIFT,
+        OVERLAY_CONSTANTS.attributes.SHIFT,
+        String(this._adapter.overlayElement.shift)
+      );
     }
   }
 

--- a/src/lib/overlay/overlay-adapter.ts
+++ b/src/lib/overlay/overlay-adapter.ts
@@ -174,12 +174,17 @@ export class OverlayAdapter extends BaseAdapter<IOverlayComponent> implements IO
       const viewportWidth = Math.max(document.documentElement.clientWidth, window.innerWidth);
       const viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight);
       const overlayRect = this._rootElement.getBoundingClientRect();
-      const isClippedX = overlayRect.right > viewportWidth || overlayRect.left < 0;
-      const isClippedY = overlayRect.bottom > viewportHeight || overlayRect.top < 0;
+      const isClippedX = overlayRect.right > viewportWidth;
+      const isClippedY = overlayRect.bottom > viewportHeight;
 
       // Update the clipped attributes to allow for state-based clipping adjustments by consumers
-      this._component.toggleAttribute(OVERLAY_CONSTANTS.attributes.CLIPPED_X, isClippedX);
-      this._component.toggleAttribute(OVERLAY_CONSTANTS.attributes.CLIPPED_Y, isClippedY);
+      // We only set these attributes once to avoid it triggering an auto-reposition loop. The attributes will be removed when the dropdown is closed.
+      if (isClippedX) {
+        this._component.setAttribute(OVERLAY_CONSTANTS.attributes.CLIPPED_X, '');
+      }
+      if (isClippedY) {
+        this._component.setAttribute(OVERLAY_CONSTANTS.attributes.CLIPPED_Y, '');
+      }
     });
   }
 

--- a/src/lib/overlay/overlay-adapter.ts
+++ b/src/lib/overlay/overlay-adapter.ts
@@ -1,18 +1,18 @@
 import { autoUpdate, Boundary } from '@floating-ui/dom';
 import { getShadowElement } from '@tylertech/forge-core';
 import { BaseAdapter, IBaseAdapter } from '../core/base/base-adapter';
-import { DEFAULT_FALLBACK_PLACEMENTS, positionElementAsync, PositionPlacement, VirtualElement } from '../core/utils/position-utils';
-import { locateElementById, roundByDPR } from '../core/utils/utils';
+import { positionElementAsync, PositionPlacement, VirtualElement } from '../core/utils/position-utils';
+import { locateElementById } from '../core/utils/utils';
 import { IOverlayComponent, OverlayComponent } from './overlay';
 import {
   IOverlayOffset,
+  OVERLAY_CONSTANTS,
   OverlayFlipState,
   OverlayHideState,
   OverlayLightDismissReason,
   OverlayPositionStrategy,
+  OverlayShiftState,
   overlayStack,
-  OVERLAY_CONSTANTS,
-  OVERLAY_FALLBACK_PLACEMENT_MAP,
   SUPPORTS_POPOVER
 } from './overlay-constants';
 
@@ -34,7 +34,7 @@ export interface IPositionElementConfig {
   placement: PositionPlacement;
   hide: OverlayHideState;
   offset: IOverlayOffset;
-  shift: boolean;
+  shift: OverlayShiftState;
   flip: OverlayFlipState;
   boundary: string | null;
   boundaryElement: HTMLElement | null;
@@ -132,14 +132,14 @@ export class OverlayAdapter extends BaseAdapter<IOverlayComponent> implements IO
         strategy,
         placement,
         hide: hide !== 'never',
-        shift,
+        shift: shift !== 'never',
         shiftOptions: {
           boundary: boundaryEl
         },
         flip: flip !== 'never',
         flipOptions: {
-          fallbackStrategy: 'bestFit',
-          fallbackPlacements: fallbackPlacements ?? OVERLAY_FALLBACK_PLACEMENT_MAP[placement] ?? DEFAULT_FALLBACK_PLACEMENTS,
+          boundary: boundaryEl,
+          fallbackPlacements,
           crossAxis: flip === 'cross' || flip === 'auto',
           mainAxis: flip === 'main' || flip === 'auto'
         },
@@ -180,15 +180,6 @@ export class OverlayAdapter extends BaseAdapter<IOverlayComponent> implements IO
       // Update the clipped attributes to allow for state-based clipping adjustments by consumers
       this._component.toggleAttribute(OVERLAY_CONSTANTS.attributes.CLIPPED_X, isClippedX);
       this._component.toggleAttribute(OVERLAY_CONSTANTS.attributes.CLIPPED_Y, isClippedY);
-
-      // If clipped, adjust the position by the clipping delta on each axis
-      if (isClippedX || isClippedY) {
-        const { x, y } = result;
-        const { height, width } = overlayRect;
-        const clippedDeltaX = isClippedX ? x + width - viewportWidth : 0;
-        const clippedDeltaY = isClippedY ? y + height - viewportHeight : 0;
-        this._rootElement.style.translate = `${roundByDPR(x - clippedDeltaX)}px ${roundByDPR(y - clippedDeltaY)}px`;
-      }
     });
   }
 

--- a/src/lib/overlay/overlay-constants.ts
+++ b/src/lib/overlay/overlay-constants.ts
@@ -41,7 +41,8 @@ const events = {
 
 const defaults = {
   HIDE: 'anchor-hidden' satisfies OverlayHideState,
-  FLIP: 'auto' satisfies OverlayFlipState
+  FLIP: 'auto' satisfies OverlayFlipState,
+  SHIFT: 'auto' satisfies OverlayShiftState
 } as const;
 
 export const OVERLAY_CONSTANTS = {
@@ -66,6 +67,7 @@ export type OverlayPositionStrategy = 'absolute' | 'fixed';
 export type OverlayPlacement = PositionPlacement;
 export type OverlayHideState = 'anchor-hidden' | 'never';
 export type OverlayFlipState = 'auto' | 'main' | 'cross' | 'never';
+export type OverlayShiftState = 'auto' | 'never' | boolean;
 export type OverlayLightDismissReason = 'click' | 'escape';
 
 export interface IOverlayToggleEvent extends Event {
@@ -77,29 +79,3 @@ export interface OverlayLightDismissEventData {
 }
 
 export const overlayStack = Symbol('overlayStack');
-
-/**
- * This is a map of fallback placements for each placement. The fallback placements are used when the
- * original placement is not possible due to the boundary or other constraints.
- */
-export const OVERLAY_FALLBACK_PLACEMENT_MAP: Record<OverlayPlacement, OverlayPlacement[]> = {
-  // Left
-  left: ['right', 'bottom', 'top', 'top-start', 'top-end', 'left-start', 'left-end', 'right-start', 'right-end'],
-  'left-start': ['left-end', 'right-start', 'right-end', 'bottom', 'top'],
-  'left-end': ['left-start', 'right-end', 'right-start', 'bottom', 'top', 'bottom-start', 'bottom-end'],
-
-  // Right
-  right: ['left', 'bottom', 'top', 'top-start', 'top-end', 'left-start', 'left-end', 'right-start', 'right-end'],
-  'right-start': ['right-end', 'left-start', 'left-end', 'bottom', 'top'],
-  'right-end': ['right-start', 'left-end', 'left-start', 'bottom', 'top', 'bottom-start', 'bottom-end'],
-
-  // Top
-  top: ['bottom', 'left', 'right', 'bottom-start', 'left-start', 'left-end', 'right-start', 'right-end'],
-  'top-start': ['bottom-start', 'left', 'right', 'left-start', 'left-end', 'right-start', 'right-end'],
-  'top-end': ['bottom-end', 'left', 'right', 'right-start', 'right-end', 'left-start', 'left-end'],
-
-  // Bottom
-  bottom: ['top', 'left', 'right', 'top-start', 'left-start', 'left-end', 'right-start', 'right-end'],
-  'bottom-start': ['top-start', 'left', 'right', 'left-start', 'left-end', 'right-start', 'right-end'],
-  'bottom-end': ['top-end', 'left', 'right', 'right-start', 'right-end', 'left-start', 'left-end']
-};

--- a/src/lib/overlay/overlay-core.ts
+++ b/src/lib/overlay/overlay-core.ts
@@ -10,7 +10,8 @@ import {
   OVERLAY_CONSTANTS,
   OverlayFlipState,
   OverlayHideState,
-  OverlayLightDismissReason
+  OverlayLightDismissReason,
+  OverlayShiftState
 } from './overlay-constants';
 
 export interface IOverlayCore extends IBaseOverlayCore {
@@ -27,7 +28,7 @@ export class OverlayCore extends BaseOverlayCore<IOverlayAdapter> implements IOv
   private _placement: OverlayPlacement = 'bottom';
   private _positionStrategy: OverlayPositionStrategy = 'fixed';
   private _offset: IOverlayOffset = {};
-  private _shift = false;
+  private _shift = OVERLAY_CONSTANTS.defaults.SHIFT as OverlayShiftState;
   private _hide = OVERLAY_CONSTANTS.defaults.HIDE as OverlayHideState;
   private _flip = OVERLAY_CONSTANTS.defaults.FLIP as OverlayFlipState;
   private _boundary: string | null;
@@ -257,17 +258,26 @@ export class OverlayCore extends BaseOverlayCore<IOverlayAdapter> implements IOv
     }
   }
 
-  public get shift(): boolean {
+  public get shift(): OverlayShiftState {
     return this._shift;
   }
-  public set shift(value: boolean) {
-    value = Boolean(value);
+  public set shift(value: OverlayShiftState) {
+    // Handle legacy boolean values for shift by converting them to the corresponding type value
+    // TODO: Remove support for boolean values in v4
+    if (value === true) {
+      value = 'auto';
+    } else if (value === false) {
+      value = 'never';
+    } else if (!['auto', 'never'].includes(value as any)) {
+      value = OVERLAY_CONSTANTS.defaults.SHIFT;
+    }
+
     if (this._shift !== value) {
       this._shift = value;
       if (this._open) {
         this.position();
       }
-      this._adapter.toggleHostAttribute(OVERLAY_CONSTANTS.attributes.SHIFT, this._shift);
+      this._adapter.setHostAttribute(OVERLAY_CONSTANTS.attributes.SHIFT, this._shift);
     }
   }
 

--- a/src/lib/overlay/overlay.test.ts
+++ b/src/lib/overlay/overlay.test.ts
@@ -4,7 +4,7 @@ import { spy } from 'sinon';
 import { sendMouse, sendKeys } from '@web/test-runner-commands';
 import { elementUpdated, fixture, html } from '@open-wc/testing';
 import { IOverlayComponent, OverlayComponent } from './overlay';
-import { OverlayFlipState, OverlayHideState, overlayStack, OVERLAY_CONSTANTS } from './overlay-constants';
+import { OverlayFlipState, OverlayHideState, overlayStack, OVERLAY_CONSTANTS, OverlayShiftState } from './overlay-constants';
 import { IOverlayAdapter, OverlayAdapter } from './overlay-adapter';
 
 import './overlay';
@@ -34,7 +34,7 @@ describe('Overlay', () => {
       expect(harness.overlayElement.placement).to.equal('bottom');
       expect(harness.overlayElement.positionStrategy).to.equal('fixed');
       expect(harness.overlayElement.offset).to.deep.equal({});
-      expect(harness.overlayElement.shift).to.be.false;
+      expect(harness.overlayElement.shift).to.equal('auto');
       expect(harness.overlayElement.hide).to.equal('anchor-hidden' satisfies OverlayHideState);
       expect(harness.overlayElement.persistent).to.be.false;
       expect(harness.overlayElement.flip).to.equal('auto' as OverlayFlipState);
@@ -366,10 +366,45 @@ describe('Overlay', () => {
     });
 
     it('should set shift', async () => {
-      const harness = await createFixture({ open: true, shift: true });
+      const harness = await createFixture({ open: true, shift: 'never' });
 
-      expect(harness.overlayElement.shift).to.be.true;
+      expect(harness.overlayElement.shift).to.equal('never');
       expect(harness.overlayElement.hasAttribute(OVERLAY_CONSTANTS.attributes.SHIFT)).to.be.true;
+      expect(harness.overlayElement.getAttribute(OVERLAY_CONSTANTS.attributes.SHIFT)).to.equal('never');
+    });
+
+    it('should set shift as boolean for backwards compatibility', async () => {
+      const harness = await createFixture();
+      expect(harness.overlayElement.shift).to.equal('auto');
+
+      harness.overlayElement.shift = false;
+      expect(harness.overlayElement.shift).to.equal('never');
+
+      harness.overlayElement.shift = true;
+      expect(harness.overlayElement.shift).to.equal('auto');
+    });
+
+    it('should set shift as boolean attribute for backwards compatibility', async () => {
+      const harness = await createFixture();
+
+      harness.overlayElement.setAttribute(OVERLAY_CONSTANTS.attributes.SHIFT, '');
+      expect(harness.overlayElement.shift).to.equal('auto');
+
+      harness.overlayElement.removeAttribute(OVERLAY_CONSTANTS.attributes.SHIFT);
+      expect(harness.overlayElement.shift).to.equal('never');
+
+      harness.overlayElement.setAttribute(OVERLAY_CONSTANTS.attributes.SHIFT, 'true');
+      expect(harness.overlayElement.shift).to.equal('auto');
+    });
+
+    it('should handle invalid shift values', async () => {
+      const harness = await createFixture({ open: true });
+
+      harness.overlayElement.shift = 'invalid' as any;
+      expect(harness.overlayElement.shift).to.equal('auto');
+
+      harness.overlayElement.shift = null as any;
+      expect(harness.overlayElement.shift).to.equal('auto');
     });
 
     it('should set position strategy', async () => {
@@ -451,7 +486,7 @@ describe('Overlay', () => {
       harness.overlayElement.placement = 'top';
       harness.overlayElement.positionStrategy = 'absolute';
       harness.overlayElement.offset = { mainAxis: 10, crossAxis: 10 };
-      harness.overlayElement.shift = true;
+      harness.overlayElement.shift = 'never';
       harness.overlayElement.hide = 'never';
       harness.overlayElement.flip = 'main';
       harness.overlayElement.boundary = 'test-boundary';
@@ -522,7 +557,7 @@ describe('Overlay', () => {
 
       await harness.positionUpdated();
 
-      expect(harness.rootElement.style.display).to.equal('none');
+      expect(harness.rootElement.style.visibility).to.equal('hidden');
     });
 
     it('should not hide when anchor element is not visible and hide is false', async () => {
@@ -683,7 +718,7 @@ interface IOverlayFixtureConfig {
   boundary?: string | null;
   fallbackPlacements?: string | null;
   positionStrategy?: string | null;
-  shift?: boolean;
+  shift?: OverlayShiftState;
 }
 
 async function createFixture({
@@ -697,7 +732,7 @@ async function createFixture({
   boundary = null,
   fallbackPlacements = null,
   positionStrategy = null,
-  shift = false
+  shift = 'auto'
 }: IOverlayFixtureConfig = {}): Promise<OverlayHarness> {
   const container = await fixture(html`
     <div style="display: flex; justify-content: center; align-items: center; height: 300px; width: 300px;" id="test-boundary">
@@ -709,7 +744,7 @@ async function createFixture({
         ?persistent=${persistent}
         flip=${flip ?? nothing}
         hide=${hide ?? nothing}
-        ?shift=${shift}
+        shift=${shift ?? nothing}
         placement=${placement ?? nothing}
         boundary=${boundary ?? nothing}
         fallback-placements=${fallbackPlacements ?? nothing}

--- a/src/lib/overlay/overlay.ts
+++ b/src/lib/overlay/overlay.ts
@@ -43,7 +43,7 @@ declare global {
  * @property {OverlayPlacement} [placement="bottom"] - The placement of the overlay relative to the anchor element.
  * @property {OverlayPositionStrategy} [positionStrategy="fixed"] - The positioning strategy to use for the overlay. Valid values are `'fixed'` and `'absolute'`.
  * @property {IOverlayPosition} offset - The offset to apply to the overlay position relative to the anchor element.
- * @property {boolean} [shift=false] - Whether or not the anchor element should shift along the side of the overlay when scrolling.
+ * @property {OverlayShiftState} [shift="auto"] - Whether or not the anchor element should shift along the side of the overlay when scrolling.
  * @property {OverlayHideState} [hide="anchor-hidden"] - Whether or not the overlay should hide itself when the anchor element is out of view.
  * @property {boolean} persistent - Whether or not the overlay handles light dismiss itself or not.
  * @property {OverlayFlipState} [flip="auto"] - Whether or not the overlay should flip to the opposite placement when not enough room.
@@ -68,7 +68,7 @@ declare global {
  * @attribute {string} [position-strategy="fixed"] - The positioning strategy to use for the overlay. Valid values are `'fixed'` and `'absolute'`.
  * @attribute {string} [hide="anchor-hidden"] - Whether or not the overlay should hide itself when the anchor element is out of view.
  * @attribute {string} persistent - Whether or not the overlay handles light dismiss itself or not.
- * @attribute {string} [shift=false] - Whether or not the anchor element should shift along the side of the overlay when scrolling.
+ * @attribute {OverlayShiftState} [shift="auto"] - Whether or not the anchor element should shift along the side of the overlay when scrolling.
  * @attribute {OverlayFlipState} [flip="auto"] - Tells the overlay not to flip to the opposite placement when not enough room.
  * @attribute {string} position-placement - The placement of the overlay around the anchor element **after** dynamic positioning. This is a read-only attribute that is only available when open.
  * @attribute {string} boundary - The id of the element to use as the boundary for the overlay.

--- a/src/lib/popover/popover.scss
+++ b/src/lib/popover/popover.scss
@@ -313,7 +313,6 @@ forge-overlay[clipped-y] {
   .forge-popover {
     height: auto;
     min-height: 0;
-    max-height: 100vh;
     overflow-y: auto;
   }
 }

--- a/src/lib/popover/popover.test.ts
+++ b/src/lib/popover/popover.test.ts
@@ -188,11 +188,11 @@ describe('Popover', () => {
     it('should proxy shift', async () => {
       const harness = await createFixture();
 
-      harness.popoverElement.shift = true;
+      harness.popoverElement.shift = 'never';
 
-      expect(harness.popoverElement.shift).to.be.true;
-      expect(harness.popoverElement.overlay.shift).to.be.true;
-      expect(harness.popoverElement.hasAttribute(OVERLAY_CONSTANTS.attributes.SHIFT)).to.be.true;
+      expect(harness.popoverElement.shift).to.equal('never');
+      expect(harness.popoverElement.overlay.shift).to.equal('never');
+      expect(harness.popoverElement.getAttribute(OVERLAY_CONSTANTS.attributes.SHIFT)).to.equal('never');
     });
 
     it('should proxy flip', async () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
- Removed usage of default fallback placements in favor of relying fully on floating-ui's computed best fit positioning strategy
- Adjusted how we handle ensuring popovers stay in view with overflow
- Enable floating-ui's shift middleware by default and adjusted typings for `shift` API on overlay to accept specific string values.
- Allow for `shift` to continue to accept boolean values for backwards compatibility.
- Use `visibility: hidden` for hide state instead of `display: none` per floating-ui docs
