### PR TITLE
fix(autocomplete): prevent dropdown interaction when input disabled

### DIFF
--- a/.changeset/plain-moments-rule.md
+++ b/.changeset/plain-moments-rule.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(autocomplete): prevent dropdown interaction when input disabled

--- a/packages/forge/src/lib/autocomplete/autocomplete-core.ts
+++ b/packages/forge/src/lib/autocomplete/autocomplete-core.ts
@@ -207,6 +207,9 @@ export class AutocompleteCore extends ListDropdownAwareCore implements IAutocomp
   }
 
   private _onDropdownIconClick(evt: MouseEvent): void {
+    if (this._adapter.inputElement.disabled) {
+      return;
+    }
     if (!this._isDropdownOpen) {
       this._adapter.focus();
       window.requestAnimationFrame(() => this._showDropdown());
@@ -216,6 +219,9 @@ export class AutocompleteCore extends ListDropdownAwareCore implements IAutocomp
   }
 
   private _onClear(evt: MouseEvent): void {
+    if (this._adapter.inputElement.disabled) {
+      return;
+    }
     evt.preventDefault();
     this._filterText = '';
     this._clearValue();

--- a/packages/forge/src/lib/autocomplete/autocomplete.test.ts
+++ b/packages/forge/src/lib/autocomplete/autocomplete.test.ts
@@ -1543,6 +1543,17 @@ describe('AutocompleteComponent', () => {
       expect(harness.popupElement).not.toBeNull();
     });
 
+    it('should not open dropdown if icon clicked when input is disabled', async () => {
+      const harness = await createTextFieldFixture();
+      harness.component.filter = () => DEFAULT_FILTER_OPTIONS;
+      harness.input.disabled = true;
+      await frame();
+      harness.iconElement!.click();
+      await frame();
+      await frame();
+      expect(harness.popupElement).toBeFalsy();
+    });
+
     it('should open dropdown if popover icon clicked', async () => {
       const harness = await createTextFieldFixture(false);
       harness.component.filter = () => DEFAULT_FILTER_OPTIONS;


### PR DESCRIPTION
## Summary
Fixes #1024 

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
