### PR TITLE
fix(lit-utils): defer hideWhenEmpty initial requestUpdate to avoid update loop

### DIFF
--- a/packages/forge/src/lib/core/utils/lit-utils.ts
+++ b/packages/forge/src/lib/core/utils/lit-utils.ts
@@ -82,7 +82,7 @@ class HideWhenEmptyDirective extends AsyncDirective {
     });
 
     this.#toggleHidden(element);
-    this.#requestUpdate(part);
+    queueMicrotask(() => this.#requestUpdate(part));
     this.#isInitialized = true;
   }
 


### PR DESCRIPTION
## Summary
Seeing the following warning related to the `hideWhenEmpty` directive within the app bar:

"reactive-element.ts:98 Element forge-app-bar scheduled an update (generally because a property was set) after an update completed, causing a new update to be scheduled. This is inefficient and should be avoided unless the next update can only be scheduled as a side effect of the previous update. See https://lit.dev/msg/change-in-update for more information."

Deferring the update in a microtask fixes it.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated (if applicable)
- [ ] Changeset added (`pnpm changeset`)

## Breaking Changes
None
