### PR TITLE
fix(chip): allow remove button to be part of tab order and expose property to control label

### DIFF
--- a/src/lib/chips/chip/chip-adapter.ts
+++ b/src/lib/chips/chip/chip-adapter.ts
@@ -26,6 +26,7 @@ export interface IChipAdapter extends IBaseAdapter {
   getChipSetState(): IChipState | null;
   setDisabled(value: boolean): void;
   setSelected(value: boolean): void;
+  setRemoveButtonLabel(value: string): void;
   focusTrigger(options?: FocusOptions): void;
   tryFocusRemoveButton(): void;
   clickRemoveButton(): void;
@@ -145,6 +146,13 @@ export class ChipAdapter extends BaseAdapter<IChipComponent> implements IChipAda
     toggleAttribute(this._triggerElement, value, 'aria-pressed', String(value));
   }
 
+  public setRemoveButtonLabel(value: string): void {
+    if (this._removeButtonElement) {
+      const label = value?.trim() || this._getDefaultRemoveButtonLabel();
+      this._removeButtonElement.setAttribute('aria-label', label);
+    }
+  }
+
   public toggleFieldVariant(value: boolean): void {
     if (value) {
       if (!this._stateLayerElement.isConnected) {
@@ -206,18 +214,24 @@ export class ChipAdapter extends BaseAdapter<IChipComponent> implements IChipAda
     this._stateLayerElement.playAnimation();
   }
 
+  private _getDefaultRemoveButtonLabel(): string {
+    return `Remove ${this._component.innerText}`;
+  }
+
   private _createRemoveButton(): IIconButtonComponent {
     const buttonEl = document.createElement('forge-icon-button');
     buttonEl.density = 'small';
     buttonEl.id = 'remove-button';
     buttonEl.classList.add('remove');
-    buttonEl.tabIndex = -1;
-    buttonEl.setAttribute('aria-label', `Remove ${this._component.innerText}`);
     buttonEl.setAttribute('part', 'remove-button');
 
     const iconEl = document.createElement('forge-icon');
     iconEl.name = 'close';
     buttonEl.appendChild(iconEl);
+
+    // Set initial aria-label, this will be updated by setRemoveButtonLabel if a custom label is provided
+    const label = this._component.removeButtonLabel?.trim() || this._getDefaultRemoveButtonLabel();
+    buttonEl.setAttribute('aria-label', label);
 
     return buttonEl;
   }

--- a/src/lib/chips/chip/chip-constants.ts
+++ b/src/lib/chips/chip/chip-constants.ts
@@ -13,7 +13,8 @@ const observedAttributes = {
   HREF: 'href',
   TARGET: 'target',
   DOWNLOAD: 'download',
-  REL: 'rel'
+  REL: 'rel',
+  REMOVE_BUTTON_LABEL: 'remove-button-label'
 };
 
 const attributes = {

--- a/src/lib/chips/chip/chip-core.ts
+++ b/src/lib/chips/chip/chip-core.ts
@@ -13,6 +13,7 @@ export interface IChipCore {
   target: string;
   download: string;
   rel: string;
+  removeButtonLabel: string;
   focus(options?: FocusOptions): void;
   focusRemoveButton(): void;
   click(): void;
@@ -30,6 +31,7 @@ export class ChipCore implements IChipCore {
   private _target: string;
   private _download: string;
   private _rel: string;
+  private _removeButtonLabel: string;
 
   private _clickListener: EventListener = this._onClick.bind(this);
   private _keydownListener: EventListener = this._onKeydown.bind(this);
@@ -342,6 +344,16 @@ export class ChipCore implements IChipCore {
       this._rel = value;
       this._adapter.setAnchorProperty('rel', value);
       this._adapter.toggleHostAttribute(CHIP_CONSTANTS.attributes.REL, !!this._rel?.trim(), this._rel);
+    }
+  }
+
+  public get removeButtonLabel(): string {
+    return this._removeButtonLabel;
+  }
+  public set removeButtonLabel(value: string) {
+    if (this._removeButtonLabel !== value) {
+      this._removeButtonLabel = value;
+      this._adapter.setRemoveButtonLabel(this._removeButtonLabel);
     }
   }
 }

--- a/src/lib/chips/chip/chip.ts
+++ b/src/lib/chips/chip/chip.ts
@@ -24,6 +24,7 @@ export interface IChipComponent extends IBaseComponent {
   target: string;
   download: string;
   rel: string;
+  removeButtonLabel: string;
   focusRemoveButton(): void;
 }
 
@@ -54,6 +55,7 @@ declare global {
  * @property {string} target - The target of the chip.
  * @property {string} download - The download of the chip.
  * @property {string} rel - The rel of the chip.
+ * @property {string} removeButtonLabel - The custom aria-label for the remove button.
  *
  * @attribute {ChipType} type - The type of chip.
  * @attribute {unknown} value - The value of the chip.
@@ -66,6 +68,7 @@ declare global {
  * @attribute {string} target - The target of the chip.
  * @attribute {string} download - The download of the chip.
  * @attribute {string} rel - The rel of the chip.
+ * @attribute {string} remove-button-label - The custom aria-label for the remove button.
  *
  * @fires {CustomEvent<IChipDeleteEventData>} forge-chip-delete - Event fired when the chip is deleted.
  * @fires {CustomEvent<IChipSelectEventData>} forge-chip-select - Event fired when the chip is selected.
@@ -191,6 +194,9 @@ export class ChipComponent extends BaseComponent implements IChipComponent {
       case CHIP_CONSTANTS.attributes.REL:
         this.rel = newValue;
         break;
+      case CHIP_CONSTANTS.attributes.REMOVE_BUTTON_LABEL:
+        this.removeButtonLabel = newValue;
+        break;
     }
   }
 
@@ -238,4 +244,7 @@ export class ChipComponent extends BaseComponent implements IChipComponent {
 
   @coreProperty()
   declare public rel: string;
+
+  @coreProperty()
+  declare public removeButtonLabel: string;
 }

--- a/src/lib/chips/chips.test.ts
+++ b/src/lib/chips/chips.test.ts
@@ -237,6 +237,7 @@ describe('Chips', () => {
       expect(el.target).to.be.undefined;
       expect(el.download).to.be.undefined;
       expect(el.rel).to.be.undefined;
+      expect(el.removeButtonLabel).to.be.undefined;
     });
 
     it('should set type via attribute', async () => {
@@ -383,6 +384,59 @@ describe('Chips', () => {
       expect(anchorEl.target).to.equal('_blank');
       expect(anchorEl.download).to.equal('test');
       expect(anchorEl.rel).to.equal('noopener');
+    });
+
+    it('should set remove button label via attribute', async () => {
+      const el = await fixture<IChipComponent>(html`<forge-chip type="input" remove-button-label="Custom remove">Test</forge-chip>`);
+      const removeButton = getRemoveButtonElement(el);
+
+      expect(el.removeButtonLabel).to.equal('Custom remove');
+      expect(removeButton?.getAttribute('aria-label')).to.equal('Custom remove');
+    });
+
+    it('should update remove button label attribute when setting property', async () => {
+      const el = await fixture<IChipComponent>(html`<forge-chip type="input">Test</forge-chip>`);
+      const removeButton = getRemoveButtonElement(el);
+
+      expect(el.removeButtonLabel).to.be.undefined;
+      expect(removeButton?.getAttribute('aria-label')).to.equal('Remove Test');
+
+      el.removeButtonLabel = 'Custom remove';
+
+      expect(removeButton?.getAttribute('aria-label')).to.equal('Custom remove');
+    });
+
+    it('should use default remove button label when custom label is not set', async () => {
+      const el = await fixture<IChipComponent>(html`<forge-chip type="input">Test Chip</forge-chip>`);
+      const removeButton = getRemoveButtonElement(el);
+
+      expect(el.removeButtonLabel).to.be.undefined;
+      expect(removeButton?.getAttribute('aria-label')).to.equal('Remove Test Chip');
+    });
+
+    it('should update remove button label when property is set after creation', async () => {
+      const el = await fixture<IChipComponent>(html`<forge-chip type="input">Test</forge-chip>`);
+      let removeButton = getRemoveButtonElement(el);
+
+      expect(removeButton?.getAttribute('aria-label')).to.equal('Remove Test');
+
+      el.removeButtonLabel = 'Delete item';
+      removeButton = getRemoveButtonElement(el);
+
+      expect(removeButton?.getAttribute('aria-label')).to.equal('Delete item');
+    });
+
+    it('should reset to default remove button label when custom label is removed', async () => {
+      const el = await fixture<IChipComponent>(html`<forge-chip type="input" remove-button-label="Custom remove">Test</forge-chip>`);
+      let removeButton = getRemoveButtonElement(el);
+
+      expect(removeButton?.getAttribute('aria-label')).to.equal('Custom remove');
+
+      el.removeAttribute(CHIP_CONSTANTS.attributes.REMOVE_BUTTON_LABEL);
+      removeButton = getRemoveButtonElement(el);
+
+      expect(el.removeButtonLabel).to.be.null;
+      expect(removeButton?.getAttribute('aria-label')).to.equal('Remove Test');
     });
 
     it('should set focus to trigger element when calling focus() method', async () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The remove button is not currently part of the tab order within an input chip. This change removes the `tabindex="-1"` from the internal `<forge-icon-button>` for the remove button, and also exposes a new `removeButtonLabel` for customizing the `aria-label` for i18n purposes if needed.
