### PR TITLE
fix(expansion-panel): trigger toggle from keyup event

### DIFF
--- a/src/lib/expansion-panel/expansion-panel.test.ts
+++ b/src/lib/expansion-panel/expansion-panel.test.ts
@@ -314,6 +314,7 @@ describe('Expansion Panel', () => {
 
       header.focus();
       header.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      header.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', bubbles: true }));
 
       expect(el.open).to.be.true;
       expect(el.hasAttribute(EXPANSION_PANEL_CONSTANTS.attributes.OPEN)).to.be.true;
@@ -336,6 +337,7 @@ describe('Expansion Panel', () => {
 
       header.focus();
       header.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      header.dispatchEvent(new KeyboardEvent('keyup', { key: ' ', bubbles: true }));
 
       expect(el.open).to.be.true;
       expect(el.hasAttribute(EXPANSION_PANEL_CONSTANTS.attributes.OPEN)).to.be.true;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
To more closely match native keyboard interaction behavior for button-like elements, the expansion panel header/trigger listeners will only toggle upon keyup for the space and enter keys.
