### PR TITLE
fix(dialog): update accessible label and description handling for improved ARIA support

### DIFF
--- a/src/lib/dialog/dialog-adapter.ts
+++ b/src/lib/dialog/dialog-adapter.ts
@@ -36,8 +36,8 @@ export class DialogAdapter extends BaseAdapter<IDialogComponent> implements IDia
   private _backdropElement: IBackdropComponent;
   private _moveHandleElement: HTMLElement;
   private _fullscreenMediaQuery: MediaQueryList | undefined;
-  private _accessibleLabelElement: HTMLElement | undefined;
-  private _accessibleDescriptionElement: HTMLElement | undefined;
+  private _accessibleLabelElement: HTMLElement;
+  private _accessibleDescriptionElement: HTMLElement;
 
   public triggerElement: HTMLElement | null;
 
@@ -52,6 +52,8 @@ export class DialogAdapter extends BaseAdapter<IDialogComponent> implements IDia
   constructor(component: IDialogComponent) {
     super(component);
     this._dialogElement = getShadowElement(component, DIALOG_CONSTANTS.selectors.DIALOG) as HTMLDialogElement;
+    this._accessibleLabelElement = getShadowElement(component, DIALOG_CONSTANTS.selectors.ACCESSIBLE_LABEL) as HTMLElement;
+    this._accessibleDescriptionElement = getShadowElement(component, DIALOG_CONSTANTS.selectors.ACCESSIBLE_DESCRIPTION) as HTMLElement;
     this._surfaceElement = getShadowElement(component, DIALOG_CONSTANTS.selectors.SURFACE) as HTMLDivElement;
     this._moveHandleElement = getShadowElement(component, DIALOG_CONSTANTS.selectors.MOVE_HANDLE) as HTMLElement;
 
@@ -207,49 +209,11 @@ export class DialogAdapter extends BaseAdapter<IDialogComponent> implements IDia
   }
 
   public setAccessibleLabel(label: string): void {
-    if (label?.trim()) {
-      this._accessibleLabelElement = this._createOrUpdateVisuallyHiddenElement(DIALOG_CONSTANTS.attributes.ARIA_LABEL_ID, label);
-      if (this._accessibleLabelElement.isConnected) {
-        return;
-      }
-      this._dialogElement.appendChild(this._accessibleLabelElement);
-      this._dialogElement.setAttribute('aria-labelledby', this._accessibleLabelElement.id);
-    } else if (this._accessibleLabelElement?.isConnected) {
-      this._dialogElement.removeAttribute('aria-labelledby');
-      this._accessibleLabelElement?.remove();
-      this._accessibleLabelElement = undefined;
-    }
+    this._accessibleLabelElement.textContent = label;
   }
 
   public setAccessibleDescription(description: string): void {
-    if (description?.trim()) {
-      this._accessibleDescriptionElement = this._createOrUpdateVisuallyHiddenElement(DIALOG_CONSTANTS.attributes.ARIA_DESCRIPTION_ID, description);
-      if (this._accessibleDescriptionElement.isConnected) {
-        return;
-      }
-      this._dialogElement.appendChild(this._accessibleDescriptionElement);
-      this._dialogElement.setAttribute('aria-describedby', this._accessibleDescriptionElement.id);
-    } else if (this._accessibleDescriptionElement?.isConnected) {
-      this._dialogElement.removeAttribute('aria-describedby');
-      this._accessibleDescriptionElement?.remove();
-      this._accessibleDescriptionElement = undefined;
-    }
-  }
-
-  private _createOrUpdateVisuallyHiddenElement(id: string, text: string): HTMLElement {
-    const content = text.trim();
-
-    let element = this._dialogElement.querySelector<HTMLElement>(`#${id}`);
-    if (element) {
-      element.textContent = content;
-      return element;
-    }
-
-    element = document.createElement('div');
-    element.classList.add('visually-hidden');
-    element.id = id;
-    element.textContent = content;
-    return element;
+    this._accessibleDescriptionElement.textContent = description;
   }
 
   private _forceClose(): void {

--- a/src/lib/dialog/dialog-constants.ts
+++ b/src/lib/dialog/dialog-constants.ts
@@ -23,9 +23,7 @@ const observedAttributes = {
 };
 
 const attributes = {
-  ...observedAttributes,
-  ARIA_LABEL_ID: 'forge-dialog-label',
-  ARIA_DESCRIPTION_ID: 'forge-dialog-description'
+  ...observedAttributes
 };
 
 const classes = {
@@ -37,7 +35,9 @@ const selectors = {
   DIALOG: '.forge-dialog',
   SURFACE: '.surface',
   MOVE_HANDLE: '.move-handle',
-  AUTOFOCUS: ':is([autofocus],[forge-dialog-focus])'
+  AUTOFOCUS: ':is([autofocus],[forge-dialog-focus])',
+  ACCESSIBLE_LABEL: '#forge-dialog-label',
+  ACCESSIBLE_DESCRIPTION: '#forge-dialog-description'
 };
 
 const events = {

--- a/src/lib/dialog/dialog.html
+++ b/src/lib/dialog/dialog.html
@@ -1,5 +1,7 @@
 <template>
-  <dialog class="forge-dialog" part="root">
+  <dialog class="forge-dialog" part="root" aria-labelledby="forge-dialog-label" aria-describedby="forge-dialog-description">
+    <div id="forge-dialog-label" class="visually-hidden"></div>
+    <div id="forge-dialog-description" class="visually-hidden"></div>
     <forge-backdrop exportparts="root:backdrop"></forge-backdrop>
     <div class="surface" part="surface">
       <div class="move-handle-container" part="move-handle-container">

--- a/src/lib/dialog/dialog.test.ts
+++ b/src/lib/dialog/dialog.test.ts
@@ -391,13 +391,13 @@ describe('Dialog', () => {
 
       await harness.showAsync();
 
-      const labelElement = harness.nativeDialogElement.querySelector(`[id="${DIALOG_CONSTANTS.attributes.ARIA_LABEL_ID}"]`) as HTMLElement;
+      const labelElement = harness.nativeDialogElement.querySelector(DIALOG_CONSTANTS.selectors.ACCESSIBLE_LABEL) as HTMLElement;
 
       expect(labelElement).to.be.ok;
       expect(labelElement.isConnected).to.be.true;
       expect(labelElement.textContent).to.equal('My dialog title');
-      expect(labelElement.id).to.equal(DIALOG_CONSTANTS.attributes.ARIA_LABEL_ID);
-      expect(harness.nativeDialogElement.getAttribute('aria-labelledby')).to.equal(DIALOG_CONSTANTS.attributes.ARIA_LABEL_ID);
+      expect(labelElement.id).to.equal('forge-dialog-label');
+      expect(harness.nativeDialogElement.getAttribute('aria-labelledby')).to.equal('forge-dialog-label');
       await expect(harness.dialogElement).to.be.accessible();
     });
 
@@ -406,13 +406,13 @@ describe('Dialog', () => {
 
       await harness.showAsync();
 
-      const descriptionElement = harness.nativeDialogElement.querySelector(`[id="${DIALOG_CONSTANTS.attributes.ARIA_DESCRIPTION_ID}"]`) as HTMLElement;
+      const descriptionElement = harness.nativeDialogElement.querySelector(DIALOG_CONSTANTS.selectors.ACCESSIBLE_DESCRIPTION) as HTMLElement;
 
       expect(descriptionElement).to.be.ok;
       expect(descriptionElement.isConnected).to.be.true;
       expect(descriptionElement.textContent).to.equal('My dialog description');
-      expect(descriptionElement.id).to.equal(DIALOG_CONSTANTS.attributes.ARIA_DESCRIPTION_ID);
-      expect(harness.nativeDialogElement.getAttribute('aria-describedby')).to.equal(DIALOG_CONSTANTS.attributes.ARIA_DESCRIPTION_ID);
+      expect(descriptionElement.id).to.equal('forge-dialog-description');
+      expect(harness.nativeDialogElement.getAttribute('aria-describedby')).to.equal('forge-dialog-description');
       await expect(harness.dialogElement).to.be.accessible();
     });
 
@@ -421,8 +421,8 @@ describe('Dialog', () => {
 
       await harness.showAsync();
 
-      const labelElements = harness.nativeDialogElement.querySelectorAll<HTMLElement>(`[id="${DIALOG_CONSTANTS.attributes.ARIA_LABEL_ID}"]`);
-      const descriptionElements = harness.nativeDialogElement.querySelectorAll<HTMLElement>(`[id="${DIALOG_CONSTANTS.attributes.ARIA_DESCRIPTION_ID}"]`);
+      const labelElements = harness.nativeDialogElement.querySelectorAll<HTMLElement>(DIALOG_CONSTANTS.selectors.ACCESSIBLE_LABEL);
+      const descriptionElements = harness.nativeDialogElement.querySelectorAll<HTMLElement>(DIALOG_CONSTANTS.selectors.ACCESSIBLE_DESCRIPTION);
 
       expect(labelElements.length).to.equal(1);
       expect(descriptionElements.length).to.equal(1);
@@ -434,8 +434,8 @@ describe('Dialog', () => {
 
       await elementUpdated(harness.dialogElement);
 
-      const newLabelElements = harness.nativeDialogElement.querySelectorAll<HTMLElement>(`[id="${DIALOG_CONSTANTS.attributes.ARIA_LABEL_ID}"]`);
-      const newDescriptionElements = harness.nativeDialogElement.querySelectorAll<HTMLElement>(`[id="${DIALOG_CONSTANTS.attributes.ARIA_DESCRIPTION_ID}"]`);
+      const newLabelElements = harness.nativeDialogElement.querySelectorAll<HTMLElement>(DIALOG_CONSTANTS.selectors.ACCESSIBLE_LABEL);
+      const newDescriptionElements = harness.nativeDialogElement.querySelectorAll<HTMLElement>(DIALOG_CONSTANTS.selectors.ACCESSIBLE_DESCRIPTION);
 
       expect(newLabelElements.length).to.equal(1);
       expect(newDescriptionElements.length).to.equal(1);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Screen readers were not announcing the accessible label and description for the dialog when opening due to the dynamic nature of how we were handling the internal accessible elements. This change ensures that these accessible elements are always available in the DOM statically to avoid any async DOM updates aside from text content changing.
