### PR TITLE
fix(list-item): fixed a bug where multiple clicks on the interactive element could occur

### DIFF
--- a/src/lib/core/utils/event-utils.ts
+++ b/src/lib/core/utils/event-utils.ts
@@ -13,3 +13,15 @@ export function proxyShadowScrollEvent(shadowEl: Node, proxyEl: Node): () => voi
 export function eventIncludesArrowKey(evt: KeyboardEvent): boolean {
   return evt.key === 'ArrowLeft' || evt.key === 'ArrowRight' || evt.key === 'ArrowUp' || evt.key === 'ArrowDown';
 }
+
+/**
+ * Returns the composed path of an event stopping at the given element.
+ * @param fromElement The element to start the composed path from.
+ * @param evt The event to get the composed path from.
+ * @returns An array of elements in the composed path starting from the given element.
+ */
+export function composedPathFrom(fromElement: HTMLElement, evt: Event): HTMLElement[] {
+  const composedElements = evt.composedPath().filter((el: Element): el is HTMLElement => el.nodeType === Node.ELEMENT_NODE);
+  const startIndex = composedElements.indexOf(fromElement);
+  return startIndex >= 0 ? composedElements.slice(0, startIndex) : [];
+}

--- a/src/lib/list/list-item/list-item-core.ts
+++ b/src/lib/list/list-item/list-item-core.ts
@@ -1,3 +1,4 @@
+import { composedPathFrom } from '../../core/utils/event-utils';
 import { IListItemAdapter } from './list-item-adapter';
 import { IListItemSelectEventData, LIST_ITEM_CONSTANTS, ListItemFocusPropagation } from './list-item-constants';
 
@@ -48,7 +49,7 @@ export class ListItemCore implements IListItemCore {
   }
 
   private _onMousedown(evt: MouseEvent): void {
-    const composedElements = evt.composedPath().filter((el: Element) => el.nodeType === Node.ELEMENT_NODE);
+    const composedElements = composedPathFrom(this._adapter.hostElement, evt);
     const fromInteractiveElement = composedElements.some(el => el === this._adapter.interactiveElement);
     if (this._focusPropagation === 'off' || !fromInteractiveElement) {
       evt.preventDefault();
@@ -56,7 +57,7 @@ export class ListItemCore implements IListItemCore {
   }
 
   private _onKeydown(evt: KeyboardEvent): void {
-    const composedElements = evt.composedPath().filter((el: Element) => el.nodeType === Node.ELEMENT_NODE);
+    const composedElements = composedPathFrom(this._adapter.hostElement, evt);
     const isFromStartEndSlot = composedElements.some((el: HTMLElement) => el.matches(LIST_ITEM_CONSTANTS.selectors.SLOTTED_START_END));
 
     if (evt.key === 'Enter' || evt.key === ' ') {
@@ -80,7 +81,7 @@ export class ListItemCore implements IListItemCore {
   }
 
   private _onClick(evt: MouseEvent): void {
-    const composedElements = evt.composedPath().filter((el: Element): el is HTMLElement => el.nodeType === Node.ELEMENT_NODE);
+    const composedElements = composedPathFrom(this._adapter.hostElement, evt);
 
     // Ignore clicks from elements that should not trigger selection
     const fromIgnoredElement = composedElements.some(el => (el as HTMLElement).matches(LIST_ITEM_CONSTANTS.selectors.IGNORE));


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Current behavior inspects the composed path for interactive events on a list item (mousedown, click, and keydown) to look for specific elements within the path of elements that event took. Since the composed path contains ALL elements within the bubbling path, it could potentially match against elements we don't care about since it's outside the scope of the specific list item.

This change adds a new utility to capture only composed elements on an event path starting from a specific element. In this case we only care about direct children of the list item.
