### PR TITLE
fix(tooltip): do not render empty tooltips

### DIFF
--- a/src/lib/tooltip/tooltip-adapter.ts
+++ b/src/lib/tooltip/tooltip-adapter.ts
@@ -9,6 +9,7 @@ import { TOOLTIP_CONSTANTS } from './tooltip-constants';
 export interface ITooltipAdapter extends IBaseAdapter<ITooltipComponent> {
   readonly hostElement: ITooltipComponent;
   readonly anchorElement: HTMLElement | null;
+  readonly hasContent: boolean;
   syncAria(): void;
   detachAria(): void;
   setAnchorElement(element: HTMLElement | null): void;
@@ -24,6 +25,7 @@ export interface ITooltipAdapter extends IBaseAdapter<ITooltipComponent> {
 export class TooltipAdapter extends BaseAdapter<ITooltipComponent> implements ITooltipAdapter {
   private _contentElement: HTMLElement;
   private _arrowElement: HTMLElement;
+  private _defaultSlotElement: HTMLSlotElement;
   private _anchorElement: HTMLElement | null = null;
   private _overlayElement: IOverlayComponent | null = null;
 
@@ -31,10 +33,21 @@ export class TooltipAdapter extends BaseAdapter<ITooltipComponent> implements IT
     super(component);
     this._contentElement = getShadowElement(this._component, TOOLTIP_CONSTANTS.selectors.CONTENT);
     this._arrowElement = getShadowElement(this._component, TOOLTIP_CONSTANTS.selectors.ARROW);
+    this._defaultSlotElement = getShadowElement(this._component, TOOLTIP_CONSTANTS.selectors.DEFAULT_SLOT) as HTMLSlotElement;
   }
 
   public get anchorElement(): HTMLElement | null {
     return this._anchorElement;
+  }
+
+  /**
+   * Tooltips are considered to have content if the default slot has assigned nodes that
+   * are either elements, or text nodes with non-whitespace content.
+   */
+  public get hasContent(): boolean {
+    return this._defaultSlotElement
+      .assignedNodes({ flatten: true })
+      .some(node => node.nodeType === Node.ELEMENT_NODE || (node.nodeType === Node.TEXT_NODE && node.textContent?.trim()));
   }
 
   public syncAria(): void {

--- a/src/lib/tooltip/tooltip-constants.ts
+++ b/src/lib/tooltip/tooltip-constants.ts
@@ -39,7 +39,8 @@ const defaults = {
 
 const selectors = {
   CONTENT: '.forge-tooltip',
-  ARROW: '.arrow'
+  ARROW: '.arrow',
+  DEFAULT_SLOT: 'slot:not([name])'
 } as const;
 
 export const TOOLTIP_CONSTANTS = {

--- a/src/lib/tooltip/tooltip-core.ts
+++ b/src/lib/tooltip/tooltip-core.ts
@@ -134,6 +134,10 @@ export class TooltipCore extends WithLongpressListener(Object) implements IToolt
   }
 
   private _show(): void {
+    if (!this._adapter.hasContent) {
+      return;
+    }
+
     this._open = true;
     this._adapter.show();
     DismissibleStack.instance.add(this._adapter.hostElement);

--- a/src/lib/tooltip/tooltip.test.ts
+++ b/src/lib/tooltip/tooltip.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { nothing } from 'lit';
+import { nothing, TemplateResult } from 'lit';
 import { elementUpdated, fixture, html } from '@open-wc/testing';
 import { sendMouse, sendKeys } from '@web/test-runner-commands';
 import { task } from '../core/utils/utils';
@@ -51,6 +51,26 @@ describe('Tooltip', () => {
 
       harness.tooltipElement.open = false;
       expect(harness.isOpen).to.be.false;
+    });
+
+    it('should not open if there is no text content', async () => {
+      const harness = await createFixture({ content: nothing });
+
+      harness.tooltipElement.open = true;
+
+      expect(harness.isOpen).to.be.false;
+      expect(harness.tooltipElement.open).to.be.false;
+      expect(harness.tooltipElement.hasAttribute(TOOLTIP_CONSTANTS.attributes.OPEN)).to.be.false;
+    });
+
+    it('should open if there is an element node even if no text content', async () => {
+      const harness = await createFixture({ content: html`<span></span>` });
+
+      harness.tooltipElement.open = true;
+
+      expect(harness.isOpen).to.be.true;
+      expect(harness.tooltipElement.open).to.be.true;
+      expect(harness.tooltipElement.hasAttribute(TOOLTIP_CONSTANTS.attributes.OPEN)).to.be.true;
     });
   });
 
@@ -745,6 +765,7 @@ class TooltipHarness {
 }
 
 interface ITooltipFixtureConfig {
+  content?: string | TemplateResult | typeof nothing;
   open?: boolean;
   type?: TooltipType;
   triggerType?: TooltipTriggerType;
@@ -752,13 +773,13 @@ interface ITooltipFixtureConfig {
   offset?: number;
 }
 
-async function createFixture({ open, type, triggerType, delay, offset }: ITooltipFixtureConfig = {}): Promise<TooltipHarness> {
+async function createFixture({ content = 'Tooltip text', open, type, triggerType, delay, offset }: ITooltipFixtureConfig = {}): Promise<TooltipHarness> {
   const container = await fixture<HTMLElement>(html`
     <div>
       <button type="button" id="alt-anchor">Alt Tooltip Anchor</button>
       <button type="button" id="test-anchor">Tooltip Anchor</button>
       <forge-tooltip ?open=${open} type=${type ?? nothing} trigger-type=${triggerType ?? nothing} delay=${delay ?? nothing} offset=${offset ?? nothing}>
-        Test tooltip content
+        ${content}
       </forge-tooltip>
     </div>
   `);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Tooltips will no longer render when opened if the content is empty (whitespace). Content is only considered "empty" if there are not element nodes, or if all of the text nodes are whitespace only.
