### PR TITLE
fix(menu): use `arrow_right_alt` icon for cascading menus with v2 icons

### DIFF
--- a/src/lib/list-dropdown/list-dropdown-utils.ts
+++ b/src/lib/list-dropdown/list-dropdown-utils.ts
@@ -344,7 +344,7 @@ export function createListItems(
       if (!option.disabled && typeof config.cascadingElementFactory === 'function' && Array.isArray(option.options) && option.options.length) {
         // Create the trailing indicator icon to show that a child menu exists for this option.
         const optionIconElement = document.createElement('forge-icon');
-        optionIconElement.name = 'arrow_right';
+        optionIconElement.name = 'arrow_right_alt';
         optionIconElement.slot = 'trailing';
         listItemElement.appendChild(optionIconElement);
 

--- a/src/lib/menu/menu.ts
+++ b/src/lib/menu/menu.ts
@@ -1,5 +1,5 @@
 import { attachShadowTemplate, coerceBoolean, customElement, ensureChild, coreProperty, isDefined } from '@tylertech/forge-core';
-import { tylIconArrowRight } from '@tylertech/tyler-icons';
+import { tylIconArrowRightAlt } from '@tylertech/tyler-icons';
 import { PositionPlacement } from '../core/utils/position-utils';
 import { IconRegistry } from '../icon';
 import { ListComponent } from '../list';
@@ -88,7 +88,7 @@ export class MenuComponent extends ListDropdownAware implements IMenuComponent {
 
   constructor() {
     super();
-    IconRegistry.define(tylIconArrowRight);
+    IconRegistry.define(tylIconArrowRightAlt);
     this._core = new MenuCore(new MenuAdapter(this));
     attachShadowTemplate(this, template, styles);
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The recent upgrade to tyler-icons v2 uses a different icon and this was missed during testing. Just updating to use the correct icon with a different name now.
