### PR TITLE
fix(time-picker): allow min and max to wrap around midnight

### DIFF
--- a/src/lib/time-picker/time-picker-core.ts
+++ b/src/lib/time-picker/time-picker-core.ts
@@ -913,11 +913,18 @@ export class TimePickerCore implements ITimePickerCore {
       this._min = this._convertTimeStringToMillis(value, true, this._allowSeconds);
 
       // Validate and reset our millis to ensure within range
+      const originalValue = this._value;
       const millis = this._validateMillis(this._value);
       this._setValue(millis);
 
       if (this._isInitialized) {
         this._applyValue(millis);
+
+        // Emit change event if the value was modified due to range validation
+        if (originalValue !== millis) {
+          const timeString = millisToTimeString(millis, true, this._allowSeconds);
+          this._emitChangeEvent(timeString);
+        }
       }
     }
   }
@@ -934,11 +941,18 @@ export class TimePickerCore implements ITimePickerCore {
       this._max = this._convertTimeStringToMillis(value, true, this._allowSeconds);
 
       // Validate and reset our millis to ensure within range
+      const originalValue = this._value;
       const millis = this._validateMillis(this._value);
       this._setValue(millis);
 
       if (this._isInitialized) {
         this._applyValue(millis);
+
+        // Emit change event if the value was modified due to range validation
+        if (originalValue !== millis) {
+          const timeString = millisToTimeString(millis, true, this._allowSeconds);
+          this._emitChangeEvent(timeString);
+        }
       }
     }
   }

--- a/src/test/spec/time-picker/time-picker.spec.ts
+++ b/src/test/spec/time-picker/time-picker.spec.ts
@@ -296,6 +296,9 @@ describe('TimePickerComponent', function(this: ITestContext) {
   it('should remove value if setting min and value is below min', function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
+    const changeEventSpy = jasmine.createSpy('change spy');
+    this.context.component.addEventListener(TIME_PICKER_CONSTANTS.events.CHANGE, changeEventSpy);
+
     const expectedTimeValue = '06:00';
     this.context.component.value = expectedTimeValue;
 
@@ -305,6 +308,8 @@ describe('TimePickerComponent', function(this: ITestContext) {
 
     expect(this.context.component.value).toBeNull();
     expect(this.context.inputElement.value).toBe('');
+    expect(changeEventSpy).toHaveBeenCalledTimes(1);
+    expect(changeEventSpy).toHaveBeenCalledWith(jasmine.objectContaining({ detail: null }));
   });
 
   it('should not set value if above max', function(this: ITestContext) {
@@ -320,6 +325,9 @@ describe('TimePickerComponent', function(this: ITestContext) {
   it('should remove value if setting max and value is above max', function(this: ITestContext) {
     this.context = _createTimePickerContext();
 
+    const changeEventSpy = jasmine.createSpy('change spy');
+    this.context.component.addEventListener(TIME_PICKER_CONSTANTS.events.CHANGE, changeEventSpy);
+
     const expectedTimeValue = '17:00';
     this.context.component.value = expectedTimeValue;
 
@@ -329,6 +337,8 @@ describe('TimePickerComponent', function(this: ITestContext) {
 
     expect(this.context.component.value).toBeNull();
     expect(this.context.inputElement.value).toBe('');
+    expect(changeEventSpy).toHaveBeenCalledTimes(1);
+    expect(changeEventSpy).toHaveBeenCalledWith(jasmine.objectContaining({ detail: null }));
   });
 
   it('should not emit change event when setting value via input element property', function(this: ITestContext) {
@@ -1022,6 +1032,23 @@ describe('TimePickerComponent', function(this: ITestContext) {
 
     const listItems = this.context.getListItems() as IListItemComponent<ITimePickerOptionValue>[];
 
+    expect(listItems[0].value.time).toBe(firstListItemMillis);
+    expect(listItems[listItems.length - 1].value.time).toBe(lastListItemMillis);
+  });
+
+  it('should show options between min and max if wrapping around midnight', async function(this: ITestContext) {
+    this.context = _createTimePickerContext();
+    const min = '23:00';
+    const max = '02:00';
+    this.context.component.min = min;
+    this.context.component.max = max;
+    this.context.component.open = true;
+    await task(POPOVER_ANIMATION_DURATION);
+
+    const firstListItemMillis = timeStringToMillis(min, true, false);
+    const lastListItemMillis = timeStringToMillis(max, true, false);
+
+    const listItems = this.context.getListItems() as IListItemComponent<ITimePickerOptionValue>[];
     expect(listItems[0].value.time).toBe(firstListItemMillis);
     expect(listItems[listItems.length - 1].value.time).toBe(lastListItemMillis);
   });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Min and max values that wrap around midnight will now show the correct options in the dropdown, and allow for values within the range defined by the min and max values.

Additionally, I also updated the `min` and `max` setters to dispatch the change event if changing the min/max values causes the time value to be removed.
