### PR TITLE
fix(tooltip): open when focused via keyboard

### DIFF
--- a/src/lib/tooltip/tooltip-adapter.ts
+++ b/src/lib/tooltip/tooltip-adapter.ts
@@ -18,6 +18,7 @@ export interface ITooltipAdapter extends IBaseAdapter<ITooltipComponent> {
   removeAnchorListener(type: string, listener: EventListener): void;
   addLightDismissListener(listener: EventListener): void;
   removeLightDismissListener(listener: EventListener): void;
+  isKeyboardFocused(): boolean;
   show(): void;
   hide(): void;
 }
@@ -110,6 +111,10 @@ export class TooltipAdapter extends BaseAdapter<ITooltipComponent> implements IT
 
   public removeLightDismissListener(listener: EventListener): void {
     this._overlayElement?.removeEventListener(OVERLAY_CONSTANTS.events.LIGHT_DISMISS, listener);
+  }
+
+  public isKeyboardFocused(): boolean {
+    return !!this._anchorElement?.matches(':focus-visible');
   }
 
   public show(): void {

--- a/src/lib/tooltip/tooltip.test.ts
+++ b/src/lib/tooltip/tooltip.test.ts
@@ -509,6 +509,34 @@ describe('Tooltip', () => {
       await harness.hoverTrigger();
       expect(harness.isOpen).to.be.true;
     });
+
+    it('should open when focusing the trigger via keyboard with hover trigger type', async () => {
+      const harness = await createFixture({ triggerType: 'hover' });
+
+      expect(harness.isOpen).to.be.false;
+
+      harness.focusTrigger();
+      expect(harness.isOpen).to.be.true;
+    });
+
+    it('should close when blurring the trigger after keyboard focus with hover trigger type', async () => {
+      const harness = await createFixture({ triggerType: 'hover' });
+
+      harness.focusTrigger();
+      expect(harness.isOpen).to.be.true;
+
+      await harness.blurTrigger();
+      expect(harness.isOpen).to.be.false;
+    });
+
+    it('should not open when clicking the trigger with hover trigger type (no keyboard focus)', async () => {
+      const harness = await createFixture({ triggerType: 'hover' });
+
+      expect(harness.isOpen).to.be.false;
+
+      await harness.clickTrigger();
+      expect(harness.isOpen).to.be.false;
+    });
   });
 
   describe('longpress trigger type', () => {
@@ -609,6 +637,29 @@ describe('Tooltip', () => {
 
       await harness.hoverOutside();
 
+      expect(harness.isOpen).to.be.false;
+    });
+
+    it('should work correctly when both focus and hover triggers are specified (no double keyboard focus handling)', async () => {
+      const harness = await createFixture();
+
+      harness.tooltipElement.setAttribute(TOOLTIP_CONSTANTS.attributes.TRIGGER_TYPE, 'focus,hover');
+
+      expect(harness.tooltipElement.triggerType).to.deep.equal(['focus', 'hover']);
+
+      // Test keyboard focus works (via explicit focus trigger)
+      harness.focusTrigger();
+      expect(harness.isOpen).to.be.true;
+
+      await harness.blurTrigger();
+      expect(harness.isOpen).to.be.false;
+
+      // Test hover works
+      await harness.hoverTrigger();
+      await task(harness.tooltipElement.delay + 100);
+      expect(harness.isOpen).to.be.true;
+
+      await harness.hoverOutside();
       expect(harness.isOpen).to.be.false;
     });
   });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Tooltips will now open when focusing anchor elements via keyboard (when `:focus-visible`) to improve accessibility compliance.
