### PR TITLE
fix(table): fixed a bug where the table head cell border could be hidden

### DIFF
--- a/src/lib/table/_core.scss
+++ b/src/lib/table/_core.scss
@@ -13,7 +13,7 @@
 // The base styles for the `<table>` element.
 @mixin base {
   width: 100%;
-  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 // The base styles for the rows of the table.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The border was being hidden when using `fixed-headers` because of the `background` style on the `<th>` "covering" the element due to collapsing borders.

This change unsets `border-collapse` (leaving as the default of `separate`) so that the borders are included in the cell dimensions, and instead sets `border-spacing: 0` to collapse the default cell spacing.
