### PR TITLE
fix(list-item): update keyboard interactions to trigger on keyup

### DIFF
--- a/src/lib/list/list-item/list-item-core.ts
+++ b/src/lib/list/list-item/list-item-core.ts
@@ -31,6 +31,7 @@ export class ListItemCore implements IListItemCore {
   private _mousedownListener: EventListener = this._onMousedown.bind(this);
   private _clickListener: EventListener = this._onClick.bind(this);
   private _keydownListener: EventListener = this._onKeydown.bind(this);
+  private _keyupListener: EventListener = this._onKeyup.bind(this);
 
   constructor(private _adapter: IListItemAdapter) {}
 
@@ -57,12 +58,21 @@ export class ListItemCore implements IListItemCore {
   }
 
   private _onKeydown(evt: KeyboardEvent): void {
-    const composedElements = composedPathFrom(this._adapter.hostElement, evt);
-    const isFromStartEndSlot = composedElements.some((el: HTMLElement) => el.matches(LIST_ITEM_CONSTANTS.selectors.SLOTTED_START_END));
-
     if (evt.key === 'Enter' || evt.key === ' ') {
       evt.stopPropagation();
+
+      const isAnchor = this._adapter.interactiveElement?.tagName === 'A';
+      if (!isAnchor) {
+        evt.preventDefault();
+      }
+
+      this._adapter.addHostListener('keyup', this._keyupListener, { capture: true });
     }
+  }
+
+  private _onKeyup(evt: KeyboardEvent): void {
+    const composedElements = composedPathFrom(this._adapter.hostElement, evt);
+    const isFromStartEndSlot = composedElements.some((el: HTMLElement) => el.matches(LIST_ITEM_CONSTANTS.selectors.SLOTTED_START_END));
 
     if (isFromStartEndSlot) {
       if (evt.key === 'Enter' || evt.key === ' ') {
@@ -74,13 +84,22 @@ export class ListItemCore implements IListItemCore {
       return;
     }
 
-    if (evt.key === ' ') {
-      evt.preventDefault();
-      this._adapter.interactiveElement?.click();
+    if (evt.key === ' ' || evt.key === 'Enter') {
+      const isAnchor = this._adapter.interactiveElement?.tagName === 'A';
+      if (isAnchor) {
+        if (evt.key === ' ') {
+          this._adapter.interactiveElement?.click();
+        }
+      } else {
+        this._adapter.animateStateLayer();
+        this._onClick(evt);
+      }
     }
+
+    this._adapter.removeHostListener('keyup', this._keyupListener, { capture: true });
   }
 
-  private _onClick(evt: MouseEvent): void {
+  private _onClick(evt: MouseEvent | KeyboardEvent): void {
     const composedElements = composedPathFrom(this._adapter.hostElement, evt);
 
     // Ignore clicks from elements that should not trigger selection
@@ -146,11 +165,12 @@ export class ListItemCore implements IListItemCore {
     if (value && !this._noninteractive) {
       this._adapter.addRootListener('mousedown', this._mousedownListener, { capture: true });
       this._adapter.addHostListener('click', this._clickListener, { capture: true });
-      this._adapter.addHostListener('keydown', this._keydownListener);
+      this._adapter.addHostListener('keydown', this._keydownListener, { capture: true });
     } else {
       this._adapter.removeRootListener('mousedown', this._mousedownListener, { capture: true });
       this._adapter.removeHostListener('click', this._clickListener, { capture: true });
-      this._adapter.removeHostListener('keydown', this._keydownListener);
+      this._adapter.removeHostListener('keydown', this._keydownListener, { capture: true });
+      this._adapter.removeHostListener('keyup', this._keyupListener, { capture: true });
     }
   }
 

--- a/src/lib/list/list.test.ts
+++ b/src/lib/list/list.test.ts
@@ -526,6 +526,7 @@ describe('List', () => {
 
       anchor.focus();
       anchor.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      anchor.dispatchEvent(new KeyboardEvent('keyup', { key: ' ', bubbles: true }));
 
       expect(spy).to.have.been.calledOnce;
     });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Updates the list item component to trigger keyboard interactions via the `keyup` event instead of `keydown`. This fixes an issue where events were triggered repeatedly when holding down the space or enter keys, but also makes composing with other components such as expansion panels easier to manage the events and avoid duplicate events from firing.

There is special case handling in this component for interactive elements such as `<button>` and `<a>` so careful attention to this area would help when reviewing given all of the various ways lists can be composed with other elements.

## Additional information
Fixes #972 
