### PR TITLE
fix(menu): allow cascading menus to use bottom and top placements if left or right isn't available

### DIFF
--- a/src/lib/menu/menu-core.ts
+++ b/src/lib/menu/menu-core.ts
@@ -486,7 +486,7 @@ export class MenuCore extends CascadingListDropdownAwareCore<IMenuOption | IMenu
     menu.popupOffset = { mainAxis: 0, crossAxis: -8 };
     menu.dense = this._dense;
     menu.placement = 'right-start';
-    menu.fallbackPlacements = ['left-start', 'right-start']; // Cascading menus should only fallback to left or right placement if needed
+    menu.fallbackPlacements = ['left-start', 'right-start', 'bottom', 'top'];
     menu.persistSelection = this._persistSelection;
     if (this._persistSelection) {
       menu.selectedValue = this._selectedValue;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Previously cascading child menus would only allow either left or right fallback placements. This caused issues on smaller viewports where menus could potentially not fit on either side of the parent menu. This change adds additional fallback placements of bottom and top to try for this scenario in that order. This should allow for more graceful handling of menus on smaller viewports to ensure the user can still access the menu options.

## Additional information
While this change allows a graceful fallback, using cascading menus on mobile viewports should be avoided due to usability concerns.
