### PR TITLE
fix(text-field): prevent focus change on clear button mousedown to fix autocomplete clear issue

### DIFF
--- a/src/dev/pages/autocomplete/autocomplete.ejs
+++ b/src/dev/pages/autocomplete/autocomplete.ejs
@@ -1,12 +1,9 @@
 <div class="vert">
   <form autocomplete="off">
     <forge-autocomplete id="autocomplete">
-      <forge-text-field popover-icon>
+      <forge-text-field show-clear popover-icon>
         <label for="autocomplete-input">Choose state</label>
         <input type="text" id="autocomplete-input" />
-        <forge-icon-button slot="trailing" density="medium" data-forge-autocomplete-clear aria-label="Clear value">
-          <forge-icon name="close"></forge-icon>
-        </forge-icon-button>
       </forge-text-field>
     </forge-autocomplete>
   </form>

--- a/src/lib/autocomplete/autocomplete-core.ts
+++ b/src/lib/autocomplete/autocomplete-core.ts
@@ -213,6 +213,7 @@ export class AutocompleteCore extends ListDropdownAwareCore implements IAutocomp
   }
 
   private _onClear(evt: MouseEvent): void {
+    evt.preventDefault();
     this._filterText = '';
     this._clearValue();
     this._adapter.setSelectedText(this._getSelectedText());

--- a/src/lib/text-field/text-field-adapter.ts
+++ b/src/lib/text-field/text-field-adapter.ts
@@ -16,8 +16,8 @@ export interface ITextFieldAdapter extends IBaseFieldAdapter {
   removeValueChangeListener(): void;
   tryFloatLabel(force?: boolean): void;
   tryConnectSlottedLabel(): void;
-  connectClearButton(listener: EventListener): void;
-  disconnectClearButton(listener: EventListener): void;
+  connectClearButton(clickListener: EventListener, mouseDownListener: EventListener): void;
+  disconnectClearButton(clickListener: EventListener, mouseDownListener: EventListener): void;
   toggleClearButtonVisibility(visible: boolean): void;
   clearInput(): void;
   getAllSlotElements(): HTMLSlotElement[];
@@ -183,12 +183,16 @@ export class TextFieldAdapter extends BaseFieldAdapter implements ITextFieldAdap
     label.htmlFor = id;
   }
 
-  public connectClearButton(listener: EventListener): void {
-    this._clearButtonSlotElement.addEventListener('click', listener);
+  public connectClearButton(clickListener: EventListener, mouseDownListener: EventListener): void {
+    this._clearButtonSlotElement.addEventListener('click', clickListener);
+    if (mouseDownListener) {
+      this._clearButtonSlotElement.addEventListener('mousedown', mouseDownListener);
+    }
   }
 
-  public disconnectClearButton(listener: EventListener): void {
-    this._clearButtonSlotElement.removeEventListener('click', listener);
+  public disconnectClearButton(clickListener: EventListener, mouseDownListener: EventListener): void {
+    this._clearButtonSlotElement.removeEventListener('click', clickListener);
+    this._clearButtonSlotElement.removeEventListener('mousedown', mouseDownListener);
   }
 
   public toggleClearButtonVisibility(visible: boolean): void {

--- a/src/lib/text-field/text-field-core.ts
+++ b/src/lib/text-field/text-field-core.ts
@@ -16,6 +16,7 @@ export class TextFieldCore extends BaseFieldCore<ITextFieldAdapter> implements I
   private _valueChangeListener: TextFieldValueChangeListener = this._onValueChange.bind(this);
   private _inputListener: EventListener = this._onInputChange.bind(this);
   private _clearButtonClickListener: EventListener = (evt: PointerEvent) => this._onClearButtonClick(evt);
+  private _clearButtonMouseDownListener: EventListener = (evt: MouseEvent) => this._onClearButtonMouseDown(evt);
 
   constructor(protected _adapter: TextFieldAdapter) {
     super(_adapter);
@@ -83,6 +84,10 @@ export class TextFieldCore extends BaseFieldCore<ITextFieldAdapter> implements I
     }
   }
 
+  private _onClearButtonMouseDown(evt: MouseEvent): void {
+    evt.preventDefault(); // Prevent focus change to avoid blur event
+  }
+
   /** Responds to the `input` event from the <input> element. */
   private _onInputChange(evt: InputEvent & { target: HTMLInputElement }): void {
     let floatLabel;
@@ -119,9 +124,9 @@ export class TextFieldCore extends BaseFieldCore<ITextFieldAdapter> implements I
       this._adapter.toggleHostAttribute(TEXT_FIELD_CONSTANTS.attributes.SHOW_CLEAR, value);
 
       if (value) {
-        this._adapter.connectClearButton(this._clearButtonClickListener);
+        this._adapter.connectClearButton(this._clearButtonClickListener, this._clearButtonMouseDownListener);
       } else {
-        this._adapter.disconnectClearButton(this._clearButtonClickListener);
+        this._adapter.disconnectClearButton(this._clearButtonClickListener, this._clearButtonMouseDownListener);
       }
       this._toggleClearButtonVisibility();
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Clicking the autocomplete clear button would fail on first attempt but work on subsequent clicks.  The blur event from clicking clear button interfered with clear operation before it could complete. Added `preventDefault()` on clear button `mousedown` to prevent focus change.