### PR TITLE
fix(menu): update offset and fallback placements for improved child menu positioning

### DIFF
--- a/src/lib/menu/menu-core.ts
+++ b/src/lib/menu/menu-core.ts
@@ -483,10 +483,10 @@ export class MenuCore extends CascadingListDropdownAwareCore<IMenuOption | IMenu
       this._onCascadingOptionSelected.bind(this)
     );
     menu.mode = 'cascade';
-    menu.popupOffset = { mainAxis: 0, crossAxis: -8 };
+    menu.popupOffset = { alignmentAxis: -8 };
     menu.dense = this._dense;
     menu.placement = 'right-start';
-    menu.fallbackPlacements = ['left-start', 'right-start', 'bottom', 'top'];
+    menu.fallbackPlacements = ['left-start', 'left-end', 'right-start', 'right-end', 'bottom', 'top'];
     menu.persistSelection = this._persistSelection;
     if (this._persistSelection) {
       menu.selectedValue = this._selectedValue;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Updates the placement values in cascading child menus to improve the alignment and fallback placements:
* Changed offset to use `alignmentAxis` instead of `mainAxis` and `crossAxis` to allow for placement-adjusted alignment when placements are flipped dynamically.
* Expanded `fallbackPlacements` to include additional placement options (`left-end`, `right-end`) for better adaptability in different screen scenarios.