### PR TITLE
feat(list-dropdown): change default icon type to component

### DIFF
--- a/src/lib/list-dropdown/list-dropdown-utils.ts
+++ b/src/lib/list-dropdown/list-dropdown-utils.ts
@@ -380,7 +380,12 @@ function createDivider(): HTMLElement {
   return document.createElement('forge-divider');
 }
 
-function createIconElement(type: ListDropdownIconType = 'font', iconName: string, iconClass?: string, componentProps?: Partial<IIconComponent>): HTMLElement {
+function createIconElement(
+  type: ListDropdownIconType = 'component',
+  iconName: string,
+  iconClass?: string,
+  componentProps?: Partial<IIconComponent>
+): HTMLElement {
   if (type === 'component') {
     const icon = document.createElement('forge-icon');
     if (iconClass) {

--- a/src/lib/select/option/option.ts
+++ b/src/lib/select/option/option.ts
@@ -150,7 +150,7 @@ export class OptionComponent extends BaseComponent implements IOptionComponent {
 
   /**
    * Gets/sets the leading icon type of this option.
-   * @default "font"
+   * @default "component"
    * @attribute leading-icon-type
    */
   @coreProperty()
@@ -178,7 +178,7 @@ export class OptionComponent extends BaseComponent implements IOptionComponent {
 
   /**
    * Gets/sets the trailing icon type of this option.
-   * @default "font"
+   * @default "component"
    * @attribute trailing-icon-type
    */
   @coreProperty()

--- a/src/test/spec/list-dropdown/list-dropdown.spec.ts
+++ b/src/test/spec/list-dropdown/list-dropdown.spec.ts
@@ -883,9 +883,9 @@ describe('ListDropdown', function(this: ITestContext) {
     expect(trailingElement).toBeTruthy();
   });
 
-  it('should set leading icon', async function(this: ITestContext) {
+  it('should set leading icon as font', async function(this: ITestContext) {
     const options: IListDropdownOption[] = [
-      { ...BASIC_OPTIONS[0], leadingIcon: 'heart', leadingIconClass: 'test-leading-icon' },
+      { ...BASIC_OPTIONS[0], leadingIcon: 'heart', leadingIconClass: 'test-leading-icon', leadingIconType: 'font' },
       { ...BASIC_OPTIONS[1] },
       { ...BASIC_OPTIONS[2] }
     ];
@@ -904,7 +904,7 @@ describe('ListDropdown', function(this: ITestContext) {
   it('should set leading icon as component', async function(this: ITestContext) {
     const options: IListDropdownOption[] = [
       { ...BASIC_OPTIONS[0] },
-      { ...BASIC_OPTIONS[1], leadingIcon: 'heart', leadingIconClass: 'test-leading-icon', leadingIconType: 'component' },
+      { ...BASIC_OPTIONS[1], leadingIcon: 'heart', leadingIconClass: 'test-leading-icon' },
       { ...BASIC_OPTIONS[2] }
     ];
     this.context = createListDropdown({ ...DEFAULT_CONFIG, options });
@@ -919,9 +919,9 @@ describe('ListDropdown', function(this: ITestContext) {
     expect(leadingIcon.classList.contains('test-leading-icon')).toBeTrue();
   });
 
-  it('should set trailing icon', async function(this: ITestContext) {
+  it('should set trailing icon as font', async function(this: ITestContext) {
     const options: IListDropdownOption[] = [
-      { ...BASIC_OPTIONS[0], trailingIcon: 'heart', trailingIconClass: 'test-trailing-icon' },
+      { ...BASIC_OPTIONS[0], trailingIcon: 'heart', trailingIconClass: 'test-trailing-icon', trailingIconType: 'font' },
       { ...BASIC_OPTIONS[1] },
       { ...BASIC_OPTIONS[2] }
     ];

--- a/src/test/spec/menu/menu.spec.ts
+++ b/src/test/spec/menu/menu.spec.ts
@@ -11,7 +11,8 @@ import {
   POPOVER_CONSTANTS,
   LIST_ITEM_CONSTANTS,
   MENU_CONSTANTS,
-  MenuOptionFactory
+  MenuOptionFactory,
+  IIconComponent
 } from '@tylertech/forge';
 import { task, frame } from '@tylertech/forge/core/utils/utils';
 import { ICON_CLASS_NAME } from '@tylertech/forge/constants';
@@ -436,10 +437,10 @@ describe('MenuComponent', function(this: ITestContext) {
 
       const list = getPopupList(getPopoverElement());
       const listItems = Array.from(list.querySelectorAll(LIST_ITEM_CONSTANTS.elementName)) as IListItemComponent[];
-      const leadingIconEl = listItems[0].querySelector('i[slot=leading]');
+      const leadingIconEl = listItems[0].querySelector('forge-icon[slot=leading]') as IIconComponent;
 
       expect(leadingIconEl).toBeTruthy();
-      expect(leadingIconEl?.textContent).toBe('code');
+      expect(leadingIconEl?.name).toBe('code');
     });
 
     it(`should load leading icons from options factory based on 'leadingIcon' or 'icon' property`, async function(this: ITestContext){
@@ -460,7 +461,7 @@ describe('MenuComponent', function(this: ITestContext) {
 
       const list = getPopupList(getPopoverElement());
       const listItems = Array.from(list.querySelectorAll(LIST_ITEM_CONSTANTS.elementName)) as IListItemComponent[];
-      const leadingIcons = listItems.map(listItem => listItem.querySelector('i[slot=leading]'));
+      const leadingIcons = listItems.map(listItem => listItem.querySelector('forge-icon[slot=leading]'));
 
       expect(leadingIcons[0]).toBeTruthy();
       expect(leadingIcons[1]).toBeTruthy();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated:  Y
- Docs have been added/updated:  Y
- Does this PR introduce a breaking change?  Y
- I have linked any related GitHub issues to be closed when this PR is merged?  N

## Describe the new behavior?
Changes the default icon type to 'component' for list-dropdown to match the behavior of the icon-button component.

