### PR TITLE
fix(date-picker): toggle button will inherit density of text field if necessary

### DIFF
--- a/src/lib/date-picker/base/base-date-picker-adapter.ts
+++ b/src/lib/date-picker/base/base-date-picker-adapter.ts
@@ -282,6 +282,12 @@ export abstract class BaseDatePickerAdapter<T extends BaseComponent> extends Bas
       }
 
       const iconButtonElement = this._createToggleElement();
+
+      // Inherit the density from the text field in certain cases
+      if (textField.density === 'extra-small') {
+        iconButtonElement.density = 'small';
+      }
+
       textField.appendChild(iconButtonElement);
       this._toggleElement = iconButtonElement;
     } else if (toggleElement) {
@@ -289,7 +295,7 @@ export abstract class BaseDatePickerAdapter<T extends BaseComponent> extends Bas
     }
   }
 
-  protected _createToggleElement(): HTMLElement {
+  protected _createToggleElement(): IIconButtonComponent {
     return createToggleElement('insert_invitation');
   }
 

--- a/src/lib/date-picker/base/base-date-picker-utils.ts
+++ b/src/lib/date-picker/base/base-date-picker-utils.ts
@@ -1,4 +1,6 @@
-export function createToggleElement(iconName: string): HTMLElement {
+import { type IIconButtonComponent } from '../../icon-button/icon-button';
+
+export function createToggleElement(iconName: string): IIconButtonComponent {
   const iconButtonElement = document.createElement('forge-icon-button');
   iconButtonElement.type = 'button';
   iconButtonElement.tabIndex = -1;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The toggle button that is created dynamically and appended to the slotted `<forge-text-field>` will no adapt its density based on the density of the text-field.

## Additional information
At this point in time, we only need to adapt the density when a text-field is using the "extra-small"` density
