### PR TITLE
fix(text-field): ensure `aria-invalid` is set on `<input>` element when `invalid` state changes

### DIFF
--- a/src/lib/text-field/text-field-adapter.ts
+++ b/src/lib/text-field/text-field-adapter.ts
@@ -10,6 +10,7 @@ export interface ITextFieldAdapter extends IBaseFieldAdapter {
   addRootListener(name: keyof HTMLElementEventMap, listener: EventListener): void;
   removeRootListener(name: keyof HTMLElementEventMap, listener: EventListener): void;
   disableInput(disabled: boolean): void;
+  setInvalid(value: boolean): void;
   handleDefaultSlotChange(listener: TextFieldInputAttributeObserver): void;
   tryAddValueChangeListener(context: unknown, listener: TextFieldValueChangeListener): void;
   removeValueChangeListener(): void;
@@ -67,6 +68,10 @@ export class TextFieldAdapter extends BaseFieldAdapter implements ITextFieldAdap
 
   public disableInput(disabled: boolean): void {
     this._inputElements.forEach(el => (el.disabled = disabled));
+  }
+
+  public setInvalid(value: boolean): void {
+    this._inputElements.forEach(el => toggleAttribute(el, value, 'aria-invalid', 'true'));
   }
 
   public inputIsDisabled(): boolean {

--- a/src/lib/text-field/text-field-core.ts
+++ b/src/lib/text-field/text-field-core.ts
@@ -127,6 +127,14 @@ export class TextFieldCore extends BaseFieldCore<ITextFieldAdapter> implements I
     }
   }
 
+  public override get invalid(): boolean {
+    return super.invalid;
+  }
+  public override set invalid(value: boolean) {
+    super.invalid = value;
+    this._adapter.setInvalid(value);
+  }
+
   public override get disabled(): boolean {
     return super.disabled;
   }

--- a/src/lib/text-field/text-field.test.ts
+++ b/src/lib/text-field/text-field.test.ts
@@ -87,6 +87,22 @@ describe('Text field', () => {
       await frame();
       expect(harness.element.disabled).to.be.true;
     });
+
+    it('should set aria-invalid attribute on input when invalid is true', async () => {
+      const harness = await createFixture();
+      harness.element.invalid = true;
+      expect(harness.inputElement.getAttribute('aria-invalid')).to.equal('true');
+    });
+
+    it('should remove aria-invalid attribute from input when invalid is false', async () => {
+      const harness = await createFixture();
+
+      harness.element.invalid = true;
+      expect(harness.inputElement.getAttribute('aria-invalid')).to.equal('true');
+
+      harness.element.invalid = false;
+      expect(harness.inputElement.hasAttribute('aria-invalid')).to.be.false;
+    });
   });
 
   describe('clear button', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: Y
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
Sets `aria-invalid="true"` on the `<input>` element(s) when the `invalid` state is `true`, otherwise removes the `aria-invalid` attribute.

## Additional information
Fixes #1009 
