### PR TITLE
fix(FAB): remove size detection logic in favor of label slotted content only

### DIFF
--- a/src/lib/floating-action-button/floating-action-button-adapter.ts
+++ b/src/lib/floating-action-button/floating-action-button-adapter.ts
@@ -3,13 +3,10 @@ import { BaseButtonAdapter, IBaseButtonAdapter } from '../button/base/base-butto
 import { IFloatingActionButtonComponent } from './floating-action-button';
 import { FLOATING_ACTION_BUTTON_CONSTANTS } from './floating-action-button-constants';
 
-export interface IFloatingActionButtonAdapter extends IBaseButtonAdapter<IFloatingActionButtonComponent> {
-  destroy(): void;
-}
+export interface IFloatingActionButtonAdapter extends IBaseButtonAdapter<IFloatingActionButtonComponent> {}
 
 export class FloatingActionButtonAdapter extends BaseButtonAdapter<IFloatingActionButtonComponent> implements IFloatingActionButtonAdapter {
   private _labelSlotElement: HTMLSlotElement;
-  private _extendedObserver: MutationObserver | undefined;
 
   constructor(component: IFloatingActionButtonComponent) {
     super(component);
@@ -18,17 +15,8 @@ export class FloatingActionButtonAdapter extends BaseButtonAdapter<IFloatingActi
 
   public override initialize(): void {
     super.initialize();
-
-    if (!this._extendedObserver) {
-      this._startExtendedWatcher();
-    }
-
+    this._labelSlotElement.addEventListener('slotchange', () => this._detectExtendedState());
     this._detectExtendedState();
-  }
-
-  public destroy(): void {
-    this._extendedObserver?.disconnect();
-    this._extendedObserver = undefined;
   }
 
   public override toggleDefaultPopoverIcon(value: boolean): void {
@@ -36,26 +24,8 @@ export class FloatingActionButtonAdapter extends BaseButtonAdapter<IFloatingActi
     this._detectExtendedState();
   }
 
-  private _startExtendedWatcher(): void {
-    this._extendedObserver = new MutationObserver(() => this._detectExtendedState());
-    this._extendedObserver.observe(this._component, { childList: true, subtree: true, characterData: true });
-  }
-
   private _detectExtendedState(): void {
-    // If there are nodes in the "label" slot, then we always assume the extended state
-    const hasLabel = this._labelSlotElement.assignedNodes().length > 0;
-    if (hasLabel) {
-      this._rootElement.classList.add(FLOATING_ACTION_BUTTON_CONSTANTS.classes.EXTENDED);
-      return;
-    }
-
-    // Remove the extended class first so we can compare the width without it affecting the styles
-    this._rootElement.classList.remove(FLOATING_ACTION_BUTTON_CONSTANTS.classes.EXTENDED);
-
-    // When the width is greater than the height, we assume the button is in the extended state
-    const isExtended = this._component.clientWidth > this._component.clientHeight;
-    if (isExtended) {
-      this._rootElement.classList.add(FLOATING_ACTION_BUTTON_CONSTANTS.classes.EXTENDED);
-    }
+    const isExtended = this._labelSlotElement.assignedNodes().length > 0 || this._component.popoverIcon;
+    this._rootElement.classList.toggle(FLOATING_ACTION_BUTTON_CONSTANTS.classes.EXTENDED, isExtended);
   }
 }

--- a/src/lib/floating-action-button/floating-action-button-core.ts
+++ b/src/lib/floating-action-button/floating-action-button-core.ts
@@ -18,10 +18,6 @@ export class FloatingActionButtonCore extends BaseButtonCore<IFloatingActionButt
     super(adapter);
   }
 
-  public destroy(): void {
-    this._adapter.destroy();
-  }
-
   public get theme(): ButtonTheme {
     return this._theme;
   }

--- a/src/lib/floating-action-button/floating-action-button.test.ts
+++ b/src/lib/floating-action-button/floating-action-button.test.ts
@@ -126,28 +126,28 @@ describe('Floating Action Button', () => {
   });
 
   describe('Extended detection', () => {
-    it('should not be extended by default', async () => {
+    it('should not be extended without a slotted label', async () => {
       const el = await fixture<IFloatingActionButtonComponent>(html`<forge-fab><forge-icon name="favorite"></forge-icon></forge-fab>`);
 
       const rootEl = getRootEl(el);
       expect(rootEl.classList.contains(FLOATING_ACTION_BUTTON_CONSTANTS.classes.EXTENDED)).to.be.false;
     });
 
-    it('should not be extended when has short label in default slot', async () => {
+    it('should not be extended with slotted text content', async () => {
       const el = await fixture<IFloatingActionButtonComponent>(html`<forge-fab>A</forge-fab>`);
 
       const rootEl = getRootEl(el);
       expect(rootEl.classList.contains(FLOATING_ACTION_BUTTON_CONSTANTS.classes.EXTENDED)).to.be.false;
     });
 
-    it('should be extended when has long label in default slot', async () => {
+    it('should not be extended when has long label in default slot', async () => {
       const el = await fixture<IFloatingActionButtonComponent>(html`<forge-fab>Long label text</forge-fab>`);
 
       const rootEl = getRootEl(el);
-      expect(rootEl.classList.contains(FLOATING_ACTION_BUTTON_CONSTANTS.classes.EXTENDED)).to.be.true;
+      expect(rootEl.classList.contains(FLOATING_ACTION_BUTTON_CONSTANTS.classes.EXTENDED)).to.be.false;
     });
 
-    it('should be extended when has short label in label slot', async () => {
+    it('should be extended when has slotted label', async () => {
       const el = await fixture<IFloatingActionButtonComponent>(html`
         <forge-fab>
           <span slot="label">A</span>
@@ -158,11 +158,11 @@ describe('Floating Action Button', () => {
       expect(rootEl.classList.contains(FLOATING_ACTION_BUTTON_CONSTANTS.classes.EXTENDED)).to.be.true;
     });
 
-    it('should be extended when has icon and label', async () => {
+    it('should be extended when has icon and slotted label', async () => {
       const el = await fixture<IFloatingActionButtonComponent>(html`
         <forge-fab>
           <forge-icon name="favorite"></forge-icon>
-          <span>Label</span>
+          <span slot="label">Label</span>
         </forge-fab>
       `);
 

--- a/src/lib/floating-action-button/floating-action-button.ts
+++ b/src/lib/floating-action-button/floating-action-button.ts
@@ -104,10 +104,6 @@ export class FloatingActionButtonComponent extends BaseButton<FloatingActionButt
     this._core = new FloatingActionButtonCore(new FloatingActionButtonAdapter(this));
   }
 
-  public disconnectedCallback(): void {
-    this._core.destroy();
-  }
-
   public override attributeChangedCallback(name: string, oldValue: string, newValue: string): void {
     switch (name) {
       case FLOATING_ACTION_BUTTON_CONSTANTS.attributes.THEME:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? **Potentially, but only minor visually (see below).**
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
This change removes legacy size detection logic for auto-detecting the "extended" state. This logic has been the cause of a few layout bugs and support questions regarding this component over the years, and only causes confusion. The answer has been to always use the `label` slot, and this is what our guidance shows as well.

While the size-based extended functionality is unlikely to be used to be used currently, it technically could cause a small visual adjustments regarding the padding around the content internally...

IMO given that this is a legacy "feature" that is unlikely to be used nowadays, we should remove it to avoid confusion. Technically it could be seen as a breaking visual change, but guidance and documentation mention the correct way to use it so this would have been an undocumented/misused feature to begin with. Open to feedback.
