### PR TITLE
fix(switch): improve contrast when disabled

### DIFF
--- a/src/lib/core/styles/tokens/switch/_tokens.scss
+++ b/src/lib/core/styles/tokens/switch/_tokens.scss
@@ -58,7 +58,7 @@ $tokens: (
   state-layer-dense-width: utils.module-ref(switch, state-layer-dense-width, state-layer-dense-size),
   state-layer-dense-height: utils.module-ref(switch, state-layer-dense-height, state-layer-dense-size),
   // Disabled
-  disabled-opacity: utils.module-val(switch, disabled-opacity, theme.emphasis(medium-low)),
+  disabled-opacity: utils.module-val(switch, disabled-opacity, theme.emphasis(medium)),
   // Active
   handle-active-on-color: utils.module-ref(switch, handle-active-on-color, handle-on-color),
   handle-active-off-color: utils.module-ref(switch, handle-active-off-color, handle-off-color),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Use the `medium` (0.56) color emphasis token for disabled state.

## Additional information
We've received feedback that disabled switches are too washed out. This is similar to a change we made in the past related to improving contrast on text field when disabled by increasing the opacity.

Tested the checkbox and radio, but determined those are fine at their current `medium-low` (0.38) opacity.
