### PR TITLE
fix(view-switcher): output height and width tokens on host element

### DIFF
--- a/src/lib/view-switcher/view-switcher.scss
+++ b/src/lib/view-switcher/view-switcher.scss
@@ -1,11 +1,17 @@
-@use './core';
+@use './core' as *;
 
 //
 // Host
 //
 
+$host-tokens: (height, width);
+
 :host {
-  @include core.host;
+  @include host;
+}
+
+:host {
+  @include tokens($includes: $host-tokens);
 }
 
 :host([hidden]) {
@@ -17,14 +23,14 @@
 //
 
 .forge-view-switcher {
-  @include core.tokens;
+  @include tokens($excludes: $host-tokens);
 }
 
 .forge-view-switcher {
-  @include core.base;
+  @include base;
 
   ::slotted(.forge-view-switcher__view--hidden) {
-    @include core.view-hidden;
+    @include view-hidden;
   }
 }
 
@@ -34,7 +40,7 @@
 
 :host(.slide) {
   ::slotted(forge-view) {
-    @include core.view-slidable;
+    @include view-slidable;
   }
 }
 
@@ -44,7 +50,7 @@
 
 :host(.fade) {
   ::slotted(forge-view) {
-    @include core.view-fadeable;
+    @include view-fadeable;
   }
 
   ::slotted(.forge-view-switcher__view--hidden) {

--- a/src/lib/view-switcher/view-switcher.ts
+++ b/src/lib/view-switcher/view-switcher.ts
@@ -27,6 +27,11 @@ declare global {
  * @tag forge-view-switcher
  *
  * @dependency forge-view
+ *
+ * @cssproperty --forge-view-switcher-height - The `height` of the view switcher.
+ * @cssproperty --forge-view-switcher-width - The `width` of the view switcher.
+ * @cssproperty --forge-view-switcher-animation-duration - The duration of view switching animations.
+ * @cssproperty --forge-view-switcher-animation-easing - The timing function of view switching animations.
  */
 @customElement({
   name: VIEW_SWITCHER_CONSTANTS.elementName,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N/A

## Describe the new behavior?
Moved the `--forge-view-switcher-height` and `--forge-view-switcher-width` declarations from the view switcher's root element to its host element to fix unexpected behavior. All custom properties have also been documented.
