### PR TITLE
fix(date-picker): open calendar on current month when max is current date

### DIFF
--- a/.changeset/sharp-deserts-open.md
+++ b/.changeset/sharp-deserts-open.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(date-picker): open calendar on current month when max is current date

--- a/packages/forge/src/lib/date-picker/base/base-date-picker-core.ts
+++ b/packages/forge/src/lib/date-picker/base/base-date-picker-core.ts
@@ -237,8 +237,9 @@ export abstract class BaseDatePickerCore<
     };
 
     // If the max date is in the past, set the calendar to the min date
-    const currentDate = new Date().getTime();
-    if (this._min && this._max && this._max.getTime() < currentDate) {
+    const currentDate = new Date();
+    currentDate.setHours(0, 0, 0, 0);
+    if (this._min && this._max && this._max.getTime() < currentDate.getTime()) {
       calendarConfig.year = this._min.getFullYear();
       calendarConfig.month = this._min.getMonth();
     }

--- a/packages/forge/src/lib/date-picker/date-picker.test.ts
+++ b/packages/forge/src/lib/date-picker/date-picker.test.ts
@@ -140,6 +140,21 @@ describe('DatePickerComponent', () => {
       expect(calendar.month).toBe(expectedMonth);
     });
 
+    it('should open calendar in current month when max is today and min is in the past', () => {
+      harness = setupTestContext(false);
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const minDate = new Date(today.getFullYear() - 1, today.getMonth(), 1);
+      harness.component.min = minDate;
+      harness.component.max = today;
+      harness.append();
+
+      openPopup(harness.component);
+      const calendar = getCalendar(harness.component);
+
+      expect(calendar.month).toBe(today.getMonth());
+    });
+
     it('should automatically render a toggle button with a Forge text-field component', () => {
       harness = setupTestContext(false, true, false);
 


### PR DESCRIPTION
## Summary
Normalize currentDate to midnight before comparing with max to prevent today from being considered "in the past" due to time component.

Fixes #1053

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
