### PR TITLE
fix(app-bar): correct typo in scoped class name

### DIFF
--- a/packages/forge/src/lib/app-bar/app-bar/app-bar.scss
+++ b/packages/forge/src/lib/app-bar/app-bar/app-bar.scss
@@ -139,7 +139,7 @@ $host-tokens: (background, foreground);
 // Attempt to auto-theme any specific slotted elements directly
 //
 
-.fprge-app-bar.scoped {
+.forge-app-bar.scoped {
   ::slotted(:where(forge-tab-bar, forge-icon-button, forge-button)) {
     color: #{token(theme-foreground)};
 


### PR DESCRIPTION
Fix selector typo caused by #1084 
