### PR TITLE
fix(paginator): announce pagination changes to screen readers

### DIFF
--- a/packages/forge/src/lib/paginator/paginator-adapter.ts
+++ b/packages/forge/src/lib/paginator/paginator-adapter.ts
@@ -1,5 +1,6 @@
 import { getShadowElement, removeAllChildren, toggleElementPlaceholder } from '@tylertech/forge-core';
 import { BaseAdapter, IBaseAdapter } from '../core/base/base-adapter.js';
+import { LiveAnnouncer } from '@tylertech/forge-core';
 import { IIconButtonComponent } from '../icon-button/index.js';
 import { ISelectComponent, ISelectOption } from '../select/index.js';
 import { IPaginatorComponent } from './paginator.js';
@@ -32,6 +33,7 @@ export interface IPaginatorAdapter extends IBaseAdapter {
   setPageSizeVisibility(visible: boolean): void;
   setFocus(options?: FocusOptions): void;
   tryDisableFields(fieldsToDisable: PaginatorFieldIdentifier[]): void;
+  announceChange(message: string): void;
 }
 
 export class PaginatorAdapter extends BaseAdapter<IPaginatorComponent> implements IPaginatorAdapter {
@@ -193,6 +195,10 @@ export class PaginatorAdapter extends BaseAdapter<IPaginatorComponent> implement
       next: () => this.setNextPageButtonEnabled(false)
     };
     fieldsToDisable.forEach(field => fieldDisablers[field]?.());
+  }
+
+  public announceChange(message: string): void {
+    LiveAnnouncer.instance.announce(message, 'polite');
   }
 
   private _tryFocus(elements: Array<IIconButtonComponent | ISelectComponent>, options?: FocusOptions): void {

--- a/packages/forge/src/lib/paginator/paginator-core.ts
+++ b/packages/forge/src/lib/paginator/paginator-core.ts
@@ -41,6 +41,7 @@ export class PaginatorCore {
   private _disabled = false;
   private _alternative = false;
   private _rangeLabelCallback: PaginatorRangeLabelBuilder;
+  private _initialized = false;
 
   private _firstPageListener: EventListener = this._onFirstPage.bind(this);
   private _previousPageListener: EventListener = this._onPreviousPage.bind(this);
@@ -58,6 +59,7 @@ export class PaginatorCore {
     this._attachListeners();
     this._toggleFirstLastButtons();
     this._syncInteractionState();
+    this._initialized = true;
   }
 
   public focus(options?: FocusOptions): void {
@@ -191,6 +193,10 @@ export class PaginatorCore {
     }
 
     this._adapter.setRangeLabel(rangeLabel);
+
+    if (this._initialized) {
+      this._adapter.announceChange(rangeLabel);
+    }
   }
 
   private _syncInteractionState(): void {

--- a/packages/forge/src/lib/paginator/paginator.test.ts
+++ b/packages/forge/src/lib/paginator/paginator.test.ts
@@ -7,6 +7,7 @@ import type { IPaginatorChangeEventData } from './paginator-constants.js';
 import { PAGINATOR_CONSTANTS } from './paginator-constants.js';
 import type { ISelectComponent } from '../select/select/select.js';
 import type { IIconButtonComponent } from '../icon-button/index.js';
+import { LiveAnnouncer } from '@tylertech/forge-core';
 
 import './paginator.js';
 
@@ -49,6 +50,36 @@ describe('Paginator', () => {
       const harness = await createFixture({ disabled: true });
 
       await expect(harness.paginatorElement).toBeAccessible();
+    });
+
+    it('should announce range changes to screen readers on page navigation', async () => {
+      const announceSpy = vi.spyOn(LiveAnnouncer.instance, 'announce');
+      const harness = await createFixture({ total: 100 });
+
+      announceSpy.mockClear();
+      harness.nextButton.click();
+
+      expect(announceSpy).toHaveBeenCalledWith('26-50 of 100', 'polite');
+    });
+
+    it('should announce range changes to screen readers on page size change', async () => {
+      const announceSpy = vi.spyOn(LiveAnnouncer.instance, 'announce');
+      const harness = await createFixture({ total: 100 });
+
+      announceSpy.mockClear();
+      harness.pageSizeSelect.value = '50';
+      harness.pageSizeSelect.dispatchEvent(new CustomEvent('change', { detail: '50' }));
+
+      expect(announceSpy).toHaveBeenCalledWith('1-50 of 100', 'polite');
+    });
+
+    it('should not announce on initial render', async () => {
+      const announceSpy = vi.spyOn(LiveAnnouncer.instance, 'announce');
+      announceSpy.mockClear();
+
+      await createFixture({ total: 100 });
+
+      expect(announceSpy).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
Use `LiveAnnouncer` to announce range label changes when users navigate pages or change page size. Satisfies WCAG 4.1.3.

Fixes #1055

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
