### PR TITLE
fix(toolbar): Apply min-width to grid center slots to allow overflows

### DIFF
--- a/src/lib/toolbar/_core.scss
+++ b/src/lib/toolbar/_core.scss
@@ -39,6 +39,10 @@
   box-sizing: border-box;
 }
 
+@mixin inner-center {
+  min-width: 0;
+}
+
 @mixin section {
   display: flex;
   align-items: center;
@@ -48,6 +52,7 @@
 
 @mixin center {
   justify-content: center;
+  min-width: 0;
 }
 
 @mixin end {

--- a/src/lib/toolbar/toolbar.scss
+++ b/src/lib/toolbar/toolbar.scss
@@ -26,6 +26,10 @@
 
 .inner {
   @include inner;
+
+  &.center {
+    @include inner-center;
+  }
 }
 
 .section {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? Y?
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
A `min-width` has been added to the center slots of the `toolbar` component.

Fixes #908 

## Additional information
The `inner-center` received a new mix-in to avoid having a justification center added and possibly causing a break with current functionality
