### PR TITLE
feat(date-picker): add new `dateFormat` and `shortcuts` APIs to allow for alternative built-in date formats

### DIFF
--- a/src/dev/pages/date-picker/date-picker.ejs
+++ b/src/dev/pages/date-picker/date-picker.ejs
@@ -2,7 +2,7 @@
   <forge-date-picker id="demo-date-picker">
     <forge-text-field>
       <label for="date-picker">Date</label>
-      <input type="text" id="date-picker" autocomplete="off" placeholder="">
+      <input type="text" id="date-picker" autocomplete="off" placeholder="MM/DD/YYYY" />
     </forge-text-field>
   </forge-date-picker>
 

--- a/src/dev/pages/date-picker/date-picker.html
+++ b/src/dev/pages/date-picker/date-picker.html
@@ -30,6 +30,35 @@ include('./src/partials/page.ejs', {
       },
       {
         type: 'select',
+        label: 'Date format',
+        id: 'opt-date-format',
+        defaultValue: 'MM/DD/YYYY',
+        options: [
+          { label: 'MM/DD/YYYY', value: 'MM/DD/YYYY' },
+          { label: 'MM/DD/YY', value: 'MM/DD/YY' },
+          { label: 'DD/MMM/YYYY', value: 'DD/MMM/YYYY' },
+          { label: 'MM-DD-YYYY', value: 'MM-DD-YYYY' },
+          { label: 'MM-DD-YY', value: 'MM-DD-YY' },
+          { label: 'DD-MMM-YYYY', value: 'DD-MMM-YYYY' },
+          { label: 'YYYY-MM-DD', value: 'YYYY-MM-DD' },
+          { label: 'YYYY-MMM-DD', value: 'YYYY-MMM-DD' },
+          { label: 'DD.MM.YYYY', value: 'DD.MM.YYYY' },
+          { label: 'DD.MM.YY', value: 'DD.MM.YY' }
+        ]
+      },
+      {
+        type: 'select',
+        label: 'Shortcuts',
+        id: 'opt-shortcuts',
+        defaultValue: 'default',
+        options: [
+          { label: 'Default', value: 'default' },
+          { label: 'Custom', value: 'custom' },
+          { label: 'Off', value: 'off' },
+        ]
+      },
+      {
+        type: 'select',
         label: 'Disabled days of week',
         id: 'opt-disabled-days',
         multiple: true,

--- a/src/dev/pages/date-picker/date-picker.ts
+++ b/src/dev/pages/date-picker/date-picker.ts
@@ -42,6 +42,27 @@ valueModeSelect.addEventListener('change', () => {
   datePicker.valueMode = valueModeSelect.value;
 });
 
+const dateFormatSelect = document.getElementById('opt-date-format') as ISelectComponent;
+dateFormatSelect.addEventListener('change', () => {
+  datePicker.dateFormat = dateFormatSelect.value;
+  datePickerInput.placeholder = dateFormatSelect.value;
+});
+
+const shortcutsSelect = document.getElementById('opt-shortcuts') as ISelectComponent;
+shortcutsSelect.addEventListener('change', () => {
+  let shortcuts;
+  if (shortcutsSelect.value === 'custom') {
+    shortcuts = {
+      'z': () => new Date('01/01/2050'),
+    };
+  } else if (shortcutsSelect.value === 'off') {
+    shortcuts = 'off';
+  } else {
+    shortcuts = undefined;
+  }
+  datePicker.shortcuts = shortcuts;
+});
+
 const disabledDaysSelect = document.getElementById('opt-disabled-days') as ISelectComponent;
 disabledDaysSelect.addEventListener('change', () => {
   datePicker.disabledDaysOfWeek = Array.isArray(disabledDaysSelect.value) ? disabledDaysSelect.value.map(v => +v) : [];
@@ -114,21 +135,21 @@ customCallbackToggle.addEventListener('forge-switch-change', ({ detail: selected
         const split = str.split('-');
 
         if (split.length !== 3) {
-          return null;
-        }
+        return null;
+      }
 
         const yyyy = +split[0];
         const mm = +split[1];
         const dd = split[2].indexOf('T') ? +split[2].split('T')[0] : +split[2];
 
         if (!yyyy || isNaN(yyyy) || !mm || isNaN(mm) || !dd || isNaN(dd)) {
-          return null;
-        }
+        return null;
+      }
 
         return new Date(yyyy, mm - 1, dd, 0, 0, 0, 0);
       }
 
-      return null;
+        return null;
     };
   } else {
     datePickerInput.placeholder = 'mm/dd/yyyy';

--- a/src/dev/pages/date-range-picker/date-range-picker.ejs
+++ b/src/dev/pages/date-range-picker/date-range-picker.ejs
@@ -2,8 +2,8 @@
   <forge-date-range-picker id="demo-date-range-picker">
     <forge-text-field>
       <label for="input-date-range-picker-01">Date</label>
-      <input type="text" id="input-date-range-picker-01" autocomplete="off" placeholder="">
-      <input type="text" id="input-date-range-picker-02" autocomplete="off" placeholder="">
+      <input type="text" id="input-date-range-picker-01" autocomplete="off" placeholder="MM/DD/YYYY">
+      <input type="text" id="input-date-range-picker-02" autocomplete="off" placeholder="MM/DD/YYYY">
       <span slot="helper-text">Enter a date range</span>
     </forge-text-field>
   </forge-date-range-picker>

--- a/src/dev/pages/date-range-picker/date-range-picker.html
+++ b/src/dev/pages/date-range-picker/date-range-picker.html
@@ -17,6 +17,24 @@ include('./src/partials/page.ejs', {
       },
       {
         type: 'select',
+        label: 'Date format',
+        id: 'opt-date-format',
+        defaultValue: 'MM/DD/YYYY',
+        options: [
+          { label: 'MM/DD/YYYY', value: 'MM/DD/YYYY' },
+          { label: 'MM/DD/YY', value: 'MM/DD/YY' },
+          { label: 'DD/MMM/YYYY', value: 'DD/MMM/YYYY' },
+          { label: 'MM-DD-YYYY', value: 'MM-DD-YYYY' },
+          { label: 'MM-DD-YY', value: 'MM-DD-YY' },
+          { label: 'DD-MMM-YYYY', value: 'DD-MMM-YYYY' },
+          { label: 'YYYY-MM-DD', value: 'YYYY-MM-DD' },
+          { label: 'YYYY-MMM-DD', value: 'YYYY-MMM-DD' },
+          { label: 'DD.MM.YYYY', value: 'DD.MM.YYYY' },
+          { label: 'DD.MM.YY', value: 'DD.MM.YY' }
+        ]
+      },
+      {
+        type: 'select',
         label: 'Disabled days of week',
         id: 'opt-disabled-days',
         multiple: true,

--- a/src/dev/pages/date-range-picker/date-range-picker.ts
+++ b/src/dev/pages/date-range-picker/date-range-picker.ts
@@ -45,6 +45,13 @@ valueModeSelect.addEventListener('change', () => {
   dateRangePicker.valueMode = valueModeSelect.value;
 });
 
+const dateFormatSelect = document.getElementById('opt-date-format') as ISelectComponent;
+dateFormatSelect.addEventListener('change', () => {
+  dateRangePicker.dateFormat = dateFormatSelect.value;
+  dateRangePickerToInput.placeholder = dateFormatSelect.value;
+  dateRangePickerFromInput.placeholder = dateFormatSelect.value;
+});
+
 const disabledDaysSelect = document.getElementById('opt-disabled-days') as ISelectComponent;
 disabledDaysSelect.addEventListener('change', () => {
   dateRangePicker.disabledDaysOfWeek = Array.isArray(disabledDaysSelect.value) ? disabledDaysSelect.value.map(v => +v) : [];

--- a/src/lib/core/mask/date-input-mask.ts
+++ b/src/lib/core/mask/date-input-mask.ts
@@ -1,5 +1,5 @@
 import { isNumeric } from '@tylertech/forge-core';
-import { InputMask, MaskedRange, createMask, type AppendFlags, type FactoryArg, type Masked } from 'imask';
+import { InputMask, MaskedEnum, MaskedRange, createMask, type AppendFlags, type FactoryArg, type Masked } from 'imask';
 
 export interface IDateInputMaskOptions {
   showMaskFormat?: boolean;
@@ -64,6 +64,16 @@ export class DateInputMask {
           to: 12,
           maxLength: 2
         },
+        Mmm: {
+          mask: MaskedEnum,
+          enum: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+          matchValue: (enumStr, inputStr, matchFrom) => MaskedEnum.DEFAULTS.matchValue(enumStr.toLowerCase(), inputStr.toLowerCase(), matchFrom)
+        },
+        MMM: {
+          mask: MaskedEnum,
+          enum: ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'],
+          matchValue: (enumStr, inputStr, matchFrom) => MaskedEnum.DEFAULTS.matchValue(enumStr.toLowerCase(), inputStr.toLowerCase(), matchFrom)
+        },
         DD: {
           mask: MaskedRange,
           autofix: true,
@@ -77,6 +87,13 @@ export class DateInputMask {
           from: 0,
           to: 9999,
           maxLength: 4
+        },
+        YY: {
+          mask: MaskedRange,
+          autofix: true,
+          from: 0,
+          to: 99,
+          maxLength: 2
         }
       }
     };

--- a/src/lib/core/utils/date-utils.ts
+++ b/src/lib/core/utils/date-utils.ts
@@ -1,107 +1,306 @@
 import { isValidDate } from '@tylertech/forge-core';
 
+export type SupportedDateFormats =
+  | 'MM/DD/YYYY'
+  | 'MM/DD/YY'
+  | 'DD/MMM/YYYY'
+  | 'MM-DD-YYYY'
+  | 'MM-DD-YY'
+  | 'DD-MMM-YYYY'
+  | 'YYYY-MM-DD'
+  | 'YYYY-MMM-DD'
+  | 'DD.MM.YYYY'
+  | 'DD.MM.YY';
 export const ISO_8601_REGEX =
   /^([+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24:?00)([.,]\d+(?!:))?)?(\17[0-5]\d([.,]\d+)?)?([zZ]|([+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/;
 export const ISO_TIMEZONE_REGEX = /a-z/i;
 const FUTURE_YEAR_COERCION = 10; // The number of years in the future to coerce two-digit years into current century
 
-/**
- * Parses a date string value to a `Date` object in local time.
- * @param str The date string value.
- */
-export function parseDateString(value: string): Date | null {
-  value = value.replace(/_|\s/g, ''); // Remove potential extraneous characters
+const MONTH_ABBREVIATIONS = {
+  JAN: 1,
+  FEB: 2,
+  MAR: 3,
+  APR: 4,
+  MAY: 5,
+  JUN: 6,
+  JUL: 7,
+  AUG: 8,
+  SEP: 9,
+  OCT: 10,
+  NOV: 11,
+  DEC: 12
+} as const;
 
-  // We first check if this is a valid date in ISO 8601 format and return it if so
-  if (ISO_8601_REGEX.test(value)) {
-    const iso8601Date = new Date(value);
+const MONTH_NAMES = {
+  1: 'JAN',
+  2: 'FEB',
+  3: 'MAR',
+  4: 'APR',
+  5: 'MAY',
+  6: 'JUN',
+  7: 'JUL',
+  8: 'AUG',
+  9: 'SEP',
+  10: 'OCT',
+  11: 'NOV',
+  12: 'DEC'
+} as const;
 
-    // This is an ISO string, but does it have a timezone? If not, we add current timezone offset
-    if (!ISO_TIMEZONE_REGEX.test(value)) {
-      iso8601Date.setMinutes(iso8601Date.getMinutes() + iso8601Date.getTimezoneOffset());
-    }
+// Date format patterns and their parsers
+interface DatePattern {
+  regex: RegExp;
+  parser: (parts: string[]) => Date | null;
+}
 
-    if (isValidDate(iso8601Date)) {
-      return iso8601Date;
-    }
+const DATE_PATTERNS: DatePattern[] = [
+  // YYYY-MM-DD (ISO-like numeric)
+  {
+    regex: /^(\d{4})-(\d{1,2})-(\d{1,2})$/,
+    parser: ([year, month, day]) => parseNumericDate(year, month, day, 'YMD')
+  },
+  // YYYY-MMM-DD
+  {
+    regex: /^(\d{4})-([A-Za-z]{3})-(\d{1,2})$/,
+    parser: ([year, monthAbbr, day]) => parseWithMonthAbbr(year, monthAbbr, day, 'YMD')
+  },
+  // MM/DD/YYYY or MM/DD/YY
+  {
+    regex: /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/,
+    parser: ([month, day, year]) => parseNumericDate(month, day, year, 'MDY')
+  },
+  // MM-DD-YYYY or MM-DD-YY
+  {
+    regex: /^(\d{1,2})-(\d{1,2})-(\d{2,4})$/,
+    parser: ([month, day, year]) => parseNumericDate(month, day, year, 'MDY')
+  },
+  // DD/MMM/YYYY
+  {
+    regex: /^(\d{1,2})\/([A-Za-z]{3})\/(\d{2,4})$/,
+    parser: ([day, monthAbbr, year]) => parseWithMonthAbbr(day, monthAbbr, year, 'DMY')
+  },
+  // DD-MMM-YYYY
+  {
+    regex: /^(\d{1,2})-([A-Za-z]{3})-(\d{2,4})$/,
+    parser: ([day, monthAbbr, year]) => parseWithMonthAbbr(day, monthAbbr, year, 'DMY')
+  },
+  // Numeric without separators (MMDDYYYY or MMDDYY)
+  {
+    regex: /^(\d{2})(\d{2})(\d{2,4})$/,
+    parser: ([month, day, year]) => parseNumericDate(month, day, year, 'MDY')
+  },
+  // DD.MM.YYYY or DD.MM.YY
+  {
+    regex: /^(\d{1,2})\.(\d{1,2})\.(\d{2,4})$/,
+    parser: ([day, month, year]) => parseNumericDate(day, month, year, 'DMY')
   }
+];
 
-  let values: string[] = [];
+// Format configurations
+interface FormatConfig {
+  pattern: string;
+  formatter: (date: Date) => string;
+}
 
-  // We accept dates with a "/" or "-" separator and in the format of MM/DD/YYYY
-  if (value.indexOf('/') !== -1) {
-    values = value.split('/');
-  } else if (value.indexOf('-') !== -1) {
-    values = value.split('-');
-  } else if ((value.length === 6 || value.length === 8) && !isNaN(+value)) {
-    values = [value.substring(0, 2), value.substring(2, 4), value.substring(4)];
+const FORMAT_CONFIGS: Record<SupportedDateFormats, FormatConfig> = {
+  'MM/DD/YYYY': {
+    pattern: 'MM/DD/YYYY',
+    formatter: date => `${pad(date.getMonth() + 1)}/${pad(date.getDate())}/${date.getFullYear()}`
+  },
+  'MM/DD/YY': {
+    pattern: 'MM/DD/YY',
+    formatter: date => `${pad(date.getMonth() + 1)}/${pad(date.getDate())}/${String(date.getFullYear()).slice(-2)}`
+  },
+  'DD/MMM/YYYY': {
+    pattern: 'DD/MMM/YYYY',
+    formatter: date => `${pad(date.getDate())}/${MONTH_NAMES[(date.getMonth() + 1) as keyof typeof MONTH_NAMES]}/${date.getFullYear()}`
+  },
+  'MM-DD-YYYY': {
+    pattern: 'MM-DD-YYYY',
+    formatter: date => `${pad(date.getMonth() + 1)}-${pad(date.getDate())}-${date.getFullYear()}`
+  },
+  'MM-DD-YY': {
+    pattern: 'MM-DD-YY',
+    formatter: date => `${pad(date.getMonth() + 1)}-${pad(date.getDate())}-${String(date.getFullYear()).slice(-2)}`
+  },
+  'DD-MMM-YYYY': {
+    pattern: 'DD-MMM-YYYY',
+    formatter: date => `${pad(date.getDate())}-${MONTH_NAMES[(date.getMonth() + 1) as keyof typeof MONTH_NAMES]}-${date.getFullYear()}`
+  },
+  'YYYY-MM-DD': {
+    pattern: 'YYYY-MM-DD',
+    formatter: date => `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+  },
+  'YYYY-MMM-DD': {
+    pattern: 'YYYY-MMM-DD',
+    formatter: date => `${date.getFullYear()}-${MONTH_NAMES[(date.getMonth() + 1) as keyof typeof MONTH_NAMES]}-${pad(date.getDate())}`
+  },
+  'DD.MM.YYYY': {
+    pattern: 'DD.MM.YYYY',
+    formatter: date => `${pad(date.getDate())}.${pad(date.getMonth() + 1)}.${date.getFullYear()}`
+  },
+  'DD.MM.YY': {
+    pattern: 'DD.MM.YY',
+    formatter: date => `${pad(date.getDate())}.${pad(date.getMonth() + 1)}.${String(date.getFullYear()).slice(-2)}`
   }
+};
 
-  const hasMonthDayYear = values.length === 3;
-  let [month, day, year] = values;
+function pad(num: number): string {
+  return String(num).padStart(2, '0');
+}
 
-  // Ensure are month and year values are coerced from 0 to 1 in case of incomplete entry
-  if (month === '0') {
-    month = '1';
-  }
-  if (day === '0') {
-    day = '1';
-  }
-
-  // Trap for the case where only 3 digit years are entered
-  if (typeof year === 'string' && year.length === 3) {
+function normalizeYear(year: string): number {
+  if (year.length === 3) {
     year = year.padStart(4, '0');
   }
 
-  if (hasMonthDayYear) {
-    const isValidMonthLength = month.length === 1 || month.length === 2;
-    const isValidDayLength = day.length === 1 || day.length === 2;
-    const isValidYearLength = year.length === 2 || year.length === 4;
+  if (year.length === 2) {
+    const currentYear = new Date().getFullYear();
+    const minYear = currentYear - (100 - FUTURE_YEAR_COERCION);
+    const maxYear = currentYear + FUTURE_YEAR_COERCION;
+    const minCentury = String(minYear).slice(0, 2);
+    const maxCentury = String(maxYear).slice(0, 2);
+    const maxYearLastTwo = +String(maxYear).slice(2);
 
-    if (!isValidMonthLength || !isValidDayLength || !isValidYearLength) {
-      return null;
-    }
+    return +year <= maxYearLastTwo ? +`${maxCentury}${year}` : +`${minCentury}${year}`;
+  }
+
+  return +year;
+}
+
+function validateAndClampDate(month: number, day: number, year: number): { month: number; day: number; year: number } {
+  const clampedMonth = Math.min(Math.max(month, 1), 12);
+  const maxDaysInMonth = new Date(year, clampedMonth, 0).getDate();
+  const clampedDay = Math.min(Math.max(day, 1), maxDaysInMonth);
+
+  return { month: clampedMonth, day: clampedDay, year };
+}
+
+function parseMonthAbbreviation(abbr: string): number | null {
+  const upperAbbr = abbr.toUpperCase() as keyof typeof MONTH_ABBREVIATIONS;
+  return MONTH_ABBREVIATIONS[upperAbbr] || null;
+}
+
+function parseNumericDate(part1: string, part2: string, part3: string, order: 'MDY' | 'YMD' | 'DMY'): Date | null {
+  let monthStr: string;
+  let dayStr: string;
+  let yearStr: string;
+
+  if (order === 'MDY') {
+    [monthStr, dayStr, yearStr] = [part1, part2, part3];
+  } else if (order === 'YMD') {
+    [yearStr, monthStr, dayStr] = [part1, part2, part3];
   } else {
+    // DMY
+    [dayStr, monthStr, yearStr] = [part1, part2, part3];
+  }
+
+  // Handle edge cases for incomplete input
+  if (monthStr === '0') {
+    monthStr = '1';
+  }
+  if (dayStr === '0') {
+    dayStr = '1';
+  }
+
+  const year = normalizeYear(yearStr);
+  const month = +monthStr;
+  const day = +dayStr;
+
+  const { month: validMonth, day: validDay, year: validYear } = validateAndClampDate(month, day, year);
+
+  const date = new Date(validYear, validMonth - 1, validDay, 0, 0, 0, 0);
+  return isValidDate(date) ? date : null;
+}
+
+function parseWithMonthAbbr(part1: string, monthAbbr: string, part3: string, order: 'DMY' | 'YMD'): Date | null {
+  const monthNum = parseMonthAbbreviation(monthAbbr);
+  if (!monthNum) {
     return null;
   }
 
-  // Check if we need to coerce two-digit years to the four-digit equivalent
-  if (year.length === 2) {
-    const minYear = new Date().getFullYear() - (100 - FUTURE_YEAR_COERCION);
-    const maxYear = new Date().getFullYear() + FUTURE_YEAR_COERCION;
-    const minYearCentury = String(minYear).slice(0, 2);
-    const maxYearCentury = String(maxYear).slice(0, 2);
-    const normalizedMaxYear = +String(maxYear).slice(2);
-    year = +year <= normalizedMaxYear ? `${maxYearCentury}${year}` : `${minYearCentury}${year}`;
+  let dayStr: string;
+  let yearStr: string;
+
+  if (order === 'DMY') {
+    [dayStr, yearStr] = [part1, part3];
+  } else {
+    [yearStr, dayStr] = [part1, part3];
   }
 
-  let numMonth = +month;
-  let numDay = +day;
-  const numYear = +year;
+  const year = normalizeYear(yearStr);
+  const day = +dayStr;
 
-  if (numMonth > 12) {
-    numMonth = 12;
+  const { day: validDay, year: validYear } = validateAndClampDate(monthNum, day, year);
+
+  const date = new Date(validYear, monthNum - 1, validDay, 0, 0, 0, 0);
+  return isValidDate(date) ? date : null;
+}
+
+function parseISO8601(value: string): Date | null {
+  if (!ISO_8601_REGEX.test(value)) {
+    return null;
   }
 
-  const maxDaysInMonth = new Date(numYear, numMonth, 0).getDate();
+  const date = new Date(value);
 
-  if (numDay > maxDaysInMonth) {
-    numDay = maxDaysInMonth;
+  // Handle timezone offset for ISO strings without explicit timezone
+  if (!ISO_TIMEZONE_REGEX.test(value)) {
+    date.setMinutes(date.getMinutes() + date.getTimezoneOffset());
   }
 
-  const parsedDate = new Date(numYear, numMonth - 1, numDay, 0, 0, 0, 0);
-  return isValidDate(parsedDate) ? parsedDate : null;
+  return isValidDate(date) ? date : null;
 }
 
 /**
- * Formats a `Date` to a specified format.
- * @param str The date string value.
+ * Parses a date string value to a `Date` object in local time.
+ * Supports multiple formats as defined in SupportedDateFormats.
+ *
+ * @param value The date string value to parse
+ * @param format Optional format hint for better parsing accuracy
+ * @returns Parsed Date object or null if parsing fails
  */
-export function formatDate(date: Date): string {
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  const year = String(date.getFullYear()).padStart(4, '0');
-  return [month, day, year].join('/');
+export function parseDateString(value: string, format?: SupportedDateFormats): Date | null {
+  const cleanValue = value.replace(/[_\s]/g, '');
+
+  // Try ISO 8601 first
+  const isoDate = parseISO8601(cleanValue);
+  if (isoDate) {
+    return isoDate;
+  }
+
+  // Try each pattern until one matches
+  for (const pattern of DATE_PATTERNS) {
+    const match = cleanValue.match(pattern.regex);
+    if (match) {
+      const result = pattern.parser(match.slice(1));
+      if (result) {
+        return result;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Formats a Date object to a specified string format.
+ *
+ * @param date The Date object to format
+ * @param format The desired output format (defaults to 'MM/DD/YYYY')
+ * @returns Formatted date string
+ * @throws Error if date is invalid or format is unsupported
+ */
+export function formatDate(date: Date, format: SupportedDateFormats = 'MM/DD/YYYY'): string {
+  if (!isValidDate(date)) {
+    throw new Error('Invalid date provided');
+  }
+
+  const config = FORMAT_CONFIGS[format];
+  if (!config) {
+    throw new Error(`Unsupported format: ${format}`);
+  }
+
+  return config.formatter(date);
 }
 
 /**

--- a/src/lib/date-picker/base/base-date-picker-constants.ts
+++ b/src/lib/date-picker/base/base-date-picker-constants.ts
@@ -1,10 +1,18 @@
 import { Masked, InputMask, type AppendFlags, type FactoryArg } from 'imask';
 import { DayOfWeek, ICalendarDateSelectEventData } from '../../calendar';
+import { type IDatePickerComponent } from '../date-picker';
+import { SupportedDateFormats } from '../../core/utils/date-utils';
 
-export declare type DatePickerParseCallback = (value: string) => Date | null;
-export declare type DatePickerFormatCallback = (value: Date | null) => string;
-export declare type DatePickerPrepareMaskCallback = (value: string, masked: Masked<string>, flags: AppendFlags, maskInstance: InputMask<FactoryArg>) => string;
-export declare type DatePickerValueMode = 'object' | 'string' | 'iso-string';
+export type DatePickerParseCallback = (value: string) => Date | null;
+export type DatePickerFormatCallback = (value: Date | null) => string | null;
+export type DatePickerPrepareMaskCallback = (value: string, masked: Masked<string>, flags: AppendFlags, maskInstance: InputMask<FactoryArg>) => string;
+export type DatePickerValueMode = 'object' | 'string' | 'iso-string';
+export type DatePickerShortcuts = IDatePickerShortcuts | 'off' | undefined;
+export type DatePickerDateFormat = SupportedDateFormats;
+
+export interface IDatePickerShortcuts {
+  [key: string]: (context: { instance: IDatePickerComponent }) => Date | null | undefined | void;
+}
 
 export interface IDatePickerCalendarDropdownConfig<T> {
   value?: T | null;
@@ -43,7 +51,9 @@ const observedAttributes = {
   MASKED: 'masked',
   MASK_FORMAT: 'mask-format',
   SHOW_MASK_FORMAT: 'show-mask-format',
+  DATE_FORMAT: 'date-format',
   VALUE_MODE: 'value-mode',
+  SHORTCUTS: 'shortcuts',
   ALLOW_INVALID_DATE: 'allow-invalid-date',
   SHOW_TODAY: 'show-today',
   SHOW_CLEAR: 'show-clear',
@@ -62,8 +72,27 @@ const selectors = {
   TOGGLE: '[forge-date-picker-toggle],[data-forge-date-picker-toggle]'
 };
 
+const defaults = {
+  DATE_FORMAT: 'MM/DD/YYYY' as DatePickerDateFormat
+};
+
+const supportedDateFormats: DatePickerDateFormat[] = [
+  'MM/DD/YYYY',
+  'MM/DD/YY',
+  'DD/MMM/YYYY',
+  'MM-DD-YYYY',
+  'MM-DD-YY',
+  'DD-MMM-YYYY',
+  'YYYY-MM-DD',
+  'YYYY-MMM-DD',
+  'DD.MM.YYYY',
+  'DD.MM.YY'
+];
+
 export const BASE_DATE_PICKER_CONSTANTS = {
   observedAttributes,
   attributes,
-  selectors
+  selectors,
+  defaults,
+  supportedDateFormats
 };

--- a/src/lib/date-picker/base/base-date-picker.ts
+++ b/src/lib/date-picker/base/base-date-picker.ts
@@ -1,16 +1,18 @@
-import { coerceBoolean, ensureChild, coreProperty, coerceNumberArray } from '@tylertech/forge-core';
+import { coerceBoolean, coerceNumberArray, coreProperty, ensureChild } from '@tylertech/forge-core';
 import { DayOfWeek } from '../../calendar/calendar-constants';
 import { BaseComponent, IBaseComponent } from '../../core/base/base-component';
+import { IBaseDatePickerAdapter } from './base-date-picker-adapter';
 import {
   BASE_DATE_PICKER_CONSTANTS,
+  DatePickerDateFormat,
   DatePickerFormatCallback,
   DatePickerParseCallback,
   DatePickerPrepareMaskCallback,
+  DatePickerShortcuts,
   DatePickerValueMode,
   IDatePickerCalendarDropdownText
 } from './base-date-picker-constants';
 import { BaseDatePickerCore } from './base-date-picker-core';
-import { IBaseDatePickerAdapter } from './base-date-picker-adapter';
 
 export interface IBaseDatePickerComponent<TValue> extends IBaseComponent {
   value: TValue | null | undefined;
@@ -27,7 +29,9 @@ export interface IBaseDatePickerComponent<TValue> extends IBaseComponent {
   masked: boolean;
   maskFormat: string;
   showMaskFormat: boolean;
+  dateFormat: DatePickerDateFormat;
   valueMode: DatePickerValueMode;
+  shortcuts: DatePickerShortcuts;
   notifyInputValueChanges: boolean;
   allowInvalidDate: boolean;
   showToday: boolean;
@@ -58,9 +62,11 @@ export interface IBaseDatePickerComponent<TValue> extends IBaseComponent {
  * @property {DatePickerPrepareMaskCallback} prepareMaskCallback - The callback to use when altering default mask entry.
  * @property {boolean} [showClear=false] - Whether the clear button is visible in the popup.
  * @property {boolean} [showMaskFormat=false] - Whether the mask format is displayed in the input or not. Only applies if `masked` is `true`.
+ * @property {DatePickerDateFormat} [dateFormat='MM/DD/YYYY'] - The date format to use for the date picker.
  * @property {boolean} [showToday=false] - Whether the today button is visible in the popup.
  * @property {TValue} value - The value of the date picker.
  * @property {DatePickerValueMode} valueMode - The type for the `value` property and `forge-date-picker-change` event.
+ * @property {DatePickerShortcuts} shortcuts - The shortcuts to use for the date picker. Can be an object with key-value pairs where the key is the shortcut name and the value is a function that returns a `Date` object.
  * @property {string} yearRange - The year range.
  *
  * @attribute {boolean} [allow-invalid-date=false] - Whether to allow an invalid date to be input. When true, the date picker will not clear out the value of the input if the date was invalid (i.e. could not be parsed).
@@ -76,8 +82,10 @@ export interface IBaseDatePickerComponent<TValue> extends IBaseComponent {
  * @attribute {string} [popup-classes] - The CSS classes that are applied to the popup element.
  * @attribute {boolean} [show-clear=false] - Whether the clear button is visible in the popup.
  * @attribute {boolean} [show-mask-format=false] - Whether the mask format is displayed in the input or not. Only applies if `masked` is `true`.
+ * @attribute {DatePickerDateFormat} [date-format=MM/DD/YYYY] - The date format to use for the date picker.
  * @attribute {boolean} [show-today=false] - Whether the today button is visible in the popup.
  * @attribute {DatePickerValueMode} [value-mode=string] - The type for the `value` property and `forge-date-picker-change` event.
+ * @attribute {DatePickerShortcuts} shortcuts - When specifies as an attribute you can only use the `off` value to disable shortcuts. Otherwise, you can use the `shortcuts` property to set your own shortcuts.
  * @attribute {string} [year-range] - The year range.
  */
 export abstract class BaseDatePickerComponent<
@@ -131,11 +139,17 @@ export abstract class BaseDatePickerComponent<
       case BASE_DATE_PICKER_CONSTANTS.observedAttributes.SHOW_MASK_FORMAT:
         this.showMaskFormat = coerceBoolean(newValue);
         break;
+      case BASE_DATE_PICKER_CONSTANTS.observedAttributes.DATE_FORMAT:
+        this.dateFormat = newValue as DatePickerDateFormat;
+        break;
       case BASE_DATE_PICKER_CONSTANTS.observedAttributes.MASK_FORMAT:
         this.maskFormat = newValue;
         break;
       case BASE_DATE_PICKER_CONSTANTS.observedAttributes.VALUE_MODE:
         this.valueMode = newValue as DatePickerValueMode;
+        break;
+      case BASE_DATE_PICKER_CONSTANTS.observedAttributes.SHORTCUTS:
+        this.shortcuts = newValue === 'off' ? {} : undefined;
         break;
       case BASE_DATE_PICKER_CONSTANTS.observedAttributes.ALLOW_INVALID_DATE:
         this.allowInvalidDate = coerceBoolean(newValue);
@@ -192,7 +206,13 @@ export abstract class BaseDatePickerComponent<
   declare public showMaskFormat: boolean;
 
   @coreProperty()
+  declare public dateFormat: DatePickerDateFormat;
+
+  @coreProperty()
   declare public valueMode: DatePickerValueMode;
+
+  @coreProperty()
+  declare public shortcuts: DatePickerShortcuts;
 
   @coreProperty()
   declare public notifyInputValueChanges: boolean;

--- a/src/lib/date-picker/date-picker-core.ts
+++ b/src/lib/date-picker/date-picker-core.ts
@@ -85,7 +85,7 @@ export class DatePickerCore extends BaseDatePickerCore<IDatePickerAdapter, Date 
 
     const formattedValue = this._formatDate(value);
 
-    this._adapter.setInputValue(formattedValue, this._notifyInputValueChanges);
+    this._adapter.setInputValue(formattedValue ?? '', this._notifyInputValueChanges);
     this._formatInputValue();
 
     if (!Platform.isMobile) {

--- a/src/lib/date-range-picker/date-range-picker-core.ts
+++ b/src/lib/date-range-picker/date-range-picker-core.ts
@@ -150,7 +150,7 @@ export class DateRangePickerCore extends BaseDatePickerCore<IDateRangePickerAdap
   }
 
   protected _setFormattedInputValue(suppressValueChanges?: boolean): void {
-    let formattedDate = this._formatDate(this._from);
+    let formattedDate = this._formatDate(this._from) ?? '';
     if (!formattedDate && !this._allowInvalidDate) {
       formattedDate = '';
     }
@@ -158,7 +158,7 @@ export class DateRangePickerCore extends BaseDatePickerCore<IDateRangePickerAdap
   }
 
   private _setFormattedToInputValue(suppressValueChanges?: boolean): void {
-    let formattedDate = this._formatDate(this._to);
+    let formattedDate = this._formatDate(this._to) ?? '';
     if (!formattedDate && !this._allowInvalidDate) {
       formattedDate = '';
     }
@@ -214,8 +214,8 @@ export class DateRangePickerCore extends BaseDatePickerCore<IDateRangePickerAdap
 
     const formattedFromValue = this._formatDate((value && value.from) || null);
     const formattedToValue = this._formatDate((value && value.to) || null);
-    this._adapter.setInputValue(formattedFromValue, this._notifyInputValueChanges);
-    this._adapter.setToInputValue(formattedToValue, this._notifyInputValueChanges);
+    this._adapter.setInputValue(formattedFromValue ?? '', this._notifyInputValueChanges);
+    this._adapter.setToInputValue(formattedToValue ?? '', this._notifyInputValueChanges);
     this._formatInputValue();
     this._formatToInputValue();
 
@@ -253,6 +253,17 @@ export class DateRangePickerCore extends BaseDatePickerCore<IDateRangePickerAdap
       this._setFormattedToInputValue();
     }
     super._applyMax();
+  }
+
+  protected override _applyMask(): void {
+    super._applyMask();
+
+    if (this._masked) {
+      this._initializeToMask();
+    } else {
+      this._adapter.destroyToMask();
+      this._formatToInputValue();
+    }
   }
 
   protected _initializeToMask(): void {

--- a/src/stories/components/date-picker/DatePicker.mdx
+++ b/src/stories/components/date-picker/DatePicker.mdx
@@ -10,15 +10,42 @@ Date pickers are used to allow users to select a date from a calendar.
 
 <Canvas of={DatePickerStories.Demo} />
 
+## Alternative Date Formats
+
+The date picker component supports multiple built-in date formats, which can be set via the `date-format` attribute. The default format is `MM/DD/YYYY`,
+but you can change it to any of the following formats:
+
+- `MM/DD/YYYY`
+- `MM/DD/YY`
+- `DD/MMM/YYYY`
+- `MM-DD-YYYY`
+- `MM-DD-YY`
+- `DD-MMM-YYYY`
+- `YYYY-MM-DD`
+- `YYYY-MMM-DD`
+- `DD.MM.YYYY`
+- `DD.MM.YY`
+
+When changing the default format, the date picker will automatically update the input mask to match the new format as well as handle the parsing and formatting of the date value.
+
+<Canvas of={DatePickerStories.DateFormats} />
+
 ## Custom Date Format
 
-Input masking is enabled by default to ensure the user enters the date in the correct format, but you can also customize the date format via the `parseCallback`, `formatCallback`,
-and `maskFormat` properties.
+You can also customize the date format via the `parseCallback`, `formatCallback`, and `maskFormat` properties. This gives you full control over how the date is parsed from the input string and how it is formatted back into a string for display.
+
+The following mask segment blocks are supported for the `mask-format` attribute:
+
+- `Mmm` - Month abbreviation (e.g., Jan, Feb, Mar)
+- `MMM` - Month abbreviation uppercase (e.g., JAN, FEB, MAR)
+- `DD` - Day of the month with leading zero (01 to 31)
+- `YYYY` - Four-digit year (e.g., 2025)
+- `YY` - Two-digit year (e.g., 25)
 
 <Canvas of={DatePickerStories.CustomFormat} />
 
 In the example above, the `parseCallback` function is used to parse the date string into a `Date` object, and the `formatCallback` function is used to format the date object into a string
-using the `YYYY-MM-DD` format. You will also need to set the `mask-format` attribute to `YYYY-MM-DD` to enable input masking support.
+using the `Mmm DD, YYYY` format. You will also need to set the `mask-format` attribute to `Mmm DD, YYYY` to enable input masking support.
 
 ```typescript
 function parseCallback(str: string): Date | null {
@@ -26,26 +53,77 @@ function parseCallback(str: string): Date | null {
     return null;
   }
 
-  const split = str.split('-');
+  // Regular expression to match "Mmm DD, YYYY" (e.g., "Jul 08, 2025")
+  const regex = /(\w{3}) (\d{2}), (\d{4})/;
+  const match = str.match(regex);
 
-  if (split.length !== 3) {
+  if (!match || match.length !== 4) {
     return null;
   }
 
-  const yyyy = +split[0];
-  const mm = +split[1];
-  const dd = split[2].indexOf('T') ? +split[2].split('T')[0] : +split[2];
+  const monthStr = match[1];
+  const day = parseInt(match[2], 10);
+  const year = parseInt(match[3], 10);
 
-  if (!yyyy || isNaN(yyyy) || !mm || isNaN(mm) || !dd || isNaN(dd)) {
+  // Map month abbreviations to month numbers (0-indexed)
+  const monthMap: { [key: string]: number } = {
+    Jan: 0,
+    Feb: 1,
+    Mar: 2,
+    Apr: 3,
+    May: 4,
+    Jun: 5,
+    Jul: 6,
+    Aug: 7,
+    Sep: 8,
+    Oct: 9,
+    Nov: 10,
+    Dec: 11
+  };
+  const month = monthMap[monthStr];
+
+  if (isNaN(day) || isNaN(month) || isNaN(year)) {
     return null;
   }
 
-  return new Date(yyyy, mm - 1, dd, 0, 0, 0, 0);
+  const date = new Date(year, month, day);
+
+  // Validate the date to prevent issues with invalid dates (e.g., Feb 30)
+  if (date.getFullYear() !== year || date.getMonth() !== month || date.getDate() !== day) {
+    return null;
+  }
+
+  return date;
 }
 
-function formatCallback(date: Date): string | null {
-  return date ? date.toISOString().split('T')[0] : null;
+function formatCallback(date: Date | null): string {
+  if (!date) {
+    return '';
+  }
+
+  const options: Intl.DateTimeFormatOptions = { month: 'short', day: '2-digit', year: 'numeric' };
+  return new Intl.DateTimeFormat('en-US', options).format(date);
 }
+```
+
+## Custom Shortcuts
+
+You can also customize the shortcuts available in the date picker by using the `shortcuts` property. This allows you to define your own key shortcuts based on your application's needs.
+
+The date picker supports the following built-in shortcuts by default:
+
+- `t`: Today
+
+If you need to turn off the built-in shortcuts, you can set the `shortcuts` attribute to `"off"`.
+
+If you want to add custom shortcuts, you can set the `shortcuts` property to a JavaScript object that maps key names to a callback function that returns a `Date` object. The callback function will receive the current date as an argument, which you can use to calculate the desired date.
+
+```typescript
+const shortcuts = {
+  t: (currentDate: Date) => new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate()),
+  y: (currentDate: Date) => new Date(currentDate.getFullYear(), 0, 1),
+  e: (currentDate: Date) => new Date(currentDate.getFullYear(), 11, 31),
+};
 ```
 
 ## API

--- a/src/stories/components/date-picker/DatePicker.stories.ts
+++ b/src/stories/components/date-picker/DatePicker.stories.ts
@@ -7,10 +7,10 @@ import '@tylertech/forge/date-picker';
 
 const component = 'forge-date-picker';
 
-const changeAction = action('forge-date-picker-change');
-const openAction = action('forge-date-picker-open');
-const closeAction = action('forge-date-picker-close');
-const inputAction = action('forge-date-picker-input');
+const changeAction = (evt: CustomEvent) => action('forge-date-picker-change')(evt.detail);
+const openAction = (evt: CustomEvent) => action('forge-date-picker-open')(evt.detail);
+const closeAction = (evt: CustomEvent) => action('forge-date-picker-close')(evt.detail);
+const inputAction = (evt: CustomEvent) => action('forge-date-picker-input')(evt.detail);
 
 const meta = {
   title: 'Components/Date Picker',
@@ -22,7 +22,6 @@ const meta = {
         .disabledDaysOfWeek=${args.disabledDaysOfWeek}
         .locale=${args.locale}
         .masked=${args.masked}
-        .maskedFormat=${args.maskedFormat}
         .max=${args.max}
         .min=${args.min}
         .open=${args.open}
@@ -30,6 +29,7 @@ const meta = {
         .showMaskFormat=${args.showMaskFormat}
         .showToday=${args.showToday}
         .yearRange=${args.yearRange}
+        .dateFormat=${args.dateFormat}
         @forge-date-picker-change=${changeAction}
         @forge-date-picker-open=${openAction}
         @forge-date-picker-close=${closeAction}
@@ -50,6 +50,7 @@ const meta = {
         'prepareMaskCallback',
         'formatCallback',
         'parseCallback',
+        'maskFormat',
         'popupClasses',
         'disabledDates',
         'value',
@@ -63,6 +64,12 @@ const meta = {
             labels: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
           },
           options: [0, 1, 2, 3, 4, 5, 6]
+        },
+        dateFormat: {
+          control: {
+            type: 'select'
+          },
+          options: ['MM/DD/YYYY', 'MM/DD/YY', 'DD/MMM/YYYY', 'MM-DD-YYYY', 'MM-DD-YY', 'DD-MMM-YYYY', 'YYYY-MM-DD', 'YYYY-MMM-DD', 'DD.MM.YYYY', 'DD.MM.YY']
         }
       }
     })
@@ -73,7 +80,7 @@ const meta = {
     disabledDaysOfWeek: [],
     locale: 'en-US',
     masked: true,
-    maskFormat: 'MM/DD/YYYY',
+    dateFormat: 'MM/DD/YYYY',
     max: '',
     min: '',
     open: false,
@@ -90,6 +97,24 @@ type Story = StoryObj;
 
 export const Demo: Story = {};
 
+export const DateFormats: Story = {
+  parameters: {
+    controls: {
+      include: ['dateFormat']
+    }
+  },
+  render: args => {
+    return html`
+      <forge-date-picker date-format=${args.dateFormat} @forge-date-picker-change=${changeAction}>
+        <forge-text-field>
+          <label for="date-picker-date-formats">${args.dateFormat}</label>
+          <input type="text" id="date-picker-date-formats" autocomplete="off" />
+        </forge-text-field>
+      </forge-date-picker>
+    `;
+  }
+};
+
 export const CustomFormat: Story = {
   ...standaloneStoryParams,
   render: () => {
@@ -98,33 +123,69 @@ export const CustomFormat: Story = {
         return null;
       }
 
-      const split = str.split('-');
+      // Regular expression to match "Mmm DD, YYYY" (e.g., "Jul 08, 2025")
+      const regex = /(\w{3}) (\d{2}), (\d{4})/;
+      const match = str.match(regex);
 
-      if (split.length !== 3) {
+      if (!match || match.length !== 4) {
         return null;
       }
 
-      const yyyy = +split[0];
-      const mm = +split[1];
-      const dd = split[2].indexOf('T') ? +split[2].split('T')[0] : +split[2];
+      const monthStr = match[1];
+      const day = parseInt(match[2], 10);
+      const year = parseInt(match[3], 10);
 
-      if (!yyyy || isNaN(yyyy) || !mm || isNaN(mm) || !dd || isNaN(dd)) {
+      // Map month abbreviations to month numbers (0-indexed)
+      const monthMap: { [key: string]: number } = {
+        Jan: 0,
+        Feb: 1,
+        Mar: 2,
+        Apr: 3,
+        May: 4,
+        Jun: 5,
+        Jul: 6,
+        Aug: 7,
+        Sep: 8,
+        Oct: 9,
+        Nov: 10,
+        Dec: 11
+      };
+      const month = monthMap[monthStr];
+
+      if (isNaN(day) || isNaN(month) || isNaN(year)) {
         return null;
       }
 
-      return new Date(yyyy, mm - 1, dd, 0, 0, 0, 0);
+      const date = new Date(year, month, day);
+
+      // Validate the date to prevent issues with invalid dates (e.g., Feb 30)
+      if (date.getFullYear() !== year || date.getMonth() !== month || date.getDate() !== day) {
+        return null;
+      }
+
+      return date;
     }
 
-    function formatCallback(date: Date): string | null {
-      return date ? date.toISOString().split('T')[0] : null;
+    function formatCallback(date: Date | null): string {
+      if (!date) {
+        return '';
+      }
+
+      const options: Intl.DateTimeFormatOptions = { month: 'short', day: '2-digit', year: 'numeric' };
+      return new Intl.DateTimeFormat('en-US', options).format(date);
     }
 
     return html`
-      <forge-date-picker .parseCallback=${parseCallback} .formatCallback=${formatCallback} mask-format="YYYY-MM-DD">
+      <forge-date-picker
+        .parseCallback=${parseCallback}
+        .formatCallback=${formatCallback}
+        mask-format="Mmm DD, YYYY"
+        shortcuts="off"
+        @forge-date-picker-change=${changeAction}>
         <forge-text-field>
           <label for="date-picker">Date</label>
-          <input type="text" id="date-picker" autocomplete="off" placeholder="YYYY-MM-DD" />
-          <span slot="support-text">Enter a date in the format YYYY-MM-DD</span>
+          <input type="text" id="date-picker" autocomplete="off" placeholder="Mmm DD, YYYY" />
+          <span slot="support-text">Enter a date in the format Mmm DD, YYYY (e.g., Jul 08, 2025)</span>
         </forge-text-field>
       </forge-date-picker>
     `;

--- a/src/test/spec/date-picker/date-picker.spec.ts
+++ b/src/test/spec/date-picker/date-picker.spec.ts
@@ -1566,7 +1566,7 @@ describe('DatePickerComponent', function(this: ITestContext) {
       inputElement.blur();
       inputElement.dispatchEvent(new Event('blur'));
 
-      expect(inputElement.value).toEqual('01/01/0202');
+      expect(inputElement.value).toEqual('01/01/202');
     });
 
     it('should clear mask format if the input is cleared programmatically', function(this: ITestContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Added a new `dateFormat` property (`date-format` attribute) to allow for developers to use a preset built-in alternative date format. This reduces the burden on developers to use custom parse and format callbacks, and avoids complexity related to the input mask and value coercion logic.

Additionally because the built-in `"n"` and `"t"` keyboard shortcuts for setting the "today" date value can conflict with formats that use the `MMM` block, we will automatically adjust the shortcuts when those formats are chosen. A new `shortcuts` property/attribute has also been added to allow for turning off the shortcuts manually, or to provide custom single character shortcuts.
