### PR TITLE
fix(table): replace outline style with focus indicator for improved accessibility and consistency

### DIFF
--- a/src/lib/table/_core.scss
+++ b/src/lib/table/_core.scss
@@ -4,6 +4,7 @@
 @use '../core/styles/theme';
 @use '../core/styles/typography';
 @use '../core/styles/animation';
+@use '../focus-indicator';
 @use './variables';
 
 @mixin host {
@@ -234,7 +235,18 @@
   font: inherit;
   color: inherit;
   width: 100%;
-  outline-offset: #{spacing.variable(xxsmall)};
+  outline: none;
+  position: relative;
+
+  forge-focus-indicator {
+    border-radius: 4px;
+
+    @include focus-indicator.provide-theme(
+      (
+        'offset-inline': -4px
+      )
+    );
+  }
 }
 
 // The base table body row styles for row interactions.

--- a/src/lib/table/table-utils.ts
+++ b/src/lib/table/table-utils.ts
@@ -212,6 +212,11 @@ export class TableUtils {
       if (columnConfig.sortable) {
         cellContainer = document.createElement('button');
         (cellContainer as HTMLButtonElement).type = 'button';
+
+        const focusIndicator = document.createElement('forge-focus-indicator');
+        focusIndicator.inward = true;
+        cellContainer.appendChild(focusIndicator);
+
         cellContainer.addEventListener('keydown', tableConfiguration.sortableHeadCellKeydownListener);
       } else {
         cellContainer = document.createElement('div');

--- a/src/lib/table/table.ts
+++ b/src/lib/table/table.ts
@@ -26,6 +26,7 @@ import {
   TableSelectTooltipCallback
 } from './types';
 import { TooltipComponent } from '../tooltip';
+import { FocusIndicatorComponent } from '../focus-indicator';
 
 export interface ITableComponent extends IBaseComponent {
   data: any[];
@@ -109,7 +110,7 @@ declare global {
  */
 @customElement({
   name: TABLE_CONSTANTS.elementName,
-  dependencies: [ExpansionPanelComponent, IconComponent, CheckboxComponent, TooltipComponent]
+  dependencies: [ExpansionPanelComponent, IconComponent, CheckboxComponent, TooltipComponent, FocusIndicatorComponent]
 })
 export class TableComponent extends BaseComponent implements ITableComponent {
   public static get observedAttributes(): string[] {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

Fixes #986 

## Describe the new behavior?
Replaced the native `outline` style on table headers to use the `<forge-focus-indicator>` instead for improved accessibility when it comes to clipped focus indicators, as well as improve consistency with the overall design and interactions.
