### PR TITLE
fix(radio): escape special characters in radio name for grouping

### DIFF
--- a/.changeset/seven-mice-bow.md
+++ b/.changeset/seven-mice-bow.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(radio): escape special characters in radio name for grouping

--- a/packages/forge/src/lib/radio/core/radio-group-manager.ts
+++ b/packages/forge/src/lib/radio/core/radio-group-manager.ts
@@ -41,7 +41,7 @@ export class RadioGroupManager {
     // If there's no associated form element search the root node
     if (!el.form && !form) {
       const root = rootNode ?? (el.getRootNode() as ShadowRoot | Document);
-      const namedRadios = root.querySelectorAll<IRadioComponent>(`${RADIO_CONSTANTS.elementName}[name=${el.name}]`);
+      const namedRadios = root.querySelectorAll<IRadioComponent>(`${RADIO_CONSTANTS.elementName}[name="${CSS.escape(el.name)}"]`);
       return Array.from(namedRadios).filter(radio => !radio.form);
     }
 

--- a/packages/forge/src/lib/radio/radio/radio.test.ts
+++ b/packages/forge/src/lib/radio/radio/radio.test.ts
@@ -540,6 +540,24 @@ describe('Radio', () => {
       expect(radioEls[1].checked).toBe(true);
     });
 
+    it('should group radios with special characters in name', async () => {
+      const screen = render(html`
+        <div>
+          <forge-radio name="test/radio"></forge-radio>
+          <forge-radio name="test/radio"></forge-radio>
+        </div>
+      `);
+      const el = screen.container.querySelector('div') as HTMLElement;
+      const ctx = new RadioHarness(el);
+      const radioEls = ctx.radioElements;
+
+      radioEls[0].checked = true;
+      radioEls[1].checked = true;
+
+      expect(radioEls[0].checked).toBe(false);
+      expect(radioEls[1].checked).toBe(true);
+    });
+
     it('should not group radios with same name in different forms', async () => {
       const screen = render(html`
         <div>


### PR DESCRIPTION
## Summary
Fixes #1049 

Uses `CSS.escape()` when building radio selector to create the group to ensure special characters are accounted for in radio names.

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
