### PR TITLE
feat(select): add "Select all" functionality

### DIFF
--- a/forge.json
+++ b/forge.json
@@ -20,8 +20,7 @@
       "distPath": "cdn/v1/libs/"
     },
     "sassOptions": {
-      "verbose": true,
-      "silenceDeprecations": ["mixed-decls"]
+      "verbose": true
     }
   },
   "customElementsManifestConfig": {

--- a/src/dev/pages/select/select.ejs
+++ b/src/dev/pages/select/select.ejs
@@ -3,7 +3,7 @@
   <forge-select label="Pick a Food Group" id="select">
     <forge-option value="">None</forge-option>
     <forge-option value="grains">Bread, Cereal, Rice, and Pasta</forge-option>
-    <forge-option value="vegetables">Vegetables (disabled)</forge-option>
+    <forge-option value="vegetables" disabled>Vegetables (disabled)</forge-option>
     <forge-option value="fruit">Fruit</forge-option>
 
     <!-- Leading -->

--- a/src/dev/pages/select/select.ejs
+++ b/src/dev/pages/select/select.ejs
@@ -3,7 +3,7 @@
   <forge-select label="Pick a Food Group" id="select">
     <forge-option value="">None</forge-option>
     <forge-option value="grains">Bread, Cereal, Rice, and Pasta</forge-option>
-    <forge-option value="vegetables" disabled>Vegetables (disabled)</forge-option>
+    <forge-option value="vegetables">Vegetables (disabled)</forge-option>
     <forge-option value="fruit">Fruit</forge-option>
 
     <!-- Leading -->

--- a/src/dev/pages/select/select.html
+++ b/src/dev/pages/select/select.html
@@ -36,6 +36,8 @@ include('./src/partials/page.ejs', {
       { type: 'switch', label: 'Show addon-end', id: 'opt-addon-end' },
       { type: 'switch', label: 'Show helper text', id: 'opt-helper-text' },
       { type: 'switch', label: 'Multiple', id: 'opt-multiple' },
+      { type: 'switch', label: 'Show select all', id: 'opt-show-select-all' },
+      { type: 'text-field', label: 'Select all label', id: 'opt-select-all-label', defaultValue: 'Select all' },
       { type: 'switch', label: 'Float label', id: 'opt-float' },
       { type: 'switch', label: 'Required', id: 'opt-required' },
       { type: 'switch', label: 'Invalid', id: 'opt-invalid' },

--- a/src/dev/pages/select/select.ts
+++ b/src/dev/pages/select/select.ts
@@ -18,6 +18,14 @@ const leadingEl = select.querySelector('[slot=leading]') as HTMLElement;
 const addonEndEl = select.querySelector('[slot=addon-end]') as HTMLElement;
 const helperTextEl = select.querySelector('[slot=helper-text]') as HTMLElement;
 
+// Add event logging
+select.addEventListener('change', ({ detail }) => {
+  console.log('change event:', detail);
+});
+select.addEventListener('forge-select-all', ({ detail }) => {
+  console.log('forge-select-all event:', detail);
+});
+
 // Hide these elements by default
 leadingEl.remove();
 addonEndEl.remove();
@@ -92,7 +100,17 @@ optSelectedTextBuilder.addEventListener('forge-switch-change', ({ detail: select
   select.selectedTextBuilder = selected ? selectedTextBuilder : undefined;
 });
 
-function optionBuilder(option: IListDropdownOption, parentElement: HTMLElement): HTMLElement {
+const optShowSelectAll = document.querySelector('#opt-show-select-all') as ISwitchComponent;
+optShowSelectAll.addEventListener('forge-switch-change', ({ detail: selected }) => {
+  select.showSelectAll = selected;
+});
+
+const optSelectAllLabel = document.querySelector('#opt-select-all-label') as HTMLInputElement;
+optSelectAllLabel.addEventListener('input', () => select.selectAllLabel = optSelectAllLabel.value);
+// Initialize with default value
+select.selectAllLabel = optSelectAllLabel.value;
+
+function optionBuilder(option: IListDropdownOption): HTMLElement {
   const item = document.createElement('div');
   item.style.display = 'flex';
   item.style.alignItems = 'center';

--- a/src/lib/list-dropdown/list-dropdown-constants.ts
+++ b/src/lib/list-dropdown/list-dropdown-constants.ts
@@ -29,10 +29,16 @@ const classes = {
   GROUP_WRAPPER: 'forge-list-dropdown__group-wrapper'
 };
 
+const selectAllOption = {
+  VALUE: '__forge_select_all__',
+  LABEL: 'Select All'
+};
+
 export const LIST_DROPDOWN_CONSTANTS = {
   observedAttributes,
   attributes,
-  classes
+  classes,
+  selectAllOption
 };
 
 export type ListDropdownOptionBuilder<T = HTMLElement> = (option: IListDropdownOption, parentElement: T) => HTMLElement | string | void;
@@ -86,6 +92,8 @@ export interface IListDropdownConfig<T = any> {
 
   // Optional values
   activeChangeCallback?: (id: string) => void;
+  showSelectAll?: boolean;
+  selectAllLabel?: string;
   closeCallback?: () => void;
   syncWidth?: boolean;
   constrainViewportWidth?: boolean;

--- a/src/lib/list-dropdown/list-dropdown-utils.ts
+++ b/src/lib/list-dropdown/list-dropdown-utils.ts
@@ -125,8 +125,36 @@ export function createListItems(
   startIndex = 0,
   renderSelected = true
 ): void {
+  // Add select all option if enabled and in multiple mode
+  let optionsToRender = options || config.options;
+  if (config.showSelectAll && config.multiple && startIndex === 0) {
+    const selectAllOption: IListDropdownOption = {
+      value: LIST_DROPDOWN_CONSTANTS.selectAllOption.VALUE,
+      label: config.selectAllLabel || LIST_DROPDOWN_CONSTANTS.selectAllOption.LABEL
+    };
+
+    const dividerOption: IListDropdownOption = {
+      value: '',
+      label: '',
+      divider: true
+    };
+
+    // Inject select all at the beginning
+    if (isListDropdownOptionType(optionsToRender, ListDropdownOptionType.Group)) {
+      const optionGroups = optionsToRender as IListDropdownOptionGroup[];
+      if (optionGroups.length > 0) {
+        optionGroups[0] = { ...optionGroups[0], options: [selectAllOption, dividerOption, ...optionGroups[0].options] };
+        optionsToRender = optionGroups;
+      } else {
+        optionsToRender = [{ text: '', options: [selectAllOption, dividerOption] }];
+      }
+    } else {
+      optionsToRender = [selectAllOption, dividerOption, ...(optionsToRender as IListDropdownOption[])];
+    }
+  }
+
   // Ensure the options are provided in the form a group (if no groups provided, then we have one anonymous group of options)
-  const groups = getOptionsByGroup(options || config.options);
+  const groups = getOptionsByGroup(optionsToRender);
   const flatOptions = getFlattenedOptions(groups);
 
   const limitOptions = config.optionLimit ? true : false;

--- a/src/lib/select/core/base-select-constants.ts
+++ b/src/lib/select/core/base-select-constants.ts
@@ -33,3 +33,8 @@ export const BASE_SELECT_CONSTANTS = {
   attributes,
   events
 };
+
+export interface SelectSelectAllEventData {
+  isAllSelected: boolean;
+  value: IListDropdownOption[];
+}

--- a/src/lib/select/core/base-select-core.ts
+++ b/src/lib/select/core/base-select-core.ts
@@ -9,7 +9,12 @@ import {
   SelectBeforeValueChangeCallback
 } from './base-select-constants';
 import { isSelectOptionType, SelectOptionType } from './select-utils';
-import { IListDropdownConfig, ListDropdownHeaderBuilder, ListDropdownFooterBuilder } from '../../list-dropdown/list-dropdown-constants';
+import {
+  IListDropdownConfig,
+  ListDropdownHeaderBuilder,
+  ListDropdownFooterBuilder,
+  LIST_DROPDOWN_CONSTANTS
+} from '../../list-dropdown/list-dropdown-constants';
 import { IBaseSelectAdapter } from './base-select-adapter';
 import { IListDropdownAwareCore, ListDropdownAwareCore } from '../../list-dropdown/list-dropdown-aware-core';
 
@@ -23,6 +28,7 @@ export interface IBaseSelectCore extends IListDropdownAwareCore {
   optionBuilder: SelectOptionBuilder;
   selectedTextBuilder: SelectSelectedTextBuilder;
   beforeValueChange: SelectBeforeValueChangeCallback<any>;
+  selectAllLabel: string;
   appendOptions(options: ISelectOption[] | ISelectOptionGroup[]): void;
   selectAll(): void;
   deselectAll(): void;
@@ -36,6 +42,8 @@ export abstract class BaseSelectCore<T extends IBaseSelectAdapter> extends ListD
   protected _value: any = [];
   protected _multiple = false;
   protected _open = false;
+  protected _showSelectAll = false;
+  protected _selectAllLabel: string;
   protected _optionBuilder: SelectOptionBuilder;
   protected _selectedTextBuilder: SelectSelectedTextBuilder;
   protected _selectedValues: string[] = [];
@@ -72,6 +80,63 @@ export abstract class BaseSelectCore<T extends IBaseSelectAdapter> extends ListD
 
   protected abstract _onDropdownScrollEnd(): void;
   protected _onFocus(evt: Event): void {}
+
+  protected _onSelectAll(): void {
+    if (!this._multiple) {
+      return;
+    }
+
+    const currentlyAllSelected = this._selectedValues.length === this._nonDividerOptions.length;
+    const willSelectAll = !currentlyAllSelected;
+
+    // Emit the select all event
+    const newValue = willSelectAll ? this._nonDividerOptions.map(o => o.value) : [];
+    const cancelled = !this._adapter.emitHostEvent(
+      'forge-select-all',
+      {
+        value: newValue,
+        isAllSelected: willSelectAll
+      },
+      true,
+      true
+    );
+
+    if (!cancelled) {
+      if (willSelectAll) {
+        this.selectAll();
+      } else {
+        this.deselectAll();
+      }
+
+      // Emit the standard change event
+      const changeData = this._multiple ? [...this._selectedValues] : this._selectedValues[0];
+      this._adapter.emitHostEvent(BASE_SELECT_CONSTANTS.events.CHANGE, changeData, true, true);
+
+      // Update the dropdown to reflect the new selection state
+      if (this._open) {
+        // Preserve the currently active option index before updating selections
+        const activeOptionIndex = this._adapter.getActiveOptionIndex();
+        this._adapter.patchSelectedValues(this._selectedValues);
+        // Update the select all checkbox to reflect its new state
+        this._updateSelectAllState();
+        // Restore the active option to preserve highlighting
+        if (activeOptionIndex >= 0) {
+          this._adapter.highlightActiveOption(activeOptionIndex);
+        }
+      }
+    }
+  }
+
+  /** Updates the select all checkbox state based on current selections */
+  private _updateSelectAllState(): void {
+    if (!this._showSelectAll || !this._multiple || !this._open) {
+      return;
+    }
+
+    const allSelected = this._selectedValues.length === this._nonDividerOptions.length;
+    // The select all option is always at dropdown index 0
+    this._adapter.toggleOptionMultiple(0, allSelected);
+  }
 
   public initialize(): void {
     if (this._optionListenerDestructor) {
@@ -131,6 +196,25 @@ export abstract class BaseSelectCore<T extends IBaseSelectAdapter> extends ListD
 
   private get _nonDividerOptions(): ISelectOption[] {
     return this._flatOptions.filter(o => !o.divider);
+  }
+
+  /** Adjusts an index from list-dropdown coordinate system to select coordinate system */
+  private _adjustIndexFromDropdown(dropdownIndex: number): number {
+    // If select all is shown and enabled, the first option (index 0) in the dropdown is select all
+    // So we need to subtract 1 from the dropdown index to get the actual option index
+    if (this._showSelectAll && this._multiple && dropdownIndex > 0) {
+      return dropdownIndex - 1;
+    }
+    return dropdownIndex;
+  }
+
+  /** Adjusts an index from select coordinate system to list-dropdown coordinate system */
+  private _adjustIndexToDropdown(selectIndex: number): number {
+    // If select all is shown and enabled, we need to add 1 to account for the select all option
+    if (this._showSelectAll && this._multiple) {
+      return selectIndex + 1;
+    }
+    return selectIndex;
   }
 
   protected _initializeValue(): void {
@@ -194,8 +278,16 @@ export abstract class BaseSelectCore<T extends IBaseSelectAdapter> extends ListD
       optionLimit: this._optionLimit,
       headerBuilder: this._popupHeaderBuilder,
       footerBuilder: this._popupFooterBuilder,
+      showSelectAll: this._showSelectAll && this._multiple,
+      selectAllLabel: this._selectAllLabel,
       closeCallback: () => this._closeDropdown(),
       selectCallback: (value: any) => {
+        // Handle select all option
+        if (value === LIST_DROPDOWN_CONSTANTS.selectAllOption.VALUE) {
+          this._onSelectAll();
+          return;
+        }
+
         const flatOptions = this._flatOptions;
         const option = flatOptions.find(o => o.value === value);
         if (option) {
@@ -271,7 +363,19 @@ export abstract class BaseSelectCore<T extends IBaseSelectAdapter> extends ListD
       // If we're in multiselect mode, we need to toggle the selected option
       if (this._multiple) {
         const isSelected = this._selectedIndexes.includes(optionIndex);
-        this._adapter.toggleOptionMultiple(optionIndex, isSelected);
+        const dropdownIndex = this._adjustIndexToDropdown(optionIndex);
+        this._adapter.toggleOptionMultiple(dropdownIndex, isSelected);
+
+        // Update select all checkbox state if it's visible
+        if (this._showSelectAll && this._open) {
+          // Preserve the currently active option index before updating select all state
+          const activeOptionIndex = this._adapter.getActiveOptionIndex();
+          this._updateSelectAllState();
+          // Restore the active option to preserve highlighting
+          if (activeOptionIndex >= 0) {
+            this._adapter.highlightActiveOption(activeOptionIndex);
+          }
+        }
       }
 
       this._applySelection();
@@ -309,9 +413,18 @@ export abstract class BaseSelectCore<T extends IBaseSelectAdapter> extends ListD
   }
 
   private _selectActiveOption(): void {
-    const activeOptionIndex = this._adapter.getActiveOptionIndex();
-    if (activeOptionIndex >= 0 && this._nonDividerOptions[activeOptionIndex]) {
-      this._onSelect(this._nonDividerOptions[activeOptionIndex], activeOptionIndex);
+    const activeDropdownIndex = this._adapter.getActiveOptionIndex();
+    if (activeDropdownIndex >= 0) {
+      // Check if the active option is the select all option
+      if (this._showSelectAll && this._multiple && activeDropdownIndex === 0) {
+        this._onSelectAll();
+        return;
+      }
+
+      const adjustedIndex = this._adjustIndexFromDropdown(activeDropdownIndex);
+      if (this._nonDividerOptions[adjustedIndex]) {
+        this._onSelect(this._nonDividerOptions[adjustedIndex], adjustedIndex);
+      }
     }
   }
 
@@ -452,37 +565,44 @@ export abstract class BaseSelectCore<T extends IBaseSelectAdapter> extends ListD
         return;
       }
 
-      let optionIndex = 0;
+      let dropdownIndex = 0;
       if (this._open) {
-        optionIndex = this._adapter.getActiveOptionIndex();
-        if (optionIndex === -1) {
-          optionIndex = this._getFirstSelectedOptionIndex();
+        dropdownIndex = this._adapter.getActiveOptionIndex();
+        if (dropdownIndex === -1) {
+          // No option is currently active, so activate the first/last highlightable option based on direction
+          if (isArrowUp) {
+            dropdownIndex = this._getLastHighlightableDropdownIndex();
+          } else {
+            dropdownIndex = this._getFirstHighlightableDropdownIndex();
+          }
+        } else {
+          // An option is already active, move to the previous/next one
+          if (isArrowUp) {
+            dropdownIndex = this._getPreviousHighlightableDropdownIndex(dropdownIndex);
+          } else {
+            dropdownIndex = this._getNextHighlightableDropdownIndex(dropdownIndex);
+          }
         }
       } else {
-        optionIndex = this._getFirstSelectedOptionIndex();
+        const firstSelectedIndex = this._getFirstSelectedOptionIndex();
+        dropdownIndex = firstSelectedIndex >= 0 ? this._adjustIndexToDropdown(firstSelectedIndex) : 0;
       }
 
-      if (isArrowUp) {
-        optionIndex = this._getPreviousHighlightableOptionIndex(optionIndex, this._nonDividerOptions);
-      } else {
-        optionIndex = this._getNextHighlightableOptionIndex(optionIndex, this._nonDividerOptions);
-      }
-
-      this._adapter.highlightActiveOption(optionIndex);
+      this._adapter.highlightActiveOption(dropdownIndex);
     } else if (isHomeKey) {
       if (this._open) {
         evt.preventDefault();
-        this._adapter.highlightActiveOption(this._nonDividerOptions.findIndex(o => !o.disabled));
+        const firstDropdownIndex = this._getFirstHighlightableDropdownIndex();
+        if (firstDropdownIndex >= 0) {
+          this._adapter.highlightActiveOption(firstDropdownIndex);
+        }
       }
     } else if (isEndKey) {
       if (this._open) {
         evt.preventDefault();
-        const options = this._nonDividerOptions;
-        for (let i = options.length - 1; i >= 0; i--) {
-          if (!options[i].disabled) {
-            this._adapter.highlightActiveOption(i);
-            break;
-          }
+        const lastDropdownIndex = this._getLastHighlightableDropdownIndex();
+        if (lastDropdownIndex >= 0) {
+          this._adapter.highlightActiveOption(lastDropdownIndex);
         }
       }
     } else if (isFilterableCharacter) {
@@ -494,30 +614,112 @@ export abstract class BaseSelectCore<T extends IBaseSelectAdapter> extends ListD
     return this._nonDividerOptions.findIndex(option => this._selectedValues.includes(option.value));
   }
 
-  private _getPreviousHighlightableOptionIndex(startIndex: number, options: ISelectOption[]): number {
+  /** Navigation methods that work in dropdown coordinate system (includes select all when enabled) */
+  private _getPreviousHighlightableDropdownIndex(startIndex: number): number {
+    if (!this._adapter.popupElement) {
+      return startIndex;
+    }
+
+    const listItems = this._adapter.popupElement.querySelectorAll('forge-list-item');
+    const totalItems = listItems.length;
+
+    if (totalItems === 0) {
+      return startIndex;
+    }
+
     let index = startIndex;
-    if (index <= 0) {
-      index = options.length - 1;
-    } else {
-      index--;
-    }
-    if (options[index].disabled) {
-      return this._getPreviousHighlightableOptionIndex(index, options);
-    }
-    return index;
+    do {
+      if (index <= 0) {
+        index = totalItems - 1;
+      } else {
+        index--;
+      }
+
+      const listItem = listItems[index] as any;
+      if (listItem && !this._isDropdownOptionDisabled(listItem)) {
+        return index;
+      }
+    } while (index !== startIndex);
+
+    return startIndex;
   }
 
-  private _getNextHighlightableOptionIndex(startIndex: number, options: ISelectOption[]): number {
+  private _getNextHighlightableDropdownIndex(startIndex: number): number {
+    if (!this._adapter.popupElement) {
+      return startIndex;
+    }
+
+    const listItems = this._adapter.popupElement.querySelectorAll('forge-list-item');
+    const totalItems = listItems.length;
+
+    if (totalItems === 0) {
+      return startIndex;
+    }
+
     let index = startIndex;
-    if (index === options.length - 1) {
-      index = 0;
-    } else {
-      index++;
+    do {
+      if (index === totalItems - 1) {
+        index = 0;
+      } else {
+        index++;
+      }
+
+      const listItem = listItems[index] as any;
+      if (listItem && !this._isDropdownOptionDisabled(listItem)) {
+        return index;
+      }
+    } while (index !== startIndex);
+
+    return startIndex;
+  }
+
+  private _getFirstHighlightableDropdownIndex(): number {
+    if (!this._adapter.popupElement) {
+      return 0;
     }
-    if (options[index].disabled) {
-      return this._getNextHighlightableOptionIndex(index, options);
+
+    const listItems = this._adapter.popupElement.querySelectorAll('forge-list-item');
+
+    for (let i = 0; i < listItems.length; i++) {
+      const listItem = listItems[i] as any;
+      if (listItem && !this._isDropdownOptionDisabled(listItem)) {
+        return i;
+      }
     }
-    return index;
+
+    return 0;
+  }
+
+  private _getLastHighlightableDropdownIndex(): number {
+    if (!this._adapter.popupElement) {
+      return 0;
+    }
+
+    const listItems = this._adapter.popupElement.querySelectorAll('forge-list-item');
+
+    for (let i = listItems.length - 1; i >= 0; i--) {
+      const listItem = listItems[i] as any;
+      if (listItem && !this._isDropdownOptionDisabled(listItem)) {
+        return i;
+      }
+    }
+
+    return 0;
+  }
+
+  private _isDropdownOptionDisabled(listItem: any): boolean {
+    // Check if it's a divider (dividers are not selectable)
+    if (listItem.querySelector && listItem.querySelector('forge-divider')) {
+      return true;
+    }
+
+    // Check if the button inside is disabled
+    const button = listItem.querySelector('button');
+    if (button && button.disabled) {
+      return true;
+    }
+
+    return false;
   }
 
   private _filter(key: string): void {
@@ -705,5 +907,21 @@ export abstract class BaseSelectCore<T extends IBaseSelectAdapter> extends ListD
   }
   public set beforeValueChange(value: SelectBeforeValueChangeCallback<any>) {
     this._beforeValueChange = value;
+  }
+
+  /** Gets/sets whether to show the select all option when in multiple mode. */
+  public get showSelectAll(): boolean {
+    return this._showSelectAll;
+  }
+  public set showSelectAll(value: boolean) {
+    this._showSelectAll = value;
+  }
+
+  /** Gets/sets the label for the select all option. */
+  public get selectAllLabel(): string {
+    return this._selectAllLabel;
+  }
+  public set selectAllLabel(value: string) {
+    this._selectAllLabel = value;
   }
 }

--- a/src/lib/select/core/base-select-core.ts
+++ b/src/lib/select/core/base-select-core.ts
@@ -298,6 +298,9 @@ export abstract class BaseSelectCore<T extends IBaseSelectAdapter> extends ListD
     };
     this._adapter.open(config);
     this._adapter.setDismissListener(this._dismissListener);
+
+    // Ensure select all state is synchronized after opening dropdown
+    this._updateSelectAllState();
   }
 
   /**

--- a/src/lib/select/select/select-constants.ts
+++ b/src/lib/select/select/select-constants.ts
@@ -17,7 +17,9 @@ const observedAttributes = {
   DISABLED: 'disabled',
   PLACEHOLDER: 'placeholder',
   OBSERVE_SCROLL: 'observe-scroll',
-  OBSERVE_SCROLL_THRESHOLD: 'observe-scroll-threshold'
+  OBSERVE_SCROLL_THRESHOLD: 'observe-scroll-threshold',
+  SHOW_SELECT_ALL: 'show-select-all',
+  SELECT_ALL_LABEL: 'select-all-label'
 };
 
 const attributes = {
@@ -25,7 +27,8 @@ const attributes = {
 };
 
 const events = {
-  SCROLLED_BOTTOM: `${elementName}-scrolled-bottom`
+  SCROLLED_BOTTOM: `${elementName}-scrolled-bottom`,
+  SELECT_ALL: `${elementName}-select-all`
 };
 
 export const SELECT_CONSTANTS = {

--- a/src/lib/select/select/select.test.ts
+++ b/src/lib/select/select/select.test.ts
@@ -991,6 +991,186 @@ describe('Select', () => {
       expect(harness.popoverElement?.offset).to.deep.equal({ mainAxis: 10, crossAxis: 10 });
     });
   });
+
+  describe('show select all', () => {
+    it('should have showSelectAll property', async () => {
+      const harness = await createFixture();
+
+      expect(harness.element.showSelectAll).to.be.false;
+
+      harness.element.showSelectAll = true;
+      await elementUpdated(harness.element);
+
+      expect(harness.element.showSelectAll).to.be.true;
+    });
+
+    it('should set show-select-all attribute when showSelectAll is true', async () => {
+      const harness = await createFixture({ showSelectAll: true });
+
+      expect(harness.element.hasAttribute('show-select-all')).to.be.true;
+    });
+
+    it('should only show select all option when multiple is true and showSelectAll is true', async () => {
+      const harness = await createFixture({ multiple: true, showSelectAll: true });
+
+      harness.element.open = true;
+      await elementUpdated(harness.element);
+
+      const listItems = harness.getListItems();
+      expect(listItems.length).to.be.greaterThan(3); // 3 regular options + select all
+
+      const firstItem = listItems[0];
+      const button = firstItem.querySelector('button');
+      expect(button?.textContent?.trim()).to.equal('Select All');
+    });
+
+    it('should not show select all option when multiple is false', async () => {
+      const harness = await createFixture({ multiple: false, showSelectAll: true });
+
+      harness.element.open = true;
+      await elementUpdated(harness.element);
+
+      const listItems = harness.getListItems();
+      expect(listItems.length).to.equal(3); // Only regular options
+
+      const firstItem = listItems[0];
+      const button = firstItem.querySelector('button');
+      expect(button?.textContent?.trim()).not.to.equal('Select All');
+    });
+
+    it('should dispatch forge-select-all event when select all is clicked', async () => {
+      const harness = await createFixture({ multiple: true, showSelectAll: true });
+      let eventDetail: any;
+
+      harness.element.addEventListener('forge-select-all', (e: any) => {
+        eventDetail = e.detail;
+      });
+
+      harness.element.open = true;
+      await elementUpdated(harness.element);
+
+      const listItems = harness.getListItems();
+      const selectAllButton = listItems[0].querySelector('button') as HTMLButtonElement;
+
+      await harness.clickElement(selectAllButton);
+
+      expect(eventDetail).to.exist;
+      expect(eventDetail.value).to.deep.equal(['one', 'two', 'three']);
+      expect(eventDetail.isAllSelected).to.be.true;
+    });
+
+    it('should select all options when select all is clicked while none selected', async () => {
+      const harness = await createFixture({ multiple: true, showSelectAll: true });
+
+      harness.element.open = true;
+      await elementUpdated(harness.element);
+
+      const listItems = harness.getListItems();
+      const selectAllButton = listItems[0].querySelector('button') as HTMLButtonElement;
+
+      expect(harness.element.value).to.deep.equal([]);
+
+      await harness.clickElement(selectAllButton);
+      await elementUpdated(harness.element);
+
+      expect(harness.element.value).to.deep.equal(['one', 'two', 'three']);
+    });
+
+    it('should deselect all options when select all is clicked while all selected', async () => {
+      const harness = await createFixture({ multiple: true, showSelectAll: true });
+
+      // First select all options
+      harness.element.value = ['one', 'two', 'three'];
+      await elementUpdated(harness.element);
+
+      harness.element.open = true;
+      await elementUpdated(harness.element);
+
+      const listItems = harness.getListItems();
+      const selectAllButton = listItems[0].querySelector('button') as HTMLButtonElement;
+
+      await harness.clickElement(selectAllButton);
+      await elementUpdated(harness.element);
+
+      expect(harness.element.value).to.deep.equal([]);
+    });
+
+    it('should have selectAllLabel property', async () => {
+      const harness = await createFixture();
+
+      expect(harness.element.selectAllLabel).to.be.undefined;
+
+      harness.element.selectAllLabel = 'Custom Select All';
+      await elementUpdated(harness.element);
+
+      expect(harness.element.selectAllLabel).to.equal('Custom Select All');
+    });
+
+    it('should set select-all-label attribute when selectAllLabel is set', async () => {
+      const harness = await createFixture({ selectAllLabel: 'Custom Select All' });
+
+      expect(harness.element.getAttribute('select-all-label')).to.equal('Custom Select All');
+    });
+
+    it('should use custom select all label in dropdown', async () => {
+      const harness = await createFixture({
+        multiple: true,
+        showSelectAll: true,
+        selectAllLabel: 'Tout sélectionner'
+      });
+
+      harness.element.open = true;
+      await elementUpdated(harness.element);
+
+      const listItems = harness.getListItems();
+      expect(listItems.length).to.be.greaterThan(3); // 3 regular options + select all
+
+      const firstItem = listItems[0];
+      const button = firstItem.querySelector('button');
+      expect(button?.textContent?.trim()).to.equal('Tout sélectionner');
+    });
+
+    it('should use default select all label when selectAllLabel is not set', async () => {
+      const harness = await createFixture({ multiple: true, showSelectAll: true });
+
+      harness.element.open = true;
+      await elementUpdated(harness.element);
+
+      const listItems = harness.getListItems();
+      const firstItem = listItems[0];
+      const button = firstItem.querySelector('button');
+      expect(button?.textContent?.trim()).to.equal('Select All');
+    });
+
+    it('should update select all label dynamically', async () => {
+      const harness = await createFixture({ multiple: true, showSelectAll: true });
+
+      harness.element.open = true;
+      await elementUpdated(harness.element);
+
+      let listItems = harness.getListItems();
+      let firstItem = listItems[0];
+      let button = firstItem.querySelector('button');
+      expect(button?.textContent?.trim()).to.equal('Select All');
+
+      // Close dropdown
+      harness.element.open = false;
+      await elementUpdated(harness.element);
+
+      // Change the label
+      harness.element.selectAllLabel = 'Choose All Items';
+      await elementUpdated(harness.element);
+
+      // Reopen dropdown
+      harness.element.open = true;
+      await elementUpdated(harness.element);
+
+      listItems = harness.getListItems();
+      firstItem = listItems[0];
+      button = firstItem.querySelector('button');
+      expect(button?.textContent?.trim()).to.equal('Choose All Items');
+    });
+  });
 });
 
 class SelectHarness extends TestHarness<ISelectComponent> {
@@ -1043,6 +1223,8 @@ interface SelectFixtureConfig {
   label?: string;
   placeholder?: string;
   multiple?: boolean;
+  showSelectAll?: boolean;
+  selectAllLabel?: string;
   labelPosition?: FieldLabelPosition;
   labelAlignment?: FieldLabelAlignment;
   invalid?: boolean;
@@ -1062,6 +1244,8 @@ async function createFixture({
   label = 'Test label',
   placeholder,
   multiple,
+  showSelectAll,
+  selectAllLabel,
   labelPosition,
   labelAlignment,
   invalid,
@@ -1083,6 +1267,8 @@ async function createFixture({
       label=${label}
       placeholder=${placeholder ?? ''}
       ?multiple=${multiple}
+      ?show-select-all=${showSelectAll}
+      select-all-label=${ifDefined(selectAllLabel)}
       label-position=${ifDefined(labelPosition)}
       label-alignment=${ifDefined(labelAlignment)}
       ?invalid=${invalid}

--- a/src/lib/select/select/select.ts
+++ b/src/lib/select/select/select.ts
@@ -16,13 +16,14 @@ import { ListComponent, ListItemComponent } from '../../list';
 import { PopoverComponent } from '../../popover';
 import { ScaffoldComponent } from '../../scaffold';
 import { ToolbarComponent } from '../../toolbar';
-import { BASE_SELECT_CONSTANTS, BaseSelectComponent, IBaseSelectComponent } from '../core';
+import { BASE_SELECT_CONSTANTS, BaseSelectComponent, IBaseSelectComponent, SelectSelectAllEventData } from '../core';
 import { OptionComponent } from '../option';
 import { OptionGroupComponent } from '../option-group';
 import { SelectAdapter } from './select-adapter';
 import { SELECT_CONSTANTS } from './select-constants';
 import { SelectCore } from './select-core';
 import { IListDropdownAware, ListDropdownAware } from '../../list-dropdown/list-dropdown-aware';
+import { DividerComponent } from '../../divider/divider';
 
 import template from './select.html';
 import styles from './select.scss';
@@ -38,6 +39,8 @@ export interface ISelectComponent
     IListDropdownAware {
   label: string;
   placeholder: string;
+  showSelectAll: boolean;
+  selectAllLabel: string;
   setFormValue(value: FormValue | null, state?: FormValue | null | undefined): void;
   [setValidity](): void;
 }
@@ -49,6 +52,7 @@ declare global {
 
   interface HTMLElementEventMap {
     'forge-select-scrolled-bottom': CustomEvent<void>;
+    'forge-select-all': CustomEvent<SelectSelectAllEventData>;
     change: CustomEvent<any>;
   }
 }
@@ -73,9 +77,12 @@ declare global {
  *
  * @event {CustomEvent<void>} forge-select-scrolled-bottom - Dispatched when the dropdown list has scrolled to the bottom.
  * @event {CustomEvent<any>} change - Dispatched when the user selects a value.
+ * @event {CustomEvent<SelectSelectAllEventData>} forge-select-all - Dispatched when the select all option is toggled.
  *
  * @property {string} label - Controls the label text.
  * @property {string} placeholder - Controls the placeholder text.
+ * @property {boolean} showSelectAll - Gets/sets whether to show the select all option when in multiple mode.
+ * @property {string} selectAllLabel - Gets/sets the label for the select all option.
  * @property {any} value - Gets/sets the value.
  * @property {number | number[]} selectedIndex - Gets/sets the selected index.
  * @property {ISelectOption[] | ISelectOptionGroup[]} options - Gets/sets the available options.
@@ -101,6 +108,8 @@ declare global {
  *
  * @attribute {string} label - Controls the label text.
  * @attribute {string} placeholder - Controls the placeholder text.
+ * @attribute {boolean} show-select-all - Gets/sets whether to show the select all option when in multiple mode.
+ * @attribute {string} select-all-label - Gets/sets the label for the select all option.
  * @attribute {any} value - Gets/sets the value.
  * @attribute {number | number[]} selected-index - Gets/sets the selected index.
  * @attribute {boolean} multiple - Gets/sets the multiple select state.
@@ -192,7 +201,8 @@ declare global {
     IconComponent,
     ScaffoldComponent,
     ToolbarComponent,
-    IconButtonComponent
+    IconButtonComponent,
+    DividerComponent
   ]
 })
 export class SelectComponent
@@ -240,6 +250,12 @@ export class SelectComponent
         return;
       case SELECT_CONSTANTS.observedAttributes.PLACEHOLDER:
         this.placeholder = newValue;
+        return;
+      case SELECT_CONSTANTS.observedAttributes.SHOW_SELECT_ALL:
+        this.showSelectAll = coerceBoolean(newValue);
+        return;
+      case SELECT_CONSTANTS.observedAttributes.SELECT_ALL_LABEL:
+        this.selectAllLabel = newValue;
         return;
     }
     super.attributeChangedCallback(name, oldValue, newValue);
@@ -289,6 +305,12 @@ export class SelectComponent
 
   @coreProperty()
   declare public readonly: boolean;
+
+  @coreProperty()
+  declare public showSelectAll: boolean;
+
+  @coreProperty()
+  declare public selectAllLabel: string;
 
   public override get floatLabel(): boolean {
     return super.floatLabel;

--- a/src/stories/components/select/Select.mdx
+++ b/src/stories/components/select/Select.mdx
@@ -39,6 +39,20 @@ The select supports a `multiple` property/attribute to allow multiple options to
 
 When the select is in multiple mode, the `value` property/attribute should be an array of selected values.
 
+## Select All
+
+When using the select in multiple mode, you can enable a "Select All" option by setting the `showSelectAll` property to `true`. This adds a convenient option at the top of the dropdown to select or deselect all available options at once.
+
+<Canvas of={SelectStories.SelectAll} />
+
+To customize the label for the "Select all" option, use the `selectAllLabel` property (or `select-all-label` attribute). This is useful for localization or when you want to use different wording.
+
+When the "Select All" option is clicked, the component dispatches a `forge-select-all` event before the standard `change` event. The `forge-select-all` event detail contains:
+- `value`: An array of all option values (when selecting all) or an empty array (when deselecting all)
+- `isAllSelected`: A boolean indicating whether all options are now selected (`true`) or deselected (`false`)
+
+You can prevent the select all action by calling `preventDefault()` on the `forge-select-all` event, which will also prevent the subsequent `change` event from being dispatched.
+
 ## API
 
 <CustomArgTypes />
@@ -49,7 +63,7 @@ When the select is in multiple mode, the `value` property/attribute should be an
 | :--- | :---------- |
 | **Select Opened**
 | `escape / space` | Closes the select.
-| `tab / enter` | Selects the focused option and closes the select.
+| `tab / enter` | Selects the focused option and closes the select. If the "Select All" option is focused, toggles all options.
 | `arrow down` | Highlights the next option if an option is selected, otherwise highlights the first option.
 | `arrow up` | Highlights the previous option if an option is selected, otherwise highlights the first option.
 | `home` | Highlights the first option that is not disabled.

--- a/src/stories/components/select/Select.stories.ts
+++ b/src/stories/components/select/Select.stories.ts
@@ -13,6 +13,7 @@ import { ISelectComponent } from '@tylertech/forge/select';
 const component = 'forge-select';
 
 const changeAction = action('change');
+const selectAllAction = action('forge-select-all');
 
 const meta = {
   title: 'Components/Select',
@@ -27,31 +28,34 @@ const meta = {
 
     return html`
       <forge-select
-        .label=${args.label}
-        .labelPosition=${args.labelPosition}
-        .labelAlignment=${args.labelAlignment}
-        .variant=${args.variant}
-        .theme=${args.theme}
-        .shape=${args.shape}
-        .density=${args.density}
-        .dense=${args.dense}
-        .supportTextInset=${args.supportTextInset}
-        .floatLabel=${args.floatLabel}
-        .placeholder=${args.placeholder}
-        .multiple=${args.multiple}
-        .open=${args.open}
+        label=${args.label ?? nothing}
+        label-position=${args.labelPosition ?? nothing}
+        label-alignment=${args.labelAlignment ?? nothing}
+        variant=${args.variant ?? nothing}
+        theme=${args.theme ?? ''}
+        shape=${args.shape ?? nothing}
+        density=${args.density ?? nothing}
+        placeholder=${args.placeholder ?? nothing}
+        ?dense=${args.dense}
+        ?support-text-inset=${args.supportTextInset}
+        ?float-label=${args.floatLabel}
+        ?multiple=${args.multiple}
+        ?show-select-all=${args.showSelectAll}
+        select-all-label=${args.selectAllLabel ?? nothing}
+        ?open=${args.open}
         ?optional=${args.optional}
         ?disabled=${args.disabled}
         ?required=${args.required}
         ?invalid=${args.invalid}
         style=${style}
-        @change=${changeAction}>
+        @change=${changeAction}
+        @forge-select-all=${selectAllAction}>
         <forge-option value="1">Option 1</forge-option>
         <forge-option value="2">Option 2</forge-option>
         <forge-option value="3">Option 3</forge-option>
         ${args.supportText.length ? html`<span slot="support-text">${args.supportText}</span>` : nothing}
         ${args.supportTextEnd.length ? html`<span slot="support-text-end">${args.supportTextEnd}</span>` : nothing}
-      </forge-text-field>
+      </forge-select>
     `;
   },
   decorators: [storyStyles(styles)],
@@ -68,7 +72,8 @@ const meta = {
         'optionBuilder',
         'selectedTextBuilder',
         'popupElement',
-        'beforeValueChange'
+        'beforeValueChange',
+        'showSelectAll'
       ],
       controls: {
         labelPosition: { control: 'select', options: ['inline-start', 'inline-end', 'block-start', 'inset', 'none'] },
@@ -81,7 +86,9 @@ const meta = {
       }
     }),
     supportText: { control: { type: 'text' } },
-    supportTextEnd: { control: { type: 'text' } }
+    supportTextEnd: { control: { type: 'text' } },
+    showSelectAll: { control: { type: 'boolean' } },
+    selectAllLabel: { control: { type: 'text' } }
   },
   args: {
     label: 'Label',
@@ -102,9 +109,11 @@ const meta = {
     disabled: false,
     floatLabel: false,
     supportTextInset: 'none',
-    open: false
+    open: false,
+    showSelectAll: false,
+    selectAllLabel: 'Select all'
   }
-} satisfies Meta<Partial<ISelectComponent> & { supportText: string; supportTextEnd: string }>;
+} satisfies Meta<Partial<ISelectComponent> & { supportText: string; supportTextEnd: string; selectAllLabel: string }>;
 
 export default meta;
 
@@ -130,5 +139,15 @@ export const Multiple: Story = {
   ...standaloneStoryParams,
   args: {
     multiple: true
+  }
+};
+
+export const SelectAll: Story = {
+  parameters: {
+    controls: { disable: true }
+  },
+  args: {
+    multiple: true,
+    showSelectAll: true
   }
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Introduces a new ["Select all" feature](https://forge.tylerdev.io/pr/tyler-technologies-oss:feat/select-all/?path=/docs/components-select--docs#select-all) to the select component when used in `multiple` mode, enabling users to easily select or deselect all options at once. The implementation adds a new static "Select all" option above all other options in the dropdown, and preserves keyboard navigation and event handling.

<img width="340" height="313" alt="image" src="https://github.com/user-attachments/assets/32668b91-16b7-4418-8bd9-d8e098ca00ef" />

## Additional information
Closes #93 
