### PR TITLE
fix(list-dropdown): fix overflow-only tooltips so that they appear whenever text is cut

### DIFF
--- a/src/lib/list-dropdown/list-dropdown-utils.ts
+++ b/src/lib/list-dropdown/list-dropdown-utils.ts
@@ -425,7 +425,7 @@ export async function asyncCreateListItemTooltipIfTextOverflows(
   await frame();
 
   // Only append the tooltip if the button or secondary label overflow the width of the parent list item.
-  if (buttonElement.scrollWidth > listItemElement.clientWidth || secondaryLabelElement.scrollWidth > listItemElement.clientWidth) {
+  if (buttonElement.scrollWidth > buttonElement.clientWidth || secondaryLabelElement.scrollWidth > secondaryLabelElement.clientWidth) {
     const tooltipElement = createListItemTooltip(tooltip, configId, optionIdIndex, listItemElement, buttonElement);
     listItemElement.appendChild(tooltipElement);
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
When using `visibilityMode: 'overflow-only'`, a tooltip will be added to any list item where text is truncated.

## Additional information
Resolves #1026
