### PR TITLE
chore(dialog): remove unused slide direction values from `DialogAnimationType`

### DIFF
--- a/src/lib/dialog/dialog-constants.ts
+++ b/src/lib/dialog/dialog-constants.ts
@@ -90,7 +90,7 @@ export interface IDialogBeforeCloseEventData {
 
 export type DialogMode = 'modal' | 'inline-modal' | 'nonmodal';
 export type DialogType = 'dialog' | 'alertdialog';
-export type DialogAnimationType = 'none' | 'zoom' | 'fade' | 'slide' | 'slide-up' | 'slide-down' | 'slide-left' | 'slide-right';
+export type DialogAnimationType = 'none' | 'zoom' | 'fade' | 'slide';
 export type DialogPositionStrategy = 'viewport' | 'container';
 export type DialogPlacement = 'custom' | 'center' | 'top' | 'right' | 'bottom' | 'left' | 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
 export type DialogSizeStrategy = 'content' | 'container-inline' | 'container-block';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The `'slide-up' | 'slide-down' | 'slide-left' | 'slide-right'` values on the `DialogAnimationType` type are not used within the dialog component. This change just removes them from the exported type to avoid confusion.

These values were originally intended to be implemented and available during initial implementation, but it was later replaced with the `preset` API (which hardcodes these animations for the sheet variants).

## Additional information
Removed in response question raised in #898 
