### PR TITLE
fix(list-item): fix regression related to slotted `<button>` width applying to other child elements

### DIFF
--- a/src/lib/list/list-item/list-item.scss
+++ b/src/lib/list/list-item/list-item.scss
@@ -152,7 +152,7 @@ slot[name='tertiary-text'] {
 }
 
 // Button slotted elements
-::slotted(:is(button, [role='button'][tabindex], [forge-list-item-button])) {
+::slotted(:is(button:not([slot]), [forge-list-item-button])) {
   @include button;
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Ensures that slotted styles only apply to slotted `<button>` elements in the default slot. This fixes a regression caused by #860 where the slotted styles were inadvertently applying to all slotted buttons with `role="button"` (which happened to include buttons placed within other slots).
