### PR TITLE
feat(date-range-picker): fixed a bug where the input mask was not being destroyed on end date input if turning off the mask

### DIFF
--- a/src/lib/date-picker/base/base-date-picker-core.ts
+++ b/src/lib/date-picker/base/base-date-picker-core.ts
@@ -533,6 +533,12 @@ export abstract class BaseDatePickerCore<TAdapter extends IBaseDatePickerAdapter
     }
   }
 
+  protected _destroyMask(): void {
+    this._adapter.destroyMask();
+    this._setInputChangeListeners();
+    this._formatInputValue();
+  }
+
   protected _applyMin(): void {
     if (this._isInitialized) {
       this._adapter.setCalendarMinDate(this._min);
@@ -690,9 +696,7 @@ export abstract class BaseDatePickerCore<TAdapter extends IBaseDatePickerAdapter
           this._removeInputChangeListeners();
           this._applyMask();
         } else {
-          this._adapter.destroyMask();
-          this._setInputChangeListeners();
-          this._formatInputValue();
+          this._destroyMask();
         }
       }
     }

--- a/src/lib/date-range-picker/date-range-picker-core.ts
+++ b/src/lib/date-range-picker/date-range-picker-core.ts
@@ -266,6 +266,12 @@ export class DateRangePickerCore extends BaseDatePickerCore<IDateRangePickerAdap
     }
   }
 
+  protected override _destroyMask(): void {
+    super._destroyMask();
+    this._adapter.destroyToMask();
+    this._formatToInputValue();
+  }
+
   protected _initializeToMask(): void {
     if (!this._masked) {
       return;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The end date input mask was not being destroyed when setting `masked = false`, this change updates the base class to use a method for destroying the mask so that the date-range-picker can override that and ensure it cleans up the mask on the end input as well.