### PR TITLE
fix(expansion-panel): update connected check

### DIFF
--- a/src/lib/expansion-panel/expansion-panel-adapter.ts
+++ b/src/lib/expansion-panel/expansion-panel-adapter.ts
@@ -148,7 +148,7 @@ export class ExpansionPanelAdapter extends BaseAdapter<IExpansionPanelComponent>
   }
 
   private _getTriggerElementById(id: string): HTMLElement | null {
-    if (id) {
+    if (id && this.isConnected) {
       const rootNode = this._component.getRootNode() as Document | ShadowRoot;
       return rootNode.getElementById(id);
     } else {

--- a/src/lib/expansion-panel/expansion-panel-core.ts
+++ b/src/lib/expansion-panel/expansion-panel-core.ts
@@ -173,10 +173,8 @@ export class ExpansionPanelCore implements IExpansionPanelCore {
 
       this._trigger = value;
 
-      if (this._adapter.isConnected) {
-        this._adapter.setTriggerElementById(this._trigger);
-        this._syncTrigger();
-      }
+      this._adapter.setTriggerElementById(this._trigger);
+      this._syncTrigger();
     }
   }
 
@@ -189,9 +187,7 @@ export class ExpansionPanelCore implements IExpansionPanelCore {
 
       this._adapter.setTriggerElement(el);
 
-      if (this._adapter.isConnected) {
-        this._syncTrigger();
-      }
+      this._syncTrigger();
     }
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? https://github.com/tyler-technologies-oss/forge/issues/968

## Describe the new behavior?
This change guarantees checking that the component is connected before calling `getRootNode()` on the component.

## Additional information
I had this similar issue that got past forge tests that seemed to be specific to Angular before: https://github.com/tyler-technologies-oss/forge/pull/904

This fix dumbs down the `isConnected` checks and just adds one around the `getRootNode()` call. Like I mentioned in the linked issue, I don't have a full understanding of this problem or how we could better write tests for it.