### PR TITLE
feat(list-dropdown): add option to have list item tooltip only appear if list item text has overflowed

### DIFF
--- a/src/lib/list-dropdown/list-dropdown-constants.ts
+++ b/src/lib/list-dropdown/list-dropdown-constants.ts
@@ -161,4 +161,7 @@ export interface ListDropdownTooltipConfig {
   offset?: number;
   anchor?: string;
   anchorElement?: HTMLElement;
+  visibilityMode?: ListDropdownTooltipVisibilityMode;
 }
+
+export type ListDropdownTooltipVisibilityMode = 'always' | 'overflow-only';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: [N]
- Docs have been added/updated: [N]
- Does this PR introduce a breaking change? [N]
- I have linked any related GitHub issues to be closed when this PR is merged? [Y]

## Describe the new behavior?
Added `visibilityMode` property to `ListDropdownTooltipConfig`. When this is unset or set to `'always'`, a tooltip will appear on hovering any list item in the dropdown. When this is set to `'overflow-only'`, a tooltip will only appear on hovering list items that have had their primary or secondary text truncated by the limited width of the list item.

Resolves issue https://github.com/tyler-technologies-oss/forge/issues/1000
