### PR TITLE
fix(list): move margins from host to internal container element

### DIFF
--- a/src/lib/list/list-item/list-item.scss
+++ b/src/lib/list/list-item/list-item.scss
@@ -131,7 +131,9 @@ $_host-tokens: [indent dense-indent disabled-cursor];
 
 // Indented
 :host([indented]) {
-  @include indented;
+  .forge-list-item {
+    @include indented;
+  }
 }
 
 // Text container base

--- a/src/lib/list/list/list.scss
+++ b/src/lib/list/list/list.scss
@@ -5,7 +5,7 @@
 // Host
 //
 
-$_host-tokens: [ navlist-spacing navlist-margin navlist-height navlist-padding navlist-shape navlist-font-size navlist-font-weight];
+$_host-tokens: [navlist-spacing navlist-margin navlist-height navlist-padding navlist-shape navlist-font-size navlist-font-weight];
 
 :host {
   @include tokens($includes: $_host-tokens);
@@ -20,7 +20,9 @@ $_host-tokens: [ navlist-spacing navlist-margin navlist-height navlist-padding n
 }
 
 :host([navlist]) {
-  margin-block: #{token(navlist-spacing)};
+  .forge-list {
+    margin-block: #{token(navlist-spacing)};
+  }
 
   @include list-item.provide-theme(
     (


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
As a general best practice in Forge we do not like to set external margins on host elements to ensure the components do not affect layouts with whitespace. Margins are typically something we expect consuming developers to place on the host elements with their own styles.

The list and list item components are unique in that they have some usage patterns for built-in whitespace such as navlist block margin (typically used within dropdown lists), and `indented` where list items have `margin-inline-start` applied to convey that they are visually beneath a parent list item.

These styles were previously set on the host element, making them susceptible to global style overrides. This PR moves those styles to the shadow DOM root container element. The CSS variables are still usable, and any `margin` styles set directly on the host elements will now compound instead of override. Developers should always prefer using the tokens where possible.

## Additional information
This was brought up in relation to a global reset stylesheet setting `margin: 0` on all (`*`) elements, and it was conflicting with the indentation styles for nested lists.
