### PR TITLE
chore: consolidating various defineXComponent calls to use the standard forge-core defineCustomElement call

### DIFF
--- a/src/lib/avatar/index.ts
+++ b/src/lib/avatar/index.ts
@@ -1,9 +1,9 @@
-import { tryDefine } from '@tylertech/forge-core';
-import { AVATAR_TAG_NAME, AvatarComponent } from './avatar';
+import { defineCustomElement } from '@tylertech/forge-core';
+import { AvatarComponent } from './avatar';
 
 export * from './avatar';
 export * from './avatar-constants';
 
 export function defineAvatarComponent(): void {
-  tryDefine(AVATAR_TAG_NAME, AvatarComponent);
+  defineCustomElement(AvatarComponent);
 }

--- a/src/lib/badge/index.ts
+++ b/src/lib/badge/index.ts
@@ -1,10 +1,10 @@
-import { tryDefine } from '@tylertech/forge-core';
-import { BADGE_TAG_NAME, BadgeComponent } from './badge';
+import { defineCustomElement } from '@tylertech/forge-core';
+import { BadgeComponent } from './badge';
 
 export * from './badge-component-delegate';
 export * from './badge-constants';
 export * from './badge';
 
 export function defineBadgeComponent(): void {
-  tryDefine(BADGE_TAG_NAME, BadgeComponent);
+  defineCustomElement(BadgeComponent);
 }

--- a/src/lib/card/index.ts
+++ b/src/lib/card/index.ts
@@ -1,9 +1,9 @@
-import { tryDefine } from '@tylertech/forge-core';
-import { CARD_TAG_NAME, CardComponent } from './card';
+import { defineCustomElement } from '@tylertech/forge-core';
+import { CardComponent } from './card';
 
-export * from './card-constants';
 export * from './card';
+export * from './card-constants';
 
 export function defineCardComponent(): void {
-  tryDefine(CARD_TAG_NAME, CardComponent);
+  defineCustomElement(CardComponent);
 }

--- a/src/lib/key/key-item/index.ts
+++ b/src/lib/key/key-item/index.ts
@@ -1,8 +1,8 @@
-import { tryDefine } from '@tylertech/forge-core';
-import { KEY_ITEM_TAG_NAME, KeyItemComponent } from './key-item';
+import { defineCustomElement } from '@tylertech/forge-core';
+import { KeyItemComponent } from './key-item';
 
 export * from './key-item';
 
 export function defineKeyItemComponent(): void {
-  tryDefine(KEY_ITEM_TAG_NAME, KeyItemComponent);
+  defineCustomElement(KeyItemComponent);
 }

--- a/src/lib/key/key/index.ts
+++ b/src/lib/key/key/index.ts
@@ -1,8 +1,8 @@
-import { tryDefine } from '@tylertech/forge-core';
-import { KEY_TAG_NAME, KeyComponent } from './key';
+import { defineCustomElement } from '@tylertech/forge-core';
+import { KeyComponent } from './key';
 
 export * from './key';
 
 export function defineKeyComponent(): void {
-  tryDefine(KEY_TAG_NAME, KeyComponent);
+  defineCustomElement(KeyComponent);
 }

--- a/src/lib/meter/meter-group/index.ts
+++ b/src/lib/meter/meter-group/index.ts
@@ -1,8 +1,8 @@
-import { tryDefine } from '@tylertech/forge-core';
-import { METER_GROUP_TAG_NAME, MeterGroupComponent } from './meter-group';
+import { defineCustomElement } from '@tylertech/forge-core';
+import { MeterGroupComponent } from './meter-group';
 
 export * from './meter-group';
 
 export function defineMeterGroupComponent(): void {
-  tryDefine(METER_GROUP_TAG_NAME, MeterGroupComponent);
+  defineCustomElement(MeterGroupComponent);
 }

--- a/src/lib/meter/meter/index.ts
+++ b/src/lib/meter/meter/index.ts
@@ -1,8 +1,8 @@
-import { tryDefine } from '@tylertech/forge-core';
+import { defineCustomElement } from '@tylertech/forge-core';
 import { MeterComponent } from './meter';
 
 export * from './meter';
 
 export function defineMeterComponent(): void {
-  tryDefine('forge-meter', MeterComponent);
+  defineCustomElement(MeterComponent);
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Modifying a handful of defineXComponent calls in some component `index.ts` files to use the standard `defineCustomElement` call that `forge-core` offers.
