### PR TITLE
fix(field): add overflow and isolation token to the inner container element

### DIFF
--- a/src/lib/core/styles/tokens/field/_tokens.scss
+++ b/src/lib/core/styles/tokens/field/_tokens.scss
@@ -53,7 +53,8 @@ $tokens: (
   disabled-background: utils.module-val(field, disabled-background, theme.variable(surface-container-low)),
   font-size: utils.module-val(field, font-size, inherit),
   dense-font-size: utils.module-val(field, dense-font-size, typography.scale('0875')),
-  placeholder-color: utils.module-val(field, placeholder-color, theme.variable(text-medium))
+  placeholder-color: utils.module-val(field, placeholder-color, theme.variable(text-medium)),
+  overflow: utils.module-val(field, overflow, hidden)
 ) !default;
 
 @function get($key) {

--- a/src/lib/core/styles/tokens/field/_tokens.scss
+++ b/src/lib/core/styles/tokens/field/_tokens.scss
@@ -54,7 +54,8 @@ $tokens: (
   font-size: utils.module-val(field, font-size, inherit),
   dense-font-size: utils.module-val(field, dense-font-size, typography.scale('0875')),
   placeholder-color: utils.module-val(field, placeholder-color, theme.variable(text-medium)),
-  overflow: utils.module-val(field, overflow, hidden)
+  overflow: utils.module-val(field, overflow, hidden),
+  isolation: utils.module-val(field, isolation, isolate)
 ) !default;
 
 @function get($key) {

--- a/src/lib/field/_core.scss
+++ b/src/lib/field/_core.scss
@@ -87,7 +87,7 @@
 
   position: relative;
   display: grid;
-  isolation: isolate;
+  isolation: #{token(isolation)};
 
   grid-area: main;
   grid-template-areas: 'start center end popover-icon accessory';

--- a/src/lib/field/_core.scss
+++ b/src/lib/field/_core.scss
@@ -98,7 +98,7 @@
 
   inline-size: 100%;
   block-size: #{token(height)};
-  overflow: hidden;
+  overflow: #{token(overflow)};
 }
 
 @mixin surface {

--- a/src/lib/field/field.ts
+++ b/src/lib/field/field.ts
@@ -142,7 +142,7 @@ declare global {
  * @cssproperty --forge-field-disabled-opacity - The opacity of the field when disabled.
  * @cssproperty --forge-field-disabled-background - The background of the field when disabled.
  * @cssproperty --forge-field-overflow - The overflow behavior of the internal container element.
- * @cssproperty --forge-field-isolate - The isolation behavior of the internal container element.
+ * @cssproperty --forge-field-isolation - The isolation behavior of the internal container element.
  *
  * @csspart root - The root container element.
  * @csspart label - The label element.

--- a/src/lib/field/field.ts
+++ b/src/lib/field/field.ts
@@ -142,6 +142,7 @@ declare global {
  * @cssproperty --forge-field-disabled-opacity - The opacity of the field when disabled.
  * @cssproperty --forge-field-disabled-background - The background of the field when disabled.
  * @cssproperty --forge-field-overflow - The overflow behavior of the internal container element.
+ * @cssproperty --forge-field-isolate - The isolation behavior of the internal container element.
  *
  * @csspart root - The root container element.
  * @csspart label - The label element.

--- a/src/lib/field/field.ts
+++ b/src/lib/field/field.ts
@@ -141,6 +141,7 @@ declare global {
  * @cssproperty --forge-field-focus-indicator-width - The width of the focus indicator.
  * @cssproperty --forge-field-disabled-opacity - The opacity of the field when disabled.
  * @cssproperty --forge-field-disabled-background - The background of the field when disabled.
+ * @cssproperty --forge-field-overflow - The overflow behavior of the internal container element.
  *
  * @csspart root - The root container element.
  * @csspart label - The label element.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: [N]
- Docs have been added/updated: [Y]
- Does this PR introduce a breaking change? [N]
- I have linked any related GitHub issues to be closed when this PR is merged? [N]

## Describe the new behavior?
There's situations, especially when using 3rd party plugins with the text field, that we need to modify the overflow and isolation CSS properties. This change gives us an easy way to do that, but leaves the default values

<img width="1621" height="374" alt="image" src="https://github.com/user-attachments/assets/aec3fc6e-574c-4440-aa91-42577333a8ff" />

