### PR TITLE
fix(dialog): fixed a bug where the backdrop could still be clicked if persistent is set after open

### DIFF
--- a/src/lib/dialog/dialog-core.ts
+++ b/src/lib/dialog/dialog-core.ts
@@ -322,6 +322,15 @@ export class DialogCore implements IDialogCore {
     value = Boolean(value);
     if (this._persistent !== value) {
       this._persistent = value;
+
+      if (this._adapter.isConnected && this._open) {
+        if (this._persistent) {
+          this._adapter.removeBackdropDismissListener(this._backdropDismissListener);
+        } else {
+          this._adapter.addBackdropDismissListener(this._backdropDismissListener);
+        }
+      }
+
       this._adapter.toggleHostAttribute(DIALOG_CONSTANTS.attributes.PERSISTENT, this._persistent);
     }
   }

--- a/src/lib/dialog/dialog.test.ts
+++ b/src/lib/dialog/dialog.test.ts
@@ -695,6 +695,16 @@ describe('Dialog', () => {
       expect(harness.isOpen).to.be.true;
     });
 
+    it('should not close when pressing escape key when persistent set after open', async () => {
+      const harness = await createFixture({ open: true });
+
+      harness.dialogElement.persistent = true;
+
+      await harness.pressEscapeKey();
+
+      expect(harness.isOpen).to.be.true;
+    });
+
     it('should close when clicking outside dialog', async () => {
       const harness = await createFixture({ open: true });
 

--- a/src/lib/dialog/dialog.test.ts
+++ b/src/lib/dialog/dialog.test.ts
@@ -677,6 +677,16 @@ describe('Dialog', () => {
       expect(harness.isOpen).to.be.true;
     });
 
+    it('should not close when clicking outside dialog when persistent set after open', async () => {
+      const harness = await createFixture({ open: true });
+
+      harness.dialogElement.persistent = true;
+
+      await harness.clickOutside();
+
+      expect(harness.isOpen).to.be.true;
+    });
+
     it('should not close when pressing escape key when persistent', async () => {
       const harness = await createFixture({ open: true, persistent: true });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Allow for the persistent state to be toggled dynamically regardless of whether the dialog is open or not.

## Additional information
This fixes an order of operations issue where opening the dialog before setting the `persistent` property would still allow the dialog to be closed when the backdrop is clicked.
