### PR TITLE
feat(app-bar): remove default auto-theming in favor of scoped CSS variables and theme attribute

### DIFF
--- a/src/dev/pages/app-bar/app-bar.ejs
+++ b/src/dev/pages/app-bar/app-bar.ejs
@@ -14,12 +14,39 @@
     <forge-app-bar-notification-button show-badge count="5" slot="end"></forge-app-bar-notification-button>
     <forge-app-bar-app-launcher-button slot="end"></forge-app-bar-app-launcher-button>
 
-    <forge-button slot="end" theme="app-bar">Sign in</forge-button>
+    <forge-button slot="end">Sign in</forge-button>
+
+    <div slot="end">
+      <forge-icon-button>
+        <forge-icon name="arrow_drop_down_circle"></forge-icon>
+      </forge-icon-button>
+  
+      <forge-popover arrow placement="bottom-end">
+        <div class="app-bar-popover">
+          <forge-toolbar no-border>
+            <forge-tab-bar clustered slot="before-start" active-tab="0">
+              <forge-tab>Tab 1</forge-tab>
+              <forge-tab>Tab 2</forge-tab>
+              <forge-tab>Tab 3</forge-tab>
+            </forge-tab-bar>
+            <forge-icon-button aria-label="Close" slot="after-end">
+              <forge-icon name="close"></forge-icon>
+            </forge-icon-button>
+          </forge-toolbar>
+          <div class="app-bar-popover__content">
+            Lorem ipsum dolor sit amet consectetur, adipisicing elit. Omnis voluptates ipsa magnam molestias cum quis, aperiam laborum voluptatem voluptas et? Aut rerum, exercitationem tenetur reprehenderit dignissimos fugiat soluta asperiores nihil!
+          </div>
+          <forge-toolbar inverted>
+            <forge-button slot="end">Save</forge-button>
+          </forge-toolbar>
+        </div>
+      </forge-popover>
+    </div>
 
     <forge-app-bar-profile-button slot="end" full-name="First Last" email="first.last@tylerforge.io" profile-button profile-button-text="View profile">
     </forge-app-bar-profile-button>
 
-    <forge-tab-bar slot="bottom" active-tab="0" clustered scroll-buttons theme="app-bar">
+    <forge-tab-bar slot="bottom" active-tab="0" clustered scroll-buttons>
       <forge-tab>Tab 1</forge-tab>
       <forge-tab>Tab 2</forge-tab>
       <forge-tab>Tab 3</forge-tab>

--- a/src/dev/pages/app-bar/app-bar.ejs
+++ b/src/dev/pages/app-bar/app-bar.ejs
@@ -14,12 +14,12 @@
     <forge-app-bar-notification-button show-badge count="5" slot="end"></forge-app-bar-notification-button>
     <forge-app-bar-app-launcher-button slot="end"></forge-app-bar-app-launcher-button>
 
-    <forge-button slot="end">Sign in</forge-button>
+    <forge-button slot="end" theme="app-bar">Sign in</forge-button>
 
     <forge-app-bar-profile-button slot="end" full-name="First Last" email="first.last@tylerforge.io" profile-button profile-button-text="View profile">
     </forge-app-bar-profile-button>
 
-    <forge-tab-bar slot="bottom" active-tab="0" clustered scroll-buttons>
+    <forge-tab-bar slot="bottom" active-tab="0" clustered scroll-buttons theme="app-bar">
       <forge-tab>Tab 1</forge-tab>
       <forge-tab>Tab 2</forge-tab>
       <forge-tab>Tab 3</forge-tab>

--- a/src/dev/pages/app-bar/app-bar.html
+++ b/src/dev/pages/app-bar/app-bar.html
@@ -6,6 +6,16 @@ include('./src/partials/page.ejs', {
     options: [
       {
         type: 'select',
+        label: 'Theme Mode',
+        id: 'opt-theme-mode',
+        defaultValue: 'inherit',
+        options: [
+          { label: 'Inherit (default)', value: 'inherit' },
+          { label: 'Scoped ', value: 'scoped' }
+        ]
+      },
+      {
+        type: 'select',
         label: 'Theme',
         id: 'opt-theme',
         defaultValue: '',

--- a/src/dev/pages/app-bar/app-bar.scss
+++ b/src/dev/pages/app-bar/app-bar.scss
@@ -1,3 +1,11 @@
 section:not(:last-of-type) {
   margin-block-end: 56px;
 }
+
+.app-bar-popover {
+  width: 500px;
+
+  &__content {
+    padding: var(--forge-spacing-medium);
+  }
+}

--- a/src/dev/pages/app-bar/app-bar.ts
+++ b/src/dev/pages/app-bar/app-bar.ts
@@ -31,7 +31,8 @@ import {
   tylIconStars,
   tylIconWarning,
   tylIconWorkOutline,
-  tylIconKeyboardVoice
+  tylIconKeyboardVoice,
+  tylIconArrowDropDownCircle
 } from '@tylertech/tyler-icons/standard';
 import { ToastComponent } from '@tylertech/forge/toast';
 
@@ -45,7 +46,8 @@ IconRegistry.define([
   tylIconWorkOutline,
   tylIconWarning,
   tylIconSettings,
-  tylIconKeyboardVoice
+  tylIconKeyboardVoice,
+  tylIconArrowDropDownCircle
 ]);
 
 const appBar = document.querySelector('forge-app-bar#forge-app-bar-example') as IAppBarComponent;
@@ -73,6 +75,11 @@ appBarMenuButton.addEventListener('click', ({ detail }) => {
 appBarSearch.addEventListener('forge-app-bar-search-input', ({ detail }) => {
   console.log('[forge-app-bar-search] ', detail);
   ToastComponent.present({ message: `Search text: ${detail.value}` });
+});
+
+const themeModeSelect = document.querySelector('#opt-theme-mode') as ISelectComponent;
+themeModeSelect.addEventListener('change', () => {
+  appBar.themeMode = themeModeSelect.value;
 });
 
 const themeSelect = document.querySelector('#opt-theme') as ISelectComponent;

--- a/src/dev/src/partials/header.ejs
+++ b/src/dev/src/partials/header.ejs
@@ -1,6 +1,6 @@
 <forge-app-bar slot="header" id="page-app-bar" title-text="<%= site.title %><%= title ? ` - ${title}` : null %>" href="/">
   <forge-icon name="forge_logo" slot="logo"></forge-icon>
-  <forge-icon-button slot="end" id="dark-theme-button" theme="app-bar">
+  <forge-icon-button slot="end" id="dark-theme-button">
     <forge-icon name="brightness_3"></forge-icon>
   </forge-icon-button>
   <forge-tooltip slot="end" anchor="dark-theme-button" type="label" placement="left">Toggle theme</forge-tooltip>

--- a/src/dev/src/partials/header.ejs
+++ b/src/dev/src/partials/header.ejs
@@ -1,6 +1,6 @@
 <forge-app-bar slot="header" id="page-app-bar" title-text="<%= site.title %><%= title ? ` - ${title}` : null %>" href="/">
   <forge-icon name="forge_logo" slot="logo"></forge-icon>
-  <forge-icon-button slot="end" id="dark-theme-button">
+  <forge-icon-button slot="end" id="dark-theme-button" theme="app-bar">
     <forge-icon name="brightness_3"></forge-icon>
   </forge-icon-button>
   <forge-tooltip slot="end" anchor="dark-theme-button" type="label" placement="left">Toggle theme</forge-tooltip>

--- a/src/lib/app-bar/app-bar/_core.scss
+++ b/src/lib/app-bar/app-bar/_core.scss
@@ -9,6 +9,7 @@
 
 @mixin base {
   background: #{token(background)};
+  color: #{token(foreground)};
 
   position: relative;
   z-index: #{token(z-index)};
@@ -82,8 +83,6 @@
 
   min-width: 0;
   padding-inline: #{token(title-padding)};
-
-  color: #{token(foreground)};
 }
 
 @mixin logo {

--- a/src/lib/app-bar/app-bar/_core.scss
+++ b/src/lib/app-bar/app-bar/_core.scss
@@ -9,7 +9,6 @@
 
 @mixin base {
   background: #{token(background)};
-  color: #{token(foreground)};
 
   position: relative;
   z-index: #{token(z-index)};
@@ -83,6 +82,8 @@
 
   min-width: 0;
   padding-inline: #{token(title-padding)};
+
+  color: #{token(foreground)};
 }
 
 @mixin logo {

--- a/src/lib/app-bar/app-bar/app-bar-constants.ts
+++ b/src/lib/app-bar/app-bar/app-bar-constants.ts
@@ -7,7 +7,8 @@ const observedAttributes = {
   ELEVATION: 'elevation',
   THEME: 'theme',
   HREF: 'href',
-  TARGET: 'target'
+  TARGET: 'target',
+  THEME_MODE: 'theme-mode'
 };
 
 const attributes = {
@@ -41,3 +42,4 @@ export const APP_BAR_CONSTANTS = {
 
 export type AppBarElevation = 'none' | 'raised';
 export type AppBarTheme = 'white' | 'custom' | '';
+export type AppBarThemeMode = 'inherit' | 'scoped';

--- a/src/lib/app-bar/app-bar/app-bar-core.ts
+++ b/src/lib/app-bar/app-bar/app-bar-core.ts
@@ -1,10 +1,11 @@
 import { IAppBarAdapter } from './app-bar-adapter';
-import { AppBarElevation, AppBarTheme, APP_BAR_CONSTANTS } from './app-bar-constants';
+import { AppBarElevation, AppBarTheme, APP_BAR_CONSTANTS, AppBarThemeMode } from './app-bar-constants';
 
 export interface IAppBarCore {
   titleText: string;
   elevation: AppBarElevation;
   theme: string;
+  themeMode: AppBarThemeMode;
   href: string;
   target: string;
 }
@@ -15,6 +16,7 @@ export class AppBarCore implements IAppBarCore {
   private _theme: AppBarTheme;
   private _href = '';
   private _target = '';
+  private _themeMode: AppBarThemeMode = 'inherit';
 
   private _centerSlotListener: EventListener = (): void => this._adapter.setCenterSlotVisibility();
   private _anchorClickListener: EventListener = this._onHrefClick.bind(this);
@@ -90,6 +92,16 @@ export class AppBarCore implements IAppBarCore {
       this._target = value?.trim().length ? value.trim() : '';
       this._adapter.setTarget(this._target);
       this._adapter.toggleHostAttribute(APP_BAR_CONSTANTS.attributes.TARGET, !!this._target, this._target);
+    }
+  }
+
+  public get themeMode(): AppBarThemeMode {
+    return this._themeMode;
+  }
+  public set themeMode(value: AppBarThemeMode) {
+    if (this._themeMode !== value) {
+      this._themeMode = value;
+      this._adapter.toggleHostAttribute(APP_BAR_CONSTANTS.attributes.THEME_MODE, this._themeMode !== 'inherit', this._themeMode);
     }
   }
 }

--- a/src/lib/app-bar/app-bar/app-bar.scss
+++ b/src/lib/app-bar/app-bar/app-bar.scss
@@ -11,7 +11,7 @@
 // Host
 //
 
-$host-tokens: [background foreground];
+$host-tokens: (background, foreground);
 
 :host {
   @include tokens($includes: $host-tokens);
@@ -29,17 +29,11 @@ $host-tokens: [background foreground];
 // Default theme
 //
 
-:host(:not([theme])) {
-  @include theme.provide(
+:host {
+  @include provide-theme(
     (
-      primary: #{token(foreground)},
-      on-primary: rgba(black, color-emphasis.value(highest)),
-      text-high: rgba(white, color-emphasis.value(highest)),
-      text-medium: rgba(white, color-emphasis.value(medium)),
-      text-low: rgba(white, color-emphasis.value(medium-low)),
-      outline-high: rgba(white, color-emphasis.value(highest)),
-      outline-medium: rgba(white, color-emphasis.value(medium)),
-      outline-low: rgba(white, color-emphasis.value(medium-low))
+      theme-foreground: #{token(foreground)},
+      theme-foreground-muted: rgba(white, color-emphasis.value(medium))
     )
   );
 }
@@ -151,16 +145,12 @@ $host-tokens: [background foreground];
 //
 
 :host([theme='white']) {
-  @include theme.provide(
+  @include override(background, white, value);
+  @include override(foreground, black, value);
+
+  @include provide-theme(
     (
-      primary: black,
-      on-primary: rgba(white, color-emphasis.value(highest)),
-      text-medium: rgba(black, color-emphasis.value(medium))
+      theme-foreground-muted: rgba(black, color-emphasis.value(medium))
     )
   );
-
-  .forge-app-bar {
-    @include override(background, white, value);
-    @include override(foreground, black, value);
-  }
 }

--- a/src/lib/app-bar/app-bar/app-bar.scss
+++ b/src/lib/app-bar/app-bar/app-bar.scss
@@ -29,6 +29,31 @@ $host-tokens: (background, foreground);
 // Default theme
 //
 
+:host(:not([theme]):not([theme-mode='scoped'])) {
+  @include theme.provide(
+    (
+      primary: #{token(foreground)},
+      on-primary: rgba(black, color-emphasis.value(highest)),
+      text-high: rgba(white, color-emphasis.value(highest)),
+      text-medium: rgba(white, color-emphasis.value(medium)),
+      text-low: rgba(white, color-emphasis.value(medium-low)),
+      outline-high: rgba(white, color-emphasis.value(highest)),
+      outline-medium: rgba(white, color-emphasis.value(medium)),
+      outline-low: rgba(white, color-emphasis.value(medium-low))
+    )
+  );
+}
+
+:host([theme-mode='scoped']) {
+  .forge-app-bar {
+    color: inherit;
+
+    .logo-title-container {
+      color: #{token(foreground)};
+    }
+  }
+}
+
 :host {
   @include provide-theme(
     (
@@ -113,6 +138,25 @@ $host-tokens: (background, foreground);
 }
 
 //
+// Slotted (scoped theme mode)
+//
+// Attempt to auto-theme any specific slotted elements directly
+//
+
+:host([theme-mode='scoped']) {
+  ::slotted(:where(forge-tab-bar, forge-icon-button, forge-button)) {
+    color: #{token(theme-foreground)};
+
+    @include tab.provide-theme(
+      (
+        active-color: #{token(theme-foreground)},
+        inactive-color: #{token(theme-foreground-muted)}
+      )
+    );
+  }
+}
+
+//
 // Slotted - Tab bar
 //
 
@@ -151,6 +195,16 @@ $host-tokens: (background, foreground);
   @include provide-theme(
     (
       theme-foreground-muted: rgba(black, color-emphasis.value(medium))
+    )
+  );
+}
+
+:host([theme='white']:not([theme-mode='scoped'])) {
+  @include theme.provide(
+    (
+      primary: black,
+      on-primary: rgba(white, color-emphasis.value(highest)),
+      text-medium: rgba(black, color-emphasis.value(medium))
     )
   );
 }

--- a/src/lib/app-bar/app-bar/app-bar.test.ts
+++ b/src/lib/app-bar/app-bar/app-bar.test.ts
@@ -171,6 +171,24 @@ describe('App Bar', () => {
     expect(testSpy.calledOnce).to.be.false;
   });
 
+  it('should disable global theme token cascade when using scoped theme mode', async () => {
+    const el = await fixture<IAppBarComponent>(html`<forge-app-bar></forge-app-bar>`);
+
+    const defaultStyle = getComputedStyle(el);
+    expect(defaultStyle.getPropertyValue('--forge-theme-primary')).to.equal('#ffffff');
+
+    expect(el.themeMode).to.equal('inherit');
+    expect(el.hasAttribute(APP_BAR_CONSTANTS.attributes.THEME_MODE)).to.be.false;
+
+    el.themeMode = 'scoped';
+
+    const noGlobalStyle = getComputedStyle(el);
+    expect(noGlobalStyle.getPropertyValue('--forge-theme-primary')).to.equal('');
+
+    expect(el.themeMode).to.equal('scoped');
+    expect(el.getAttribute(APP_BAR_CONSTANTS.attributes.THEME_MODE)).to.equal('scoped');
+  });
+
   function getRootEl(el: IAppBarComponent): HTMLElement {
     return el.shadowRoot?.firstElementChild as HTMLElement;
   }

--- a/src/lib/app-bar/app-bar/app-bar.ts
+++ b/src/lib/app-bar/app-bar/app-bar.ts
@@ -1,7 +1,7 @@
-import { customElement, attachShadowTemplate, coreProperty } from '@tylertech/forge-core';
+import { customElement, attachShadowTemplate, coreProperty, coerceBoolean } from '@tylertech/forge-core';
 import { AppBarAdapter } from './app-bar-adapter';
 import { AppBarCore } from './app-bar-core';
-import { AppBarElevation, AppBarTheme, APP_BAR_CONSTANTS } from './app-bar-constants';
+import { AppBarElevation, AppBarTheme, APP_BAR_CONSTANTS, AppBarThemeMode } from './app-bar-constants';
 import { BaseComponent, IBaseComponent } from '../../core/base/base-component';
 
 import template from './app-bar.html';
@@ -11,6 +11,7 @@ export interface IAppBarComponent extends IBaseComponent {
   titleText: string;
   elevation: AppBarElevation;
   theme: AppBarTheme;
+  themeMode: AppBarThemeMode;
   href: string;
   target: string;
 }
@@ -35,15 +36,19 @@ declare global {
  * @property {AppBarTheme} theme - The theme of the app bar.
  * @property {string} href - The href that will be used to make the logo and title area a clickable link.
  * @property {string} target - The `<a>` target of the logo + title area link when `href` is set.
+ * @property {AppBarThemeMode} [themeMode="inherit"] - Controls how the theme is applied. `inherit` will apply the global theme to the app bar and all child components. `scoped` will only apply the theme to the app bar and not set any global tokens.
  *
  * @attribute {string} title-text - The text to display in the title.
  * @attribute {string} [elevation="raised"] - The elevation of the app bar.
  * @attribute {string} theme - The theme of the app bar.
  * @attribute {string} href - The href that will be used to make the logo and title area a clickable link
  * @attribute {string} target - The `<a>` target of the logo + title area link when `href` is set.
+ * @attribute {string} [theme-mode="inherit"] - Controls how the theme is applied. `inherit` will apply the global theme to the app bar and all child components. `scoped` will only apply the theme to the app bar and not set any global tokens.
  *
  * @cssproperty --forge-app-bar-background - The background color of the app bar.
  * @cssproperty --forge-app-bar-foreground - The text color of the app bar.
+ * @cssproperty --forge-app-bar-theme-foreground - The text color of the app bar when using the **scoped theme mode**.
+ * @cssproperty --forge-app-bar-theme-foreground-muted - The muted text color of the app bar when using the **scoped theme mode**.
  * @cssproperty --forge-app-bar-z-index - The `z-index` of the app bar.
  * @cssproperty --forge-app-bar-elevation - The elevation of the app bar.
  * @cssproperty --forge-app-bar-height - The height of the app bar.
@@ -66,6 +71,8 @@ declare global {
  * @slot end - Places content at the end of the app bar.
  *
  * @cssclass forge-app-bar - The app bar container element _(required)_.
+ * @cssclass forge-app-bar--scoped - Sets the theme mode to scoped.
+ * @cssclass forge-app-bar-theme - Applies the scoped theme from the app bar to the element.
  * @cssclass forge-app-bar--raised - The app bar container element when raised.
  * @cssclass forge-app-bar__logo - The logo container element.
  * @cssclass forge-app-bar__title - The title container element.
@@ -85,7 +92,8 @@ export class AppBarComponent extends BaseComponent implements IAppBarComponent {
       APP_BAR_CONSTANTS.attributes.ELEVATION,
       APP_BAR_CONSTANTS.attributes.THEME,
       APP_BAR_CONSTANTS.attributes.HREF,
-      APP_BAR_CONSTANTS.attributes.TARGET
+      APP_BAR_CONSTANTS.attributes.TARGET,
+      APP_BAR_CONSTANTS.attributes.THEME_MODE
     ];
   }
 
@@ -118,6 +126,9 @@ export class AppBarComponent extends BaseComponent implements IAppBarComponent {
       case APP_BAR_CONSTANTS.attributes.TARGET:
         this.target = newValue;
         break;
+      case APP_BAR_CONSTANTS.attributes.THEME_MODE:
+        this.themeMode = newValue as AppBarThemeMode;
+        break;
     }
   }
 
@@ -135,4 +146,7 @@ export class AppBarComponent extends BaseComponent implements IAppBarComponent {
 
   @coreProperty()
   declare public target: string;
+
+  @coreProperty()
+  declare public themeMode: AppBarThemeMode;
 }

--- a/src/lib/app-bar/forge-app-bar.scss
+++ b/src/lib/app-bar/forge-app-bar.scss
@@ -10,18 +10,28 @@
 
 .forge-app-bar {
   @include core.tokens;
-  @include theme.provide(
+
+  @include core.provide-theme(
     (
-      primary: #{core.token(foreground)},
-      on-primary: rgba(black, color-emphasis.value(highest)),
-      text-high: rgba(white, color-emphasis.value(highest)),
-      text-medium: rgba(white, color-emphasis.value(medium)),
-      text-low: rgba(white, color-emphasis.value(medium-low)),
-      outline-high: rgba(white, color-emphasis.value(highest)),
-      outline-medium: rgba(white, color-emphasis.value(medium)),
-      outline-low: rgba(white, color-emphasis.value(medium-low))
+      theme-foreground: #{core.token(foreground)},
+      theme-foreground-muted: rgba(white, color-emphasis.value(medium))
     )
   );
+
+  &:not(.forge-app-bar--scoped) {
+    @include theme.provide(
+      (
+        primary: #{core.token(foreground)},
+        on-primary: rgba(black, color-emphasis.value(highest)),
+        text-high: rgba(white, color-emphasis.value(highest)),
+        text-medium: rgba(white, color-emphasis.value(medium)),
+        text-low: rgba(white, color-emphasis.value(medium-low)),
+        outline-high: rgba(white, color-emphasis.value(highest)),
+        outline-medium: rgba(white, color-emphasis.value(medium)),
+        outline-low: rgba(white, color-emphasis.value(medium-low))
+      )
+    );
+  }
 }
 
 .forge-app-bar {
@@ -41,6 +51,16 @@
   &:has(.forge-app-bar__section-end):not(:has(.forge-app-bar__section-center)) {
     grid-template-columns: 1fr auto;
     grid-template-areas: 'start end';
+  }
+
+  &--scoped {
+    color: inherit;
+
+    .forge-app-bar__logo,
+    .forge-app-bar__title h1,
+    .forge-app-bar__logo-title-container {
+      color: #{core.token(foreground)};
+    }
   }
 
   &--raised {
@@ -74,7 +94,7 @@
     @include focus-indicator.standalone($type: inward);
     @include focus-indicator.provide-theme(
       (
-        color: currentColor,
+        color: #{core.token(foreground)},
         offset-block: #{spacing.variable(xxsmall)},
         shape: #{shape.variable(medium)}
       )
@@ -91,7 +111,7 @@
       @include state-layer.standalone;
       @include state-layer.provide-theme(
         (
-          color: currentColor
+          color: #{core.token(foreground)}
         )
       );
     }
@@ -137,5 +157,15 @@
       grid-area: end;
       justify-content: end;
     }
+  }
+
+  .forge-app-bar-theme {
+    color: #{core.token(theme-foreground)};
+
+    @include focus-indicator.provide-theme(
+      (
+        color: #{core.token(theme-foreground)}
+      )
+    );
   }
 }

--- a/src/lib/app-bar/help-button/app-bar-help-button.html
+++ b/src/lib/app-bar/help-button/app-bar-help-button.html
@@ -1,6 +1,6 @@
 <template>
   <forge-menu placement="bottom-end">
-    <forge-icon-button>
+    <forge-icon-button theme="app-bar">
       <forge-icon name="help"></forge-icon>
     </forge-icon-button>
     <forge-tooltip type="label" placement="bottom">Help</forge-tooltip>

--- a/src/lib/app-bar/menu-button/app-bar-menu-button.html
+++ b/src/lib/app-bar/menu-button/app-bar-menu-button.html
@@ -1,5 +1,5 @@
 <template>
-  <forge-icon-button>
+  <forge-icon-button theme="app-bar">
     <forge-icon name="menu"></forge-icon>
   </forge-icon-button>
   <forge-tooltip type="label" placement="bottom">Menu</forge-tooltip>

--- a/src/lib/app-bar/notification-button/app-bar-notification-button.html
+++ b/src/lib/app-bar/notification-button/app-bar-notification-button.html
@@ -1,5 +1,5 @@
 <template>
-  <forge-icon-button>
+  <forge-icon-button theme="app-bar">
     <forge-icon></forge-icon>
     <forge-badge slot="badge"></forge-badge>
   </forge-icon-button>

--- a/src/lib/app-bar/profile-button/app-bar-profile-button.html
+++ b/src/lib/app-bar/profile-button/app-bar-profile-button.html
@@ -1,5 +1,5 @@
 <template>
-  <forge-icon-button>
+  <forge-icon-button theme="app-bar">
     <forge-avatar aria-hidden="true"></forge-avatar>
   </forge-icon-button>
   <forge-tooltip type="label" placement="bottom-end">View profile</forge-tooltip>

--- a/src/lib/app-bar/search/app-bar-search.scss
+++ b/src/lib/app-bar/search/app-bar-search.scss
@@ -1,8 +1,11 @@
 @use './core' as *;
 @use '../../focus-indicator';
+@use '../app-bar';
 
 :host {
   @include host;
+
+  color: #{app-bar.token(theme-foreground)};
 }
 
 :host([hidden]) {

--- a/src/lib/button/button-constants.ts
+++ b/src/lib/button/button-constants.ts
@@ -20,4 +20,4 @@ export const BUTTON_CONSTANTS = {
 };
 
 export type ButtonVariant = 'text' | 'outlined' | 'tonal' | 'filled' | 'raised' | 'link';
-export type ButtonTheme = Theme;
+export type ButtonTheme = Theme | 'app-bar';

--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -3,6 +3,7 @@
 @use '../state-layer';
 @use '../focus-indicator';
 @use '../circular-progress';
+@use '../app-bar/app-bar';
 @use '../icon';
 
 //
@@ -126,6 +127,29 @@ forge-focus-indicator {
 @include theme(error);
 @include theme(warning);
 @include theme(info);
+
+//
+// App bar theme
+//
+
+:host([theme='app-bar']) {
+  @include provide-theme(
+    (
+      text-color: #{app-bar.token(theme-foreground)},
+      outlined-color: #{app-bar.token(theme-foreground)},
+      outlined-border-color: #{app-bar.token(theme-foreground)},
+      link-color: #{app-bar.token(theme-foreground)}
+    )
+  );
+
+  forge-focus-indicator {
+    @include focus-indicator.provide-theme(
+      (
+        color: #{app-bar.token(theme-foreground)}
+      )
+    );
+  }
+}
 
 //
 // Variants

--- a/src/lib/core/styles/tokens/app-bar/app-bar/_tokens.scss
+++ b/src/lib/core/styles/tokens/app-bar/app-bar/_tokens.scss
@@ -18,7 +18,10 @@ $tokens: (
   title-padding: utils.module-val(app-bar, title-padding, spacing.variable(xsmall)),
   columns: utils.module-val(app-bar, columns, 1fr 1fr 1fr),
   transition-duration: utils.module-val(app-bar, transition-duration, animation.variable(duration-short4)),
-  transition-timing: utils.module-val(app-bar, transition-timing, animation.variable(easing-standard))
+  transition-timing: utils.module-val(app-bar, transition-timing, animation.variable(easing-standard)),
+  // Scoped theming tokens for app bar children to optionally inherit
+  theme-foreground: utils.module-ref(app-bar, theme-foreground, foreground),
+  theme-foreground-muted: utils.module-val(app-bar, theme-foreground-muted, rgba(white, theme.emphasis(medium)))
 ) !default;
 
 @function get($key) {

--- a/src/lib/icon-button/icon-button-constants.ts
+++ b/src/lib/icon-button/icon-button-constants.ts
@@ -38,6 +38,6 @@ export const ICON_BUTTON_CONSTANTS = {
 };
 
 export type IconButtonVariant = 'icon' | 'outlined' | 'tonal' | 'filled' | 'raised';
-export type IconButtonTheme = Theme | 'default';
+export type IconButtonTheme = Theme | 'default' | 'app-bar';
 export type IconButtonShape = 'circular' | 'squared';
 export type IconButtonDensity = Density;

--- a/src/lib/icon-button/icon-button.scss
+++ b/src/lib/icon-button/icon-button.scss
@@ -5,6 +5,7 @@
 @use '../focus-indicator';
 @use '../badge';
 @use '../circular-progress';
+@use '../app-bar/app-bar';
 
 //
 // Host
@@ -372,3 +373,16 @@ forge-state-layer {
 @include theme(error);
 @include theme(warning);
 @include theme(info);
+
+//
+// App Bar Theme
+//
+
+:host([theme='app-bar']) {
+  @include provide-theme(
+    (
+      icon-color: #{app-bar.token(theme-foreground)},
+      focus-indicator-color: #{app-bar.token(theme-foreground)}
+    )
+  );
+}

--- a/src/lib/tabs/tab-bar/tab-bar.scss
+++ b/src/lib/tabs/tab-bar/tab-bar.scss
@@ -1,5 +1,8 @@
 @use './core' as *;
+@use '../../app-bar/app-bar';
 @use '../../icon-button';
+@use '../tab';
+@use '../../core/styles/theme';
 
 //
 // Host
@@ -105,5 +108,26 @@ forge-icon-button {
 :host([clustered='end']) {
   .forge-tab-bar {
     @include override(justify, flex-end, value);
+  }
+}
+
+//
+// App Bar Theme
+//
+
+:host([theme='app-bar']) {
+  @include tab.provide-theme(
+    (
+      active-color: #{app-bar.token(theme-foreground)},
+      inactive-color: #{app-bar.token(theme-foreground-muted)}
+    )
+  );
+
+  forge-icon-button {
+    @include icon-button.provide-theme(
+      (
+        icon-color: #{app-bar.token(theme-foreground)}
+      )
+    );
   }
 }

--- a/src/stories/components/app-bar/AppBar.mdx
+++ b/src/stories/components/app-bar/AppBar.mdx
@@ -25,19 +25,35 @@ The following example shows the usage of all of the common app bar elements plac
 
 ## Theming
 
-> **Important:** The following information was introduced in version `3.8.0` and is not available in earlier versions.
->
-> If you are seeing any problems with theming of sub-components, please ensure you are using the latest version of Forge, and then continue reading.
-
-The app bar will automatically use the "brand" theme by default, and apply the appropriate colors to the background and text. This handles the most common use cases,
-but you can also customize the app bar to use a different theme or color scheme. There are also additional utilities to help you theme the app bar and its sub-components.
+The app bar will automatically use the "brand" theme by default, and inherit global theme tokens to ensure child elements are styled accordingly. This handles the most
+common use cases, but you can also customize the app bar to use a different theme or adjust how its theme tokens are applied.
 
 The important aspect of theming the app bar is to correctly style the sub-components that are placed within it. By default the app bar will set the `color` style
-that it expects, which will be inherited automatically to most text content. However, some elements may need to be explicitly set to the correct colors. For this reason,
-we have provided a built in `theme="app-bar"` attribute that can be applied to common elements such as `<forge-icon-button>`, `<forge-button>`, and `<forge-tab-bar>`.
+that it expects, which will be inherited automatically by most child elements. This comes with the caveat that some child elements may inherit color styles incorrectly.
+This issue is most commonly seen with popovers and dialogs that placed as children within the app bar, and the global theme tokens may cascade to those elements causing
+problems with the colors.
 
+### Theme Mode
+
+The app bar has two theme modes:
+- `"inherit"` _(default)_: The app bar will inherit the global theme tokens and apply them to the app bar and its child elements.
+- `"scoped"`: The app bar will set its own theme tokens and scope them to the app bar only. No global theme tokens will be applied to the app bar or its child elements.
+
+To handle the problem where the global theme is cascading to child elements that you don't want to inherit the theme, you can set the `theme-mode` attribute on the app bar
+to `"scoped"`. This will ensure that the app bar's theme tokens are scoped to only the app bar, and switches the app bar to instead set scoped theme tokens for the child elements
+to optionally inherit.
+
+This fixes the problem of cascading global theme tokens to child elements, but you may potentially see another issue when doing this where certain elements placed directly in the app bar
+may no longer be inheriting the correct theme colors because this inheritance has been disabled. To fix this problem, Forge provides a `theme="app-bar"` attribute that can be set on
+the following child elements to allow for them to inherit the "scoped" theme tokens from the app bar:
+
+- `<forge-button>`
+- `<forge-icon-button>`
+- `<forge-tab-bar>`
+
+Example usage with `theme-mode="scoped"`:
 ```html
-<forge-app-bar>
+<forge-app-bar theme-mode="scoped">
   <!-- Themed icon button -->
   <forge-icon-button slot="end" theme="app-bar">
     <forge-icon name="settings"></forge-icon>
@@ -55,7 +71,7 @@ we have provided a built in `theme="app-bar"` attribute that can be applied to c
 </forge-app-bar>
 ```
 
-Using the `theme="app-bar"` attribute will automatically set the correct colors for usage within an app bar. Keep in mind that the following convenience components automatically set 
+Using the `theme="app-bar"` attribute will automatically set the correct colors for usage within a scoped app bar. Keep in mind that the following convenience components automatically set 
 this attribute for you, so you do not need to set it manually:
 
 - `<forge-app-bar-menu-button>`
@@ -63,9 +79,14 @@ this attribute for you, so you do not need to set it manually:
 - `<forge-app-bar-profile-button>`
 - `<forge-app-bar-notification-button>`
 
-> **Note:** The `theme="app-bar"` attribute is only supported on a small subset of components.
+> **Note:** The `theme="app-bar"` attribute is only supported on a small subset of Forge components as noted above.
 >
-> If you are using a component that does not support this attribute, you will need to manually use the app bar's theme tokens:
+> If you are using a component that does not support this attribute, but would like it to inherit the scoped theme tokens, you will need to manually reference the app bar's scoped theme tokens:
+>
+> Available scoped tokens:
+> - `--forge-app-bar-theme-foreground`: The foreground color of the app bar theme.
+> - `--forge-app-bar-theme-background-muted`: A muted foreground color using the `medium` color emphasis.
+>
 > ```css
 > forge-app-bar forge-avatar {
 >   --forge-avatar-background: var(--forge-app-bar-theme-foreground);
@@ -73,7 +94,7 @@ this attribute for you, so you do not need to set it manually:
 > }
 > ```
 >
-> This will ensure that the component uses the correct colors for the app bar theme.
+> This will ensure that this component uses the correct colors for the app bar theme.
   
 
 ### White Theme
@@ -83,11 +104,14 @@ white and the contrast/text color to black.
 
 <Canvas of={AppBarStories.WhiteTheme} />
 
-> **Note:** The sub-components will properly inherit the correct theme colors if using the `theme="app-bar"` attribute.
+> **Note:** The sub-components will properly inherit the correct theme colors if using the `theme="app-bar"` attribute, and this can be used in conjunction with the `theme-mode="scoped"` attribute.
 
 ### Custom Theme
 
-The app bar can also be themed using a custom theme by using the design tokens as CSS variables. This allows you to set the background color, text color, and other styles using to match your desired brand.
+The app bar can also be themed using a custom theme by using the design tokens as CSS variables. This allows you to set the background color, text color, and
+other styles using to match your desired brand.
+
+In addition to the above, if you want to disable inheritance of global theme tokens you can set `theme-mode="scoped"`.
 
 <Canvas of={AppBarStories.CustomTheme} />
 

--- a/src/stories/components/app-bar/AppBar.mdx
+++ b/src/stories/components/app-bar/AppBar.mdx
@@ -23,13 +23,58 @@ The following example shows the usage of all of the common app bar elements plac
 
 <Canvas of={AppBarStories.Full} />
 
-## Themed
+## Theming
 
-The app bar can be themed by providing a `theme` attribute. By default it will automatically use the "brand" theme and apply the appropriate colors
-to itself and all slotted elements by overriding the global theme colors within the context of the app bar itself only.
+> **Important:** The following information was introduced in version `3.8.0` and is not available in earlier versions.
+>
+> If you are seeing any problems with theming of sub-components, please ensure you are using the latest version of Forge, and then continue reading.
 
-> **Important:** This means that if you adjust the global theme variables for colors, the app bar will not be affected by those changes because it
-> has its own theming context.
+The app bar will automatically use the "brand" theme by default, and apply the appropriate colors to the background and text. This handles the most common use cases,
+but you can also customize the app bar to use a different theme or color scheme. There are also additional utilities to help you theme the app bar and its sub-components.
+
+The important aspect of theming the app bar is to correctly style the sub-components that are placed within it. By default the app bar will set the `color` style
+that it expects, which will be inherited automatically to most text content. However, some elements may need to be explicitly set to the correct colors. For this reason,
+we have provided a built in `theme="app-bar"` attribute that can be applied to common elements such as `<forge-icon-button>`, `<forge-button>`, and `<forge-tab-bar>`.
+
+```html
+<forge-app-bar>
+  <!-- Themed icon button -->
+  <forge-icon-button slot="end" theme="app-bar">
+    <forge-icon name="settings"></forge-icon>
+  </forge-icon-button>
+
+  <!-- Themed button -->
+  <forge-button slot="end" theme="app-bar">Profile</forge-button>
+
+  <!-- Theme tab bar -->
+  <forge-tab-bar slot="bottom" theme="app-bar">
+    <forge-tab selected>Tab 1</forge-tab>
+    <forge-tab>Tab 2</forge-tab>
+    <forge-tab>Tab 3</forge-tab>
+  </forge-tab-bar>
+</forge-app-bar>
+```
+
+Using the `theme="app-bar"` attribute will automatically set the correct colors for usage within an app bar. Keep in mind that the following convenience components automatically set 
+this attribute for you, so you do not need to set it manually:
+
+- `<forge-app-bar-menu-button>`
+- `<forge-app-bar-help-button>`
+- `<forge-app-bar-profile-button>`
+- `<forge-app-bar-notification-button>`
+
+> **Note:** The `theme="app-bar"` attribute is only supported on a small subset of components.
+>
+> If you are using a component that does not support this attribute, you will need to manually use the app bar's theme tokens:
+> ```css
+> forge-app-bar forge-avatar {
+>   --forge-avatar-background: var(--forge-app-bar-theme-foreground);
+>   --forge-avatar-color: var(--forge-theme-text-high);
+> }
+> ```
+>
+> This will ensure that the component uses the correct colors for the app bar theme.
+  
 
 ### White Theme
 
@@ -38,13 +83,16 @@ white and the contrast/text color to black.
 
 <Canvas of={AppBarStories.WhiteTheme} />
 
+> **Note:** The sub-components will properly inherit the correct theme colors if using the `theme="app-bar"` attribute.
+
 ### Custom Theme
 
-You can also provide a custom theme by setting the `theme="custom"` attribute. This will disable any global auto-theming that is built-in to the app bar
-and allow you to provide your own fully custom styling. This also allows the global theme variables to cascade down into the app bar as they normally would
-because the app bar is no longer overriding the global theme variables.
+The app bar can also be themed using a custom theme by using the design tokens as CSS variables. This allows you to set the background color, text color, and other styles using to match your desired brand.
 
 <Canvas of={AppBarStories.CustomTheme} />
+
+> **Note:** To ensure that sub-components properly inherit your custom theme, you may either need to manually override their own component-specific design tokens, or
+> you can update the app bar theme design tokens as well to ensure they are inherited by all sub-components that use the `theme="app-bar"` attribute.
 
 ## API
 

--- a/src/stories/components/app-bar/AppBar.stories.ts
+++ b/src/stories/components/app-bar/AppBar.stories.ts
@@ -19,6 +19,8 @@ const meta = {
   title: 'Components/App Bar',
   render: args => {
     const el = customElementStoryRenderer(component, args);
+    el.setAttribute('theme-mode', 'scoped');
+
     const icon = document.createElement('forge-icon');
     icon.setAttribute('slot', 'logo');
     icon.setAttribute('name', 'forge_logo');
@@ -56,7 +58,7 @@ export const Demo: Story = {};
 export const Full: Story = {
   ...standaloneStoryParams,
   render: () => html`
-    <forge-app-bar title-text="Tyler Forge™">
+    <forge-app-bar title-text="Tyler Forge™" theme-mode="scoped">
       <forge-app-bar-menu-button slot="start"></forge-app-bar-menu-button>
       <forge-icon slot="logo" name="forge_logo"></forge-icon>
       <forge-app-bar-search slot="center">
@@ -92,7 +94,7 @@ export const CustomTheme: Story = {
   `)
   ],
   render: () => html`
-    <forge-app-bar class="custom-app-bar" title-text="Tyler Forge™">
+    <forge-app-bar class="custom-app-bar" title-text="Tyler Forge™" theme-mode="scoped">
       <forge-icon slot="logo" name="forge_logo"></forge-icon>
       <forge-button slot="end" theme="app-bar">Sign In</forge-button>
     </forge-app-bar>
@@ -129,7 +131,7 @@ export const CSSOnly: Story = {
           <input type="text" placeholder="Search" aria-label="Search" id="app-bar-search" style="width: 256px" />
         </div>
         -->
-        <div class="forge-field forge-field--filled">
+        <div class="forge-field">
           <svg class="forge-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
             <path d="M0 0h24v24H0z" fill="none" />
             <path

--- a/src/stories/components/app-bar/AppBar.stories.ts
+++ b/src/stories/components/app-bar/AppBar.stories.ts
@@ -56,7 +56,7 @@ export const Demo: Story = {};
 export const Full: Story = {
   ...standaloneStoryParams,
   render: () => html`
-    <forge-app-bar title-text="Tyler Forge™" theme="custom">
+    <forge-app-bar title-text="Tyler Forge™">
       <forge-app-bar-menu-button slot="start"></forge-app-bar-menu-button>
       <forge-icon slot="logo" name="forge_logo"></forge-icon>
       <forge-app-bar-search slot="center">
@@ -81,17 +81,20 @@ export const CustomTheme: Story = {
   ...standaloneStoryParams,
   decorators: [
     storyStyles(`
-      .custom-app-bar {
-        --forge-app-bar-background: whitesmoke;
-        --forge-app-bar-foreground: darkblue;
-        --forge-theme-primary: orangered;
-      }
+.custom-app-bar {
+  --forge-app-bar-background: salmon;
+  --forge-app-bar-foreground: black;
+}
+
+.custom-app-bar forge-button {
+  margin-inline-end: var(--forge-spacing-xsmall);
+}
   `)
   ],
   render: () => html`
-    <forge-app-bar class="custom-app-bar" title-text="Tyler Forge™" theme="custom">
+    <forge-app-bar class="custom-app-bar" title-text="Tyler Forge™">
       <forge-icon slot="logo" name="forge_logo"></forge-icon>
-      <forge-button slot="end">Sign In</forge-button>
+      <forge-button slot="end" theme="app-bar">Sign In</forge-button>
     </forge-app-bar>
   `
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? Potential for visual regression, but has migration steps.
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
This change adds a new `theme-mode="scoped"` API that allows developers to opt-out of the built-in global theme token overrides that are applied to the `<forge-app-bar>` in favor of two new tokens designed specifically for targeting certain child elements within an app bar:
- `--forge-app-bar-theme-foreground`
- `--forge-app-bar-theme-foreground-muted`

These two new tokens will not apply to any elements by default, but I have also added a new opt-in `theme="app-bar"` attribute to the following components that will inherit these new tokens when rendered within an app-bar:
- `<forge-button>`
- `<forge-icon-button>`
- `<forge-tab-bar>`

The following convenience components automatically apply the `theme="app-bar"` to their internal `<forge-icon-button>` elements for you (developers should see no change when using these components):
- `<forge-app-bar-menu-button>`
- `<forge-app-bar-profile-button>`
- `<forge-app-bar-help-button>`
- `<forge-app-bar-notification-button>`

An example of the problem that this component was facing in regards to auto-theming is demonstrated here:
https://stackblitz.com/edit/forge-v3-app-bar-theming-problem-demo?file=src%2Fcustom-app-bar-component.ts,src%2Fmain.ts