### PR TITLE
chore(stepper-constants): fix to set explicit index type for compatibility

### DIFF
--- a/src/lib/stepper/stepper/stepper-constants.ts
+++ b/src/lib/stepper/stepper/stepper-constants.ts
@@ -62,7 +62,7 @@ const ACCEPTABLE_KEYS = [
   strings.TAB_KEY
 ];
 
-const KEYCODE_MAP = {
+const KEYCODE_MAP: Record<number, string> = {
   [numbers.ARROW_LEFT_KEYCODE]: strings.ARROW_LEFT_KEY,
   [numbers.ARROW_RIGHT_KEYCODE]: strings.ARROW_RIGHT_KEY,
   [numbers.END_KEYCODE]: strings.END_KEY,


### PR DESCRIPTION
Fixes compatibility issue with external bundlers that import and type check against Forge.