### PR TITLE
fix: enable Lit-based component compatibility with Forge `@customElement` decorator

### DIFF
--- a/src/lib/avatar/avatar.ts
+++ b/src/lib/avatar/avatar.ts
@@ -57,7 +57,7 @@ export class AvatarComponent extends LitElement implements IAvatarComponent {
   public static styles = unsafeCSS(styles);
 
   /** @deprecated Used for compatibility with legacy Forge @customElement decorator. */
-  static [CUSTOM_ELEMENT_NAME_PROPERTY] = AVATAR_TAG_NAME;
+  public static [CUSTOM_ELEMENT_NAME_PROPERTY] = AVATAR_TAG_NAME;
 
   /**
    * The text to display in the avatar.

--- a/src/lib/avatar/avatar.ts
+++ b/src/lib/avatar/avatar.ts
@@ -2,7 +2,7 @@ import { LitElement, PropertyValues, TemplateResult, html, nothing, unsafeCSS } 
 import { customElement, property, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { AVATAR_CONSTANTS } from './avatar-constants';
+import { CUSTOM_ELEMENT_NAME_PROPERTY } from '@tylertech/forge-core';
 
 import styles from './avatar.scss';
 
@@ -32,6 +32,8 @@ const charsByLetterCount = (text: string, count: number): string => {
 
 export const AVATAR_TAG_NAME: keyof HTMLElementTagNameMap = 'forge-avatar';
 
+const DEFAULT_LETTER_COUNT = 2;
+
 /**
  * @tag forge-avatar
  *
@@ -54,6 +56,9 @@ export const AVATAR_TAG_NAME: keyof HTMLElementTagNameMap = 'forge-avatar';
 export class AvatarComponent extends LitElement implements IAvatarComponent {
   public static styles = unsafeCSS(styles);
 
+  /** @deprecated Used for compatibility with legacy Forge @customElement decorator. */
+  static [CUSTOM_ELEMENT_NAME_PROPERTY] = AVATAR_TAG_NAME;
+
   /**
    * The text to display in the avatar.
    * @default ''
@@ -67,7 +72,7 @@ export class AvatarComponent extends LitElement implements IAvatarComponent {
    * @attribute letter-count
    */
   @property({ type: Number, attribute: 'letter-count' })
-  public letterCount: number = AVATAR_CONSTANTS.numbers.DEFAULT_LETTER_COUNT;
+  public letterCount = DEFAULT_LETTER_COUNT;
 
   /**
    * The background image URL to use.
@@ -91,7 +96,7 @@ export class AvatarComponent extends LitElement implements IAvatarComponent {
         part="root"
         class=${classMap({ 'forge-avatar': true, 'forge-avatar--image': !!this._image })}
         style=${this._image ? styleMap({ backgroundImage: `url(${this._image.src})` }) : nothing}>
-        <slot>${this._image ? nothing : charsByLetterCount(this.text, this.letterCount ?? AVATAR_CONSTANTS.numbers.DEFAULT_LETTER_COUNT)}</slot>
+        <slot>${this._image ? nothing : charsByLetterCount(this.text, this.letterCount ?? DEFAULT_LETTER_COUNT)}</slot>
       </div>
     `;
   }

--- a/src/lib/badge/badge.ts
+++ b/src/lib/badge/badge.ts
@@ -1,9 +1,10 @@
 import { html, LitElement, PropertyValues, TemplateResult, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { BadgeTheme } from './badge-constants';
+import { toggleState } from '../core/utils/utils';
+import { CUSTOM_ELEMENT_NAME_PROPERTY } from '@tylertech/forge-core';
 
 import styles from './badge.scss';
-import { toggleState } from '../core';
 
 export interface IBadgeComponent extends LitElement {
   dot: boolean;
@@ -48,6 +49,9 @@ export const BADGE_TAG_NAME: keyof HTMLElementTagNameMap = 'forge-badge';
 @customElement(BADGE_TAG_NAME)
 export class BadgeComponent extends LitElement implements IBadgeComponent {
   public static styles = unsafeCSS(styles);
+
+  /** @deprecated Used for compatibility with legacy Forge @customElement decorator. */
+  static [CUSTOM_ELEMENT_NAME_PROPERTY] = BADGE_TAG_NAME;
 
   #internals: ElementInternals;
 

--- a/src/lib/badge/badge.ts
+++ b/src/lib/badge/badge.ts
@@ -51,7 +51,7 @@ export class BadgeComponent extends LitElement implements IBadgeComponent {
   public static styles = unsafeCSS(styles);
 
   /** @deprecated Used for compatibility with legacy Forge @customElement decorator. */
-  static [CUSTOM_ELEMENT_NAME_PROPERTY] = BADGE_TAG_NAME;
+  public static [CUSTOM_ELEMENT_NAME_PROPERTY] = BADGE_TAG_NAME;
 
   #internals: ElementInternals;
 

--- a/src/lib/card/card.ts
+++ b/src/lib/card/card.ts
@@ -1,6 +1,7 @@
 import { html, LitElement, PropertyValues, TemplateResult, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { toggleState } from '../core/utils/utils';
+import { CUSTOM_ELEMENT_NAME_PROPERTY } from '@tylertech/forge-core';
 
 import styles from './card.scss';
 
@@ -44,6 +45,9 @@ export const CARD_TAG_NAME: keyof HTMLElementTagNameMap = 'forge-card';
 @customElement(CARD_TAG_NAME)
 export class CardComponent extends LitElement implements ICardComponent {
   public static styles = unsafeCSS(styles);
+
+  /** @deprecated Used for compatibility with legacy Forge @customElement decorator. */
+  static [CUSTOM_ELEMENT_NAME_PROPERTY] = CARD_TAG_NAME;
 
   #internals: ElementInternals;
 

--- a/src/lib/card/card.ts
+++ b/src/lib/card/card.ts
@@ -47,7 +47,7 @@ export class CardComponent extends LitElement implements ICardComponent {
   public static styles = unsafeCSS(styles);
 
   /** @deprecated Used for compatibility with legacy Forge @customElement decorator. */
-  static [CUSTOM_ELEMENT_NAME_PROPERTY] = CARD_TAG_NAME;
+  public static [CUSTOM_ELEMENT_NAME_PROPERTY] = CARD_TAG_NAME;
 
   #internals: ElementInternals;
 

--- a/src/lib/key/key-item/index.ts
+++ b/src/lib/key/key-item/index.ts
@@ -1,8 +1,8 @@
 import { tryDefine } from '@tylertech/forge-core';
-import { KeyItemComponent } from './key-item';
+import { KEY_ITEM_TAG_NAME, KeyItemComponent } from './key-item';
 
 export * from './key-item';
 
 export function defineKeyItemComponent(): void {
-  tryDefine('forge-key-item', KeyItemComponent);
+  tryDefine(KEY_ITEM_TAG_NAME, KeyItemComponent);
 }

--- a/src/lib/key/key-item/key-item.ts
+++ b/src/lib/key/key-item/key-item.ts
@@ -2,8 +2,11 @@ import { LitElement, TemplateResult, html, unsafeCSS } from 'lit';
 import { customElement, property, queryAssignedNodes, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { setDefaultAria } from '../../core/utils/a11y-utils';
+import { CUSTOM_ELEMENT_NAME_PROPERTY } from '@tylertech/forge-core';
 
 import styles from './key-item.scss';
+
+export const KEY_ITEM_TAG_NAME: keyof HTMLElementTagNameMap = 'forge-key-item';
 
 /**
  * @tag forge-key-item
@@ -25,9 +28,12 @@ import styles from './key-item.scss';
  * @csspart label - The label element.
  * @csspart value - The value element.
  */
-@customElement('forge-key-item')
+@customElement(KEY_ITEM_TAG_NAME)
 export class KeyItemComponent extends LitElement {
   public static styles = unsafeCSS(styles);
+
+  /** @deprecated Used for compatibility with legacy Forge @customElement decorator. */
+  static [CUSTOM_ELEMENT_NAME_PROPERTY] = KEY_ITEM_TAG_NAME;
 
   /**
    * Whether the label and value dislay on one line.

--- a/src/lib/key/key-item/key-item.ts
+++ b/src/lib/key/key-item/key-item.ts
@@ -33,7 +33,7 @@ export class KeyItemComponent extends LitElement {
   public static styles = unsafeCSS(styles);
 
   /** @deprecated Used for compatibility with legacy Forge @customElement decorator. */
-  static [CUSTOM_ELEMENT_NAME_PROPERTY] = KEY_ITEM_TAG_NAME;
+  public static [CUSTOM_ELEMENT_NAME_PROPERTY] = KEY_ITEM_TAG_NAME;
 
   /**
    * Whether the label and value dislay on one line.

--- a/src/lib/key/key/index.ts
+++ b/src/lib/key/key/index.ts
@@ -1,8 +1,8 @@
 import { tryDefine } from '@tylertech/forge-core';
-import { KeyComponent } from './key';
+import { KEY_TAG_NAME, KeyComponent } from './key';
 
 export * from './key';
 
 export function defineKeyComponent(): void {
-  tryDefine('forge-key', KeyComponent);
+  tryDefine(KEY_TAG_NAME, KeyComponent);
 }

--- a/src/lib/key/key/key.ts
+++ b/src/lib/key/key/key.ts
@@ -24,7 +24,7 @@ export class KeyComponent extends LitElement {
   public static styles = unsafeCSS(styles);
 
   /** @deprecated Used for compatibility with legacy Forge @customElement decorator. */
-  static [CUSTOM_ELEMENT_NAME_PROPERTY] = KEY_TAG_NAME;
+  public static [CUSTOM_ELEMENT_NAME_PROPERTY] = KEY_TAG_NAME;
 
   private _internals: ElementInternals;
 

--- a/src/lib/key/key/key.ts
+++ b/src/lib/key/key/key.ts
@@ -1,8 +1,11 @@
 import { LitElement, TemplateResult, html, unsafeCSS } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { setDefaultAria } from '../../core/utils/a11y-utils';
+import { CUSTOM_ELEMENT_NAME_PROPERTY } from '@tylertech/forge-core';
 
 import styles from './key.scss';
+
+export const KEY_TAG_NAME: keyof HTMLElementTagNameMap = 'forge-key';
 
 /**
  * @tag forge-key
@@ -16,9 +19,12 @@ import styles from './key.scss';
  *
  * @csspart root - The root element.
  */
-@customElement('forge-key')
+@customElement(KEY_TAG_NAME)
 export class KeyComponent extends LitElement {
   public static styles = unsafeCSS(styles);
+
+  /** @deprecated Used for compatibility with legacy Forge @customElement decorator. */
+  static [CUSTOM_ELEMENT_NAME_PROPERTY] = KEY_TAG_NAME;
 
   private _internals: ElementInternals;
 

--- a/src/lib/meter/meter-group/index.ts
+++ b/src/lib/meter/meter-group/index.ts
@@ -1,8 +1,8 @@
 import { tryDefine } from '@tylertech/forge-core';
-import { MeterGroupComponent } from './meter-group';
+import { METER_GROUP_TAG_NAME, MeterGroupComponent } from './meter-group';
 
 export * from './meter-group';
 
 export function defineMeterGroupComponent(): void {
-  tryDefine('forge-meter-group', MeterGroupComponent);
+  tryDefine(METER_GROUP_TAG_NAME, MeterGroupComponent);
 }

--- a/src/lib/meter/meter-group/meter-group.ts
+++ b/src/lib/meter/meter-group/meter-group.ts
@@ -1,4 +1,4 @@
-import { debounce } from '@tylertech/forge-core';
+import { CUSTOM_ELEMENT_NAME_PROPERTY, debounce } from '@tylertech/forge-core';
 import { html, LitElement, PropertyValues, TemplateResult, unsafeCSS } from 'lit';
 import { customElement, property, queryAssignedElements, queryAssignedNodes, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -7,6 +7,8 @@ import { toggleState } from '../../core/utils/utils';
 import { MeterComponent, MeterDensity, MeterDirection, MeterInnerShape, MeterShape } from '../meter/meter';
 
 import styles from './meter-group.scss';
+
+export const METER_GROUP_TAG_NAME: keyof HTMLElementTagNameMap = 'forge-meter-group';
 
 /**
  * @tag forge-meter-group
@@ -29,11 +31,14 @@ import styles from './meter-group.scss';
  * @slot label - Positions a label above the meter group.
  * @slot value - A textual representation of the meter's value.
  */
-@customElement('forge-meter-group')
+@customElement(METER_GROUP_TAG_NAME)
 export class MeterGroupComponent extends LitElement {
   /* @ignore */
   public static styles = unsafeCSS(styles);
   public static formAssociated = true;
+
+  /** @deprecated Used for compatibility with legacy Forge @customElement decorator. */
+  static [CUSTOM_ELEMENT_NAME_PROPERTY] = METER_GROUP_TAG_NAME;
 
   /**
    * The minimum value of each meter in the group.

--- a/src/lib/meter/meter-group/meter-group.ts
+++ b/src/lib/meter/meter-group/meter-group.ts
@@ -38,7 +38,7 @@ export class MeterGroupComponent extends LitElement {
   public static formAssociated = true;
 
   /** @deprecated Used for compatibility with legacy Forge @customElement decorator. */
-  static [CUSTOM_ELEMENT_NAME_PROPERTY] = METER_GROUP_TAG_NAME;
+  public static [CUSTOM_ELEMENT_NAME_PROPERTY] = METER_GROUP_TAG_NAME;
 
   /**
    * The minimum value of each meter in the group.

--- a/src/lib/meter/meter/meter.ts
+++ b/src/lib/meter/meter/meter.ts
@@ -65,7 +65,8 @@ export class MeterComponent extends LitElement {
   public static styles = unsafeCSS(styles);
   public static formAssociated = true;
 
-  static [CUSTOM_ELEMENT_NAME_PROPERTY] = METER_TAG_NAME;
+  /** @deprecated Used for compatibility with legacy Forge @customElement decorator. */
+  public static [CUSTOM_ELEMENT_NAME_PROPERTY] = METER_TAG_NAME;
 
   /**
    * The current value of the meter.

--- a/src/lib/meter/meter/meter.ts
+++ b/src/lib/meter/meter/meter.ts
@@ -5,8 +5,11 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { Theme } from '../../constants';
 import { setDefaultAria } from '../../core/utils/a11y-utils';
 import { toggleState } from '../../core/utils/utils';
+import { CUSTOM_ELEMENT_NAME_PROPERTY } from '@tylertech/forge-core';
 
 import styles from './meter.scss';
+
+export const METER_TAG_NAME: keyof HTMLElementTagNameMap = 'forge-meter';
 
 export type MeterDirection = 'horizontal' | 'vertical';
 export type MeterDensity = 'default' | 'small' | 'medium' | 'large';
@@ -57,10 +60,12 @@ const VALUE_STATE_MAP = new Map<MeterStatus, string>([
  * @slot - The default slot for the meter's label.
  * @slot value - A textual representation of the meter's value.
  */
-@customElement('forge-meter')
+@customElement(METER_TAG_NAME)
 export class MeterComponent extends LitElement {
   public static styles = unsafeCSS(styles);
   public static formAssociated = true;
+
+  static [CUSTOM_ELEMENT_NAME_PROPERTY] = METER_TAG_NAME;
 
   /**
    * The current value of the meter.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
This is a temporary change applied to all current Lit-based components in the library, and will also apply to all future Lit-based components as well. The plan is to migrate fully to Lit over time, but until we do so, we should expose the custom element tag name on Lit components via a static property so that it can be used with the Forge-based `@customElement` decorator.

This isn't necessarily to support using these decorators interchangeable within Forge (although you should be able to now), but it's to fix a compatibility issue with existing libraries out there that also make use of this decorator from the `@tylertech/forge-core` package (specifically the internal spatial library as we found compatibility issues already during testing).

While this change is not ideal, it will reduce friction as teams update Forge, but also ensures that we can continue to build components a consistent way within Forge until the time comes to fully migrate to Lit (which we will then remove these static properties).

