### PR TITLE
fix(calendar): only emit month change event once when year also changes on next/previous

### DIFF
--- a/src/lib/calendar/calendar-core.ts
+++ b/src/lib/calendar/calendar-core.ts
@@ -1488,14 +1488,14 @@ export class CalendarCore implements ICalendarCore {
   /**
    * Sets the month text and attribute in the adapter.
    * @param userSelected Whether the month was explicitly selected by the user (optional)
-   * @param emitEvent Whether to suppress emitting the month change event (optional)
+   * @param suppressEvent Whether to suppress emitting the month change event (optional)
    * */
-  private _setMonth(userSelected?: boolean, emitEvent?: boolean): void {
+  private _setMonth(userSelected?: boolean, suppressEvent?: boolean): void {
     this._adapter.setMonth(this._month, this._locale);
     this._adapter.setHostAttribute(CALENDAR_CONSTANTS.attributes.MONTH, this._month.toString());
     if (this._isInitialized) {
       this._setNavigationButtonStates();
-      if (!emitEvent) {
+      if (!suppressEvent) {
         this._adapter.emitHostEvent(CALENDAR_CONSTANTS.events.MONTH_CHANGE, {
           month: this._month,
           userSelected: userSelected ?? false,
@@ -1508,14 +1508,14 @@ export class CalendarCore implements ICalendarCore {
   /**
    * Sets the year text and attribute in the adapter.
    * @param userSelected Whether the year was explicity selected by the user (optional)
-   * @param emitEvent Whether to suppress emitting the month change event (optional)
+   * @param suppressEvent Whether to suppress emitting the month change event (optional)
    * */
-  private _setYear(userSelected?: boolean, emitEvent?: boolean): void {
+  private _setYear(userSelected?: boolean, suppressEvent?: boolean): void {
     this._adapter.setYear(this._year, this._locale);
     this._adapter.setHostAttribute(CALENDAR_CONSTANTS.attributes.YEAR, this._year.toString());
     if (this._isInitialized) {
       this._setNavigationButtonStates();
-      if (!emitEvent) {
+      if (!suppressEvent) {
         this._adapter.emitHostEvent(CALENDAR_CONSTANTS.events.MONTH_CHANGE, {
           month: this._month,
           userSelected: userSelected ?? false,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: N
- Docs have been added/updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?
When handling next/previous month click, if the year also changes, they were being set independently and each firing the month change event.  Adding a `suppressEvent` parameter to the private setters, and passing it to prevent the year change from emitted the event before the month has also been updated, which will then emit a single event.

## Additional information
Also fixes the one date-picker test that started failing in December because it was expecting the event listener to be called once, when it was called twice, so this will allow CI's to start passing again this month.
