### PR TITLE
fix(app-bar-profile-button): fixed a bug where the popover could get destroyed before the animation completes

### DIFF
--- a/src/lib/app-bar/profile-button/app-bar-profile-button-adapter.ts
+++ b/src/lib/app-bar/profile-button/app-bar-profile-button-adapter.ts
@@ -138,7 +138,7 @@ export class AppBarProfileButtonAdapter extends BaseAdapter<IAppBarProfileButton
   public async closePopup(): Promise<void> {
     if (this._popupElement) {
       await this._popupElement.hideAsync();
-      this._popupElement.remove();
+      this._popupElement?.remove();
       this._popupElement = undefined;
       this._profileCardElement = undefined;
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
This bug can occur if the component is destroyed before the animation of the popover is complete.

## Additional information
This was found in response to clicking the profile button, and using Angular to switch routes which caused the component to be destroyed immediately, but the animation complete listener continued to run which unset the popover element reference.
