### PR TITLE
fix(table): prevent duplicate filter events on delegate reuse

### DIFF
--- a/src/lib/table/table-utils.ts
+++ b/src/lib/table/table-utils.ts
@@ -1524,13 +1524,16 @@ export class TableUtils {
 
     // If this is a FormFieldComponentDelegate then we can listen for when the value changes, otherwise we just render the custom delegate element
     if (!!filterListener && delegate instanceof FormFieldComponentDelegate && isFunction(delegate.onChange)) {
-      if (!isDefined(columnConfig.filterDebounceTime) || isNumber(columnConfig.filterDebounceTime)) {
-        const debounceTime = isDefined(columnConfig.filterDebounceTime)
-          ? (columnConfig.filterDebounceTime as number)
-          : TABLE_CONSTANTS.numbers.DEFAULT_FILTER_DEBOUNCE_TIME;
-        delegate.onChange(debounce((value: any) => filterListener(value, columnIndex), debounceTime));
-      } else {
-        delegate.onChange((value: any) => filterListener(value, columnIndex));
+      if (!(delegate as any).__forgeTableListenerAttached) {
+        if (!isDefined(columnConfig.filterDebounceTime) || isNumber(columnConfig.filterDebounceTime)) {
+          const debounceTime = isDefined(columnConfig.filterDebounceTime)
+            ? (columnConfig.filterDebounceTime as number)
+            : TABLE_CONSTANTS.numbers.DEFAULT_FILTER_DEBOUNCE_TIME;
+          delegate.onChange(debounce((value: any) => filterListener(value, columnIndex), debounceTime));
+        } else {
+          delegate.onChange((value: any) => filterListener(value, columnIndex));
+        }
+        (delegate as any).__forgeTableListenerAttached = true;
       }
     }
 


### PR DESCRIPTION
Resolves issue where forge-table-filter event fires multiple times based on how many times filter elements have been rendered. This occurred when the same delegate instance was reused and onChange() was called multiple times, accumulating event listeners.

The fix adds a flag to prevent attaching multiple onChange listeners to the same delegate instance, ensuring each filter only fires one event regardless of how many times the table is re-rendered.

Issue - https://github.com/tyler-technologies-oss/forge/issues/622

## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: [Y/N]
- Docs have been added/updated: [Y/N]
- Does this PR introduce a breaking change? [Y/N]
- I have linked any related GitHub issues to be closed when this PR is merged? [Y/N]

## Describe the new behavior?
<!-- A clear and concise description of the changes, including any breaking changes (if applicable) -->
Prevents forge-table-filter events from firing multiple times when filter elements are re-rendered. The fix adds a flag (__forgeTableListenerAttached) to prevent duplicate onChange listeners from being attached to the same delegate instance when filters are toggled or tables are re-rendered.

## Additional information
<!-- Add any other context about the change here. -->
Issue: When using direct delegate instances (e.g., filterDelegate: new TextFieldComponentDelegate(...)), the onChange() method would accumulate multiple event listeners each time filters were enabled/disabled or the table was re-rendered, causing events to fire N times where N = render count.
Solution: Minimal 3-line fix that checks if a listener is already attached before adding a new one, ensuring only one active listener per delegate instance while maintaining backward compatibility with both factory functions and direct instances.

https://github.com/user-attachments/assets/bcdbab1a-3c8e-45d4-85e0-836311bd4498


