### PR TITLE
fix(app-bar): remove default width to allow for wider logos without overriding styles

### DIFF
--- a/src/lib/app-bar/app-bar/_core.scss
+++ b/src/lib/app-bar/app-bar/_core.scss
@@ -88,7 +88,6 @@
 @mixin logo {
   font-size: #{token(logo-font-size)};
   height: 1em;
-  width: 1em;
 }
 
 @mixin elevation-raised {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
We only care to ensure that logos fit within the height bounds of the app bar. The width style was incorrectly restricting logos to be square causing issues and requiring devs to override this.

This change just removes the `width` style that is applied to slotted logos. This enables wider images (which is very common, especially in customer branding) where logos are not square.
