### PR TITLE
feat(time-picker): sanitize invalid step values

### DIFF
--- a/.changeset/big-pets-pick.md
+++ b/.changeset/big-pets-pick.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+feat(time-picker): sanitize invalid step values to fix infinite loop

--- a/packages/forge/src/lib/time-picker/time-picker-core.ts
+++ b/packages/forge/src/lib/time-picker/time-picker-core.ts
@@ -987,7 +987,7 @@ export class TimePickerCore implements ITimePickerCore {
     return this._step;
   }
   public set step(value: number) {
-    this._step = value;
+    this._step = value > 0 ? value : TIME_PICKER_CONSTANTS.numbers.DEFAULT_MINUTE_STEP;
   }
 
   public get allowInput(): boolean {

--- a/packages/forge/src/lib/time-picker/time-picker.test.ts
+++ b/packages/forge/src/lib/time-picker/time-picker.test.ts
@@ -821,6 +821,18 @@ describe('TimePickerComponent', () => {
       expect(harness.element.step).toBe(expectedMinutes);
     });
 
+    it('should default step to 60 when set to zero', async () => {
+      harness = await createFixture();
+      harness.element.step = 0;
+      expect(harness.element.step).toBe(TIME_PICKER_CONSTANTS.numbers.DEFAULT_MINUTE_STEP);
+    });
+
+    it('should default step to 60 when set to negative value', async () => {
+      harness = await createFixture();
+      harness.element.step = -15;
+      expect(harness.element.step).toBe(TIME_PICKER_CONSTANTS.numbers.DEFAULT_MINUTE_STEP);
+    });
+
     it('should set allowInput via attribute', async () => {
       harness = await createFixture();
       harness.element.setAttribute(TIME_PICKER_CONSTANTS.attributes.ALLOW_INPUT, 'false');


### PR DESCRIPTION
## Summary
Sanitizes invalid step values to fix out of memory error (infinite loop when generating time values).

Fixes #1066 

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
