### PR TITLE
fix(autocomplete): prevent dropdown interaction when input is disabled

### DIFF
--- a/src/lib/autocomplete/autocomplete-adapter.ts
+++ b/src/lib/autocomplete/autocomplete-adapter.ts
@@ -194,14 +194,23 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
 
   public setDropdownIconListener(type: string, listener: EventListener): void {
     window.requestAnimationFrame(() => {
+      const wrappedListener = (event: Event): void => {
+        if (this._inputElement?.disabled || this._inputElement?.hasAttribute('disabled')) {
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
+        listener(event);
+      };
+
       const textField = this._component.querySelector(TEXT_FIELD_CONSTANTS.elementName);
       if (textField && (textField.popoverIcon || textField.hasAttribute(FIELD_CONSTANTS.attributes.POPOVER_ICON))) {
         const eventType = type === 'mousedown' ? FIELD_CONSTANTS.events.POPOVER_ICON_MOUSEDOWN : FIELD_CONSTANTS.events.POPOVER_ICON_CLICK;
-        this._component.addEventListener(eventType, listener);
+        this._component.addEventListener(eventType, wrappedListener);
       }
 
       const dropdownIcon = this._component.querySelector(AUTOCOMPLETE_CONSTANTS.selectors.DROPDOWN_ICON);
-      dropdownIcon?.addEventListener(type, listener);
+      dropdownIcon?.addEventListener(type, wrappedListener);
     });
   }
 


### PR DESCRIPTION
Wrap the dropdown icon listener to check the disabled state before executing. Prevents dropdown from flashing and items from being selected when disabled.

## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added/updated: [N]
- Docs have been added/updated: [N]
- Does this PR introduce a breaking change? [N]
- I have linked any related GitHub issues to be closed when this PR is merged? [Y]

## Describe the new behavior?
Fixes #[1024](https://github.com/tyler-technologies-oss/forge/issues/1024)
When the autocomplete input is disabled, clicking the dropdown icon no longer causes any interaction. Previously, the dropdown would flash momentarily, and users could select items if they clicked quickly enough.

https://github.com/user-attachments/assets/e7adbe53-ee87-48ce-a6ad-6b11eabbb950


## Additional information
The wrapped listener checks both `this._inputElement?.disabled` (property) and `this._inputElement?.hasAttribute('disabled')` (attribute).
No breaking changes. 
I ran the tests for the autocomplete component, and all the tests passed.