### PR TITLE
Feat/table before render event

### DIFF
--- a/src/lib/table/table-constants.ts
+++ b/src/lib/table/table-constants.ts
@@ -91,6 +91,7 @@ const events = {
   FILTER: `${elementName}-filter`,
   INITIALIZED: `${elementName}-initialized`,
   COLUMN_RESIZE: `${elementName}-column-resize`,
+  BEFORE_BODY_RENDERED: `${elementName}-before-body-rendered`,
   BODY_RENDERED: `${elementName}-body-rendered`
 };
 

--- a/src/lib/table/table-core.ts
+++ b/src/lib/table/table-core.ts
@@ -600,6 +600,7 @@ export class TableCore implements ITableCore {
    * Creates and renders the table with the current column configuration and data.
    */
   public render(): void {
+    this._adapter.emitHostEvent(TABLE_CONSTANTS.events.BEFORE_BODY_RENDERED, undefined, false);
     this._adapter.createTable(this._tableConfiguration);
     this._renderSelections();
     this._rendered = true;
@@ -613,6 +614,7 @@ export class TableCore implements ITableCore {
     if (!this._rendered) {
       return;
     }
+    this._adapter.emitHostEvent(TABLE_CONSTANTS.events.BEFORE_BODY_RENDERED, undefined, false);
     this._adapter.recreateTableBody(this._tableConfiguration);
     this._renderSelections();
     this._adapter.emitHostEvent(TABLE_CONSTANTS.events.BODY_RENDERED, undefined, false);

--- a/src/lib/table/table.ts
+++ b/src/lib/table/table.ts
@@ -81,6 +81,7 @@ declare global {
     'forge-table-filter': CustomEvent<ITableFilterEventData>;
     'forge-table-initialized': CustomEvent<void>;
     'forge-table-column-resize': CustomEvent<ITableColumnResizeEventData>;
+    'forge-table-before-body-rendered': CustomEvent<void>;
     'forge-table-body-rendered': CustomEvent<void>;
   }
 }
@@ -101,6 +102,7 @@ declare global {
  * @event {CustomEvent<ITableFilterEventData>} forge-table-filter - Dispatched when a column is filtered. Only applies when `filter` is specified.
  * @event {CustomEvent<void>} forge-table-initialized - Dispatched when the table is initialized in the DOM for the first time.
  * @event {CustomEvent<ITableColumnResizeEventData>} forge-table-column-resize - Dispatched when a column is resized.
+ * @event {CustomEvent<void>} forge-table-before-body-rendered - Dispatched before the table body is rendered.
  * @event {CustomEvent<void>} forge-table-body-rendered - Dispatched when the table body is rendered.
  *
  * @cssclass forge-data-table - The base table class.

--- a/src/test/spec/table/table.spec.ts
+++ b/src/test/spec/table/table.spec.ts
@@ -383,16 +383,22 @@ describe('TableComponent', function(this: ITestContext) {
       expect(callback).toHaveBeenCalled();
     });
     
-    it('should emit body rendered event when table body renders', async function(this: ITestContext) {
+    it('should emit body rendered events in order when table body renders', function(this: ITestContext) {
       this.context = setupTestContext();
       
-      this.context.component.data = data;
-      this.context.component.columnConfigurations = columns;
+      const templateBuilderCallback = jasmine.createSpy('templateBuilderCallback');
+      const beforeRenderedCallback = jasmine.createSpy('beforeRenderedCallback');
+      const renderedCallback = jasmine.createSpy('renderedCallback');
+            
+      const tableColumns: IColumnConfiguration[] = deepCopy(columns);
+      tableColumns[0].template = templateBuilderCallback;
+      this.context.component.columnConfigurations = tableColumns;
+      this.context.component.addEventListener(TABLE_CONSTANTS.events.BEFORE_BODY_RENDERED, beforeRenderedCallback);
+      this.context.component.addEventListener(TABLE_CONSTANTS.events.BODY_RENDERED, renderedCallback);
+      this.context.component.data = deepCopy(data);
       
-      const callback = jasmine.createSpy('callback');
-      this.context.component.addEventListener(TABLE_CONSTANTS.events.BODY_RENDERED, callback);
-      this.context.component.data = [...data];
-      expect(callback).toHaveBeenCalled();
+      expect(beforeRenderedCallback).toHaveBeenCalledBefore(templateBuilderCallback);
+      expect(templateBuilderCallback).toHaveBeenCalledBefore(renderedCallback);      
     });
 
     it('should emit select-double event when double clicking a row', function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? https://github.com/tyler-technologies-oss/forge/issues/918

## Describe the new behavior?
Adds a `forge-table-before-body-rendered` event to the table that dispatches immediately before the table body renders.

## Additional information
Related to this PR: https://github.com/tyler-technologies-oss/forge/pull/919

The `forge-table-body-rendered` event does work as intended and enables some dynamic component management strategies, but I realized this `forge-table-before-body-rendered` hook is actually what would enable the strategies I was imagining most developers would want to use -- on render, operating on a cache of existing component refs, and *then* having the `TableTemplateBuilder` repopulate the cache with the new refs.
