### PR TITLE
fix(overlay): do not hide overlay by default when clipped by ancestors

### DIFF
--- a/src/dev/pages/overlay/overlay.html
+++ b/src/dev/pages/overlay/overlay.html
@@ -51,7 +51,7 @@ include('./src/partials/page.ejs', {
         type: 'select',
         label: 'Hide',
         id: 'opt-hide',
-        defaultValue: 'anchorHidden',
+        defaultValue: 'never',
         options: [
           { label: 'Anchor hidden', value: 'anchorHidden' },
           { label: 'Never', value: 'never' },

--- a/src/lib/overlay/overlay-constants.ts
+++ b/src/lib/overlay/overlay-constants.ts
@@ -40,7 +40,7 @@ const events = {
 } as const;
 
 const defaults = {
-  HIDE: 'anchor-hidden' satisfies OverlayHideState,
+  HIDE: 'never' satisfies OverlayHideState,
   FLIP: 'auto' satisfies OverlayFlipState,
   SHIFT: 'auto' satisfies OverlayShiftState
 } as const;

--- a/src/lib/overlay/overlay.test.ts
+++ b/src/lib/overlay/overlay.test.ts
@@ -35,7 +35,7 @@ describe('Overlay', () => {
       expect(harness.overlayElement.positionStrategy).to.equal('fixed');
       expect(harness.overlayElement.offset).to.deep.equal({});
       expect(harness.overlayElement.shift).to.equal('auto');
-      expect(harness.overlayElement.hide).to.equal('anchor-hidden' satisfies OverlayHideState);
+      expect(harness.overlayElement.hide).to.equal('never' satisfies OverlayHideState);
       expect(harness.overlayElement.persistent).to.be.false;
       expect(harness.overlayElement.flip).to.equal('auto' as OverlayFlipState);
     });
@@ -487,7 +487,7 @@ describe('Overlay', () => {
       harness.overlayElement.positionStrategy = 'absolute';
       harness.overlayElement.offset = { mainAxis: 10, crossAxis: 10 };
       harness.overlayElement.shift = 'never';
-      harness.overlayElement.hide = 'never';
+      harness.overlayElement.hide = 'anchor-hidden';
       harness.overlayElement.flip = 'main';
       harness.overlayElement.boundary = 'test-boundary';
       harness.overlayElement.boundaryElement = document.body;
@@ -548,9 +548,11 @@ describe('Overlay', () => {
   });
 
   describe('hide', () => {
-    it('should hide when anchor element is not visible', async () => {
-      const harness = await createFixture({ open: true });
+    it('should hide when anchor element is not visible when anchor-hidden', async () => {
+      const harness = await createFixture({ open: true, hide: 'anchor-hidden' });
 
+      expect(harness.overlayElement.hide).to.equal('anchor-hidden');
+      expect(harness.overlayElement.getAttribute(OVERLAY_CONSTANTS.attributes.HIDE)).to.equal('anchor-hidden');
       expect(harness.isOpen).to.be.true;
 
       harness.anchorElement.style.marginRight = '9999px';
@@ -560,11 +562,10 @@ describe('Overlay', () => {
       expect(harness.rootElement.style.visibility).to.equal('hidden');
     });
 
-    it('should not hide when anchor element is not visible and hide is false', async () => {
-      const harness = await createFixture({ open: true, hide: 'never' });
+    it('should not hide when anchor element is not visible and hide is never (default)', async () => {
+      const harness = await createFixture({ open: true });
 
       expect(harness.overlayElement.hide).to.equal('never');
-      expect(harness.overlayElement.getAttribute(OVERLAY_CONSTANTS.attributes.HIDE)).to.equal('never');
       expect(harness.isOpen).to.be.true;
 
       harness.anchorElement.style.marginRight = '9999px';
@@ -574,7 +575,7 @@ describe('Overlay', () => {
       expect(harness.rootElement.style.display).to.not.equal('none');
     });
 
-    it('should fall back to default hide value if null value is provided', async () => {
+    it('should fall back to default hide value (never) if null value is provided', async () => {
       const harness = await createFixture();
 
       harness.overlayElement.hide = null as any;

--- a/src/lib/overlay/overlay.ts
+++ b/src/lib/overlay/overlay.ts
@@ -44,7 +44,7 @@ declare global {
  * @property {OverlayPositionStrategy} [positionStrategy="fixed"] - The positioning strategy to use for the overlay. Valid values are `'fixed'` and `'absolute'`.
  * @property {IOverlayPosition} offset - The offset to apply to the overlay position relative to the anchor element.
  * @property {OverlayShiftState} [shift="auto"] - Whether or not the anchor element should shift along the side of the overlay when scrolling.
- * @property {OverlayHideState} [hide="anchor-hidden"] - Whether or not the overlay should hide itself when the anchor element is out of view.
+ * @property {OverlayHideState} [hide="never"] - Whether or not the overlay should hide itself when the anchor element is out of view.
  * @property {boolean} persistent - Whether or not the overlay handles light dismiss itself or not.
  * @property {OverlayFlipState} [flip="auto"] - Whether or not the overlay should flip to the opposite placement when not enough room.
  * @property {string} boundary - The id of the element to use as the boundary for the overlay.
@@ -66,7 +66,7 @@ declare global {
  * @attribute {string} [inline=false] - Whether or not the overlay should be rendered inline (not in the :top-layer).
  * @attribute {string} [placement="bottom"] - The placement of the overlay relative to the anchor element.
  * @attribute {string} [position-strategy="fixed"] - The positioning strategy to use for the overlay. Valid values are `'fixed'` and `'absolute'`.
- * @attribute {string} [hide="anchor-hidden"] - Whether or not the overlay should hide itself when the anchor element is out of view.
+ * @attribute {string} [hide="never"] - Whether or not the overlay should hide itself when the anchor element is out of view.
  * @attribute {string} persistent - Whether or not the overlay handles light dismiss itself or not.
  * @attribute {OverlayShiftState} [shift="auto"] - Whether or not the anchor element should shift along the side of the overlay when scrolling.
  * @attribute {OverlayFlipState} [flip="auto"] - Tells the overlay not to flip to the opposite placement when not enough room.

--- a/src/lib/popover/popover.test.ts
+++ b/src/lib/popover/popover.test.ts
@@ -168,11 +168,11 @@ describe('Popover', () => {
     it('should proxy hide', async () => {
       const harness = await createFixture();
 
-      harness.popoverElement.hide = 'never';
+      harness.popoverElement.hide = 'anchor-hidden';
 
-      expect(harness.popoverElement.hide).to.equal('never');
-      expect(harness.popoverElement.overlay.hide).to.equal('never');
-      expect(harness.popoverElement.getAttribute(OVERLAY_CONSTANTS.attributes.HIDE)).to.equal('never');
+      expect(harness.popoverElement.hide).to.equal('anchor-hidden');
+      expect(harness.popoverElement.overlay.hide).to.equal('anchor-hidden');
+      expect(harness.popoverElement.getAttribute(OVERLAY_CONSTANTS.attributes.HIDE)).to.equal('anchor-hidden');
     });
 
     it('should proxy persistent', async () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The default state for the overlay `hide` property is now set to `"never"` (instead of `"anchor-hidden"`). This tells the overlay **not** to hide itself when its anchor element is hidden from view via a clipping container (typically a scrollable parent element/containing block).

The reason for this change is due to inconsistencies in detecting clipping ancestors across browsers. This functionality is an implementation detail behind most other popover-based components, and can be enabled if a developer chooses to use the low level overlay component directly, but otherwise this change should be transparent.

The only noticeable difference is if you scroll an anchor element while an attached overlay is open, but the anchor element is scrolled out of view, the overlay will no longer automatically hide itself by default. This is likely a more intuitive default anyway.
