### PR TITLE
fix(profile-button): update tooltip text and add deprecation notice in docs

### DIFF
--- a/src/lib/app-bar/profile-button/app-bar-profile-button-adapter.ts
+++ b/src/lib/app-bar/profile-button/app-bar-profile-button-adapter.ts
@@ -7,7 +7,8 @@ import { IAppBarProfileButtonComponent } from './app-bar-profile-button';
 import { APP_BAR_PROFILE_BUTTON_CONSTANTS, IAppBarProfileCardConfig } from './app-bar-profile-button-constants';
 import { ICON_BUTTON_CONSTANTS, IIconButtonComponent } from '../../icon-button';
 import { forwardAttributes } from '../../core/utils/reflect-utils';
-import { IPopoverComponent } from '../../popover';
+import { type IPopoverComponent } from '../../popover';
+import { type ITooltipComponent } from '../../tooltip';
 
 export interface IAppBarProfileButtonAdapter extends IBaseAdapter {
   popupElement: IPopoverComponent | undefined;
@@ -34,6 +35,7 @@ export interface IAppBarProfileButtonAdapter extends IBaseAdapter {
 
 export class AppBarProfileButtonAdapter extends BaseAdapter<IAppBarProfileButtonComponent> implements IAppBarProfileButtonAdapter {
   private _avatarElement: IAvatarComponent;
+  private _tooltipElement: ITooltipComponent;
   private _iconButtonElement: IIconButtonComponent;
   private _popupElement?: IPopoverComponent;
   private _profileCardElement?: IProfileCardComponent;
@@ -49,6 +51,7 @@ export class AppBarProfileButtonAdapter extends BaseAdapter<IAppBarProfileButton
 
   public initialize(): void {
     this._avatarElement = getLightElement(this._component, AVATAR_CONSTANTS.elementName) as IAvatarComponent;
+    this._tooltipElement = getLightElement(this._component, 'forge-tooltip') as ITooltipComponent;
     this._iconButtonElement = getLightElement(this._component, ICON_BUTTON_CONSTANTS.elementName) as IIconButtonComponent;
 
     const originalAriaLabelledBy = this._iconButtonElement.getAttribute('aria-labelledby'); // Set by tooltip
@@ -150,6 +153,7 @@ export class AppBarProfileButtonAdapter extends BaseAdapter<IAppBarProfileButton
 
   public setAvatarText(value: string): void {
     this._avatarElement.text = value;
+    this._tooltipElement.textContent = `View ${value}'s profile`;
     removeAllChildren(this._avatarElement);
   }
 

--- a/src/stories/components/app-bar/profile/profile.mdx
+++ b/src/stories/components/app-bar/profile/profile.mdx
@@ -5,11 +5,17 @@ import * as ProfileStories from './profile.stories';
 <Meta of={ProfileStories} />
 
 <Title />
+
 For convenience Forge provides the `<forge-app-bar-profile-button>` component. This component uses an icon-button (with a predefined avatar), and is responsible for displaying profile information within a popup. The power of this component is that it will ensure a consistent experience for users across all applications that consume it.
 
 If necessary, you can use the `profileCardBuilder` API to provide custom content within the profile card popup.
 
 > It is expected that you place this component in the end slot of the app-bar for consistency and familiarity for users.
+
+## Deprecation notice
+
+**🚨 This component is deprecated and has been replaced by the [user profile](https://tyler-technologies-oss.github.io/forge-extended/v1/?path=/docs/components-user-profile--docs) component in the Tyler Forge™ Extended library.** This
+component will remain in the core library for the foreseeable future, but no new features will be added and it may be removed in a future major release. We recommend that you migrate to the new user profile component when possible.
 
 ## Common
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y (Closes #974)

## Describe the new behavior?
* Updated the tooltip within component to include the avatar text (will use the full name if provided)
* Added a deprecation notice to the docs recommending migration to the new user profile component in the extended library.

## Additional information
This does not account for localization. This component is deprecated and it's recommended to use the extended component which does support localization and further enhancements to this pattern/component will be done in that library.
