### PR TITLE
feat(date-picker-component-delegate): fix onChange to use correct element event

### DIFF
--- a/.changeset/dark-impalas-like.md
+++ b/.changeset/dark-impalas-like.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+feat(date-picker-component-delegate): fix onChange to use correct element event to trigger table filter

--- a/packages/forge/src/lib/date-picker/date-picker-component-delegate.test.ts
+++ b/packages/forge/src/lib/date-picker/date-picker-component-delegate.test.ts
@@ -5,7 +5,8 @@ import {
   DatePickerComponentDelegate,
   DatePickerComponentDelegateProps,
   IDatePickerComponent,
-  IDatePickerComponentDelegateOptions
+  IDatePickerComponentDelegateOptions,
+  DATE_PICKER_CONSTANTS
 } from './index.js';
 
 interface IDatePickerComponentDelegateHarness {
@@ -54,11 +55,21 @@ describe('DatePickerComponentDelegate', () => {
 
   it('should listen for change event', () => {
     harness = setupTestContext();
-
     const value = '01/01/2020';
     const changeSpy = vi.fn();
     harness.delegate.onChange(changeSpy);
-    _setInputValue(harness.delegate.element, value, 'input');
+    harness.delegate.element.dispatchEvent(new CustomEvent(DATE_PICKER_CONSTANTS.events.CHANGE, { detail: value }));
+
+    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledWith(value);
+  });
+
+  it('should listen for change event when masked', () => {
+    harness = setupTestContext({ masked: true });
+    const value = '01/01/2020';
+    const changeSpy = vi.fn();
+    harness.delegate.onChange(changeSpy);
+    harness.delegate.element.dispatchEvent(new CustomEvent(DATE_PICKER_CONSTANTS.events.CHANGE, { detail: value }));
 
     expect(changeSpy).toHaveBeenCalledOnce();
     expect(changeSpy).toHaveBeenCalledWith(value);

--- a/packages/forge/src/lib/date-picker/date-picker-component-delegate.ts
+++ b/packages/forge/src/lib/date-picker/date-picker-component-delegate.ts
@@ -54,11 +54,7 @@ export class DatePickerComponentDelegate extends FormFieldComponentDelegate<IDat
   }
 
   public onChange(listener: (value: string) => void): void {
-    if (this._element.masked) {
-      this._element.addEventListener(DATE_PICKER_CONSTANTS.events.INPUT, evt => listener((evt.target as HTMLInputElement).value));
-    } else {
-      this.getInputElement().addEventListener('input', evt => listener((evt.target as HTMLInputElement).value));
-    }
+    this._element.addEventListener(DATE_PICKER_CONSTANTS.events.CHANGE, (evt: CustomEvent) => listener(evt.detail));
   }
 
   public onInput(listener: (value: string) => void): void {


### PR DESCRIPTION
## Summary
Fixes #1060 

Updates the `onChange` listener within the delegate to listen for the correct `forge-date-picker-change` event to consolidate change notifications under a single event regardless of mask state.

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
