### PR TITLE
fix(autocomplete): fix text highlighting for selected options

### DIFF
--- a/src/lib/autocomplete/autocomplete-core.ts
+++ b/src/lib/autocomplete/autocomplete-core.ts
@@ -451,14 +451,28 @@ export class AutocompleteCore extends ListDropdownAwareCore implements IAutocomp
       asyncStyle: ListDropdownAsyncStyle.Skeleton,
       headerBuilder: this._popupHeaderBuilder,
       footerBuilder: this._popupFooterBuilder,
-      transform: label => {
-        if (this._filterText) {
-          // Highlight the filter text within the option label
+      transform: (label, option, isSelected) => {
+        const inputValue = this._adapter.getInputValue();
+        const isUserTyping =
+          this._filterText &&
+          inputValue?.length &&
+          inputValue !== label && // User hasn't just selected this exact option
+          this._adapter.hasFocus();
+
+        if (isUserTyping) {
+          // When filtering: highlight only the matching search text
           const highlightElement = highlightTextHTML(label, this._filterText);
           if (highlightElement) {
             return highlightElement;
           }
+        } else if (isSelected) {
+          // When not filtering: bold the entire text of selected options
+          const boldElement = document.createElement('span');
+          boldElement.style.fontWeight = 'bold';
+          boldElement.textContent = label;
+          return boldElement;
         }
+
         return label;
       },
       allowBusy: true,

--- a/src/lib/list-dropdown/list-dropdown-constants.ts
+++ b/src/lib/list-dropdown/list-dropdown-constants.ts
@@ -45,7 +45,7 @@ export type ListDropdownOptionBuilder<T = HTMLElement> = (option: IListDropdownO
 export type ListDropdownHeaderBuilder = () => HTMLElement;
 export type ListDropdownFooterBuilder = () => HTMLElement;
 export type ListDropdownOptionGroupBuilder<T = any> = (option: IListDropdownOptionGroup<T>) => HTMLElement | string;
-export type ListDropdownTransformCallback = (label: string) => string | HTMLElement;
+export type ListDropdownTransformCallback = (label: string, option?: IListDropdownOption, isSelected?: boolean) => string | HTMLElement;
 export type ListDropdownIconType = 'font' | 'component';
 
 export interface IBaseListDropdownOption<T = any> {

--- a/src/lib/list-dropdown/list-dropdown-utils.ts
+++ b/src/lib/list-dropdown/list-dropdown-utils.ts
@@ -263,7 +263,7 @@ export function createListItems(
         if (typeof config.transform !== 'function') {
           buttonElement.textContent = option.label || '';
         } else {
-          const result = config.transform(option.label);
+          const result = config.transform(option.label, option, isSelected);
           if (typeof result === 'string') {
             buttonElement.textContent = result;
           } else if (typeof result === 'object' && (result as HTMLElement).nodeType !== undefined) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
When two options have the same label text, but only one of those options is selected, the other unselected option will no longer be bolded/highlighted incorrectly.

With that said, using two options with the same label text should be avoided as it can be confusing to users.

## Additional information
Resolves #997 
