### PR TITLE
fix(select): fix duplicate `label` CSS part

### DIFF
--- a/src/lib/select/select/select.html
+++ b/src/lib/select/select/select.html
@@ -1,6 +1,6 @@
 <template>
   <forge-field id="field" popover-icon focus-indicator-allow-focus focus-indicator-focus-mode="focus">
-    <div id="select-label" slot="label"></div>
+    <span id="select-label" slot="label"></span>
     <slot slot="start" name="start"></slot>
     <div data-forge-field-input class="selected-text-container" part="text-container" aria-live="assertive" aria-atomic="true">
       <slot name="value">

--- a/src/lib/select/select/select.html
+++ b/src/lib/select/select/select.html
@@ -1,6 +1,6 @@
 <template>
   <forge-field id="field" popover-icon focus-indicator-allow-focus focus-indicator-focus-mode="focus">
-    <label id="select-label" aria-hidden="true" part="label" slot="label"></label>
+    <div id="select-label" slot="label"></div>
     <slot slot="start" name="start"></slot>
     <div data-forge-field-input class="selected-text-container" part="text-container" aria-live="assertive" aria-atomic="true">
       <slot name="value">

--- a/src/lib/select/select/select.test.ts
+++ b/src/lib/select/select/select.test.ts
@@ -900,7 +900,7 @@ class SelectHarness extends TestHarness<ISelectComponent> {
   public selectedTextElement: HTMLElement;
 
   public get labelElement(): HTMLLabelElement | null {
-    return getShadowElement(this.element, 'label') as HTMLLabelElement;
+    return getShadowElement(this.element, SELECT_CONSTANTS.selectors.LABEL) as HTMLLabelElement;
   }
 
   constructor(el: ISelectComponent) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? [N
- I have linked any related GitHub issues to be closed when this PR is merged?
  Fixes #891

## Describe the new behavior?
Removes duplicate `label` CSS shadow part, instead just relying on the exported `label` part from the `<forge-field>`.

Additionally, updated the internal `<label>` element to use a `<span>` instead as it was set to `aria-hidden="true"` and using a `<label>` element was not necessary for this component.
