### PR TITLE
fix(table): remove head cell filter vertical align style (#915)

### DIFF
--- a/src/lib/table/forge-table.scss
+++ b/src/lib/table/forge-table.scss
@@ -70,7 +70,6 @@ forge-table {
 
       .forge-table-head__cell {
         border: none;
-        vertical-align: bottom;
       }
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Removed  vertical-align style on head cell that was applied for filtered columns.
