### PR TITLE
fix(tooltip): allow hovering tooltip for accessibility compliance

### DIFF
--- a/src/lib/tooltip/_core.scss
+++ b/src/lib/tooltip/_core.scss
@@ -6,7 +6,6 @@
 
 @mixin host {
   display: contents;
-  pointer-events: none;
 }
 
 @mixin base {
@@ -27,7 +26,6 @@
 
   width: #{token(width)};
   max-width: #{token(max-width)};
-  pointer-events: none;
   text-align: #{token(content-align)};
   line-height: normal;
   white-space: normal;

--- a/src/lib/tooltip/tooltip-adapter.ts
+++ b/src/lib/tooltip/tooltip-adapter.ts
@@ -18,6 +18,8 @@ export interface ITooltipAdapter extends IBaseAdapter<ITooltipComponent> {
   removeAnchorListener(type: string, listener: EventListener): void;
   addLightDismissListener(listener: EventListener): void;
   removeLightDismissListener(listener: EventListener): void;
+  addTooltipListener(type: string, listener: EventListener, opts?: AddEventListenerOptions): void;
+  removeTooltipListener(type: string, listener: EventListener): void;
   isKeyboardFocused(): boolean;
   show(): void;
   hide(): void;
@@ -111,6 +113,14 @@ export class TooltipAdapter extends BaseAdapter<ITooltipComponent> implements IT
 
   public removeLightDismissListener(listener: EventListener): void {
     this._overlayElement?.removeEventListener(OVERLAY_CONSTANTS.events.LIGHT_DISMISS, listener);
+  }
+
+  public addTooltipListener(type: string, listener: EventListener, opts?: AddEventListenerOptions): void {
+    this.hostElement?.addEventListener(type, listener, opts);
+  }
+
+  public removeTooltipListener(type: string, listener: EventListener): void {
+    this.hostElement?.removeEventListener(type, listener);
   }
 
   public isKeyboardFocused(): boolean {

--- a/src/lib/tooltip/tooltip-constants.ts
+++ b/src/lib/tooltip/tooltip-constants.ts
@@ -25,7 +25,8 @@ const attributes = {
 } as const;
 
 const numbers = {
-  LONGPRESS_VISIBILITY_DURATION: 3000
+  LONGPRESS_VISIBILITY_DURATION: 3000,
+  HOVER_OUTSIDE_THRESHOLD: 100
 };
 
 const defaults = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
To make sure we are compliant with the WCAG guidelines when it comes to tooltips, we needed to enable pointers to hover over the tooltip when open.

This change uses a delay when pointers move off the anchor element to check if hovering the tooltip or anchor and keep the tooltip open. It also allows `pointer-events` on the tooltip now as well, but with that said, tooltip content should always remain non-interactive.
