### PR TITLE
fix(secret): prevent unexpected icon button size when line-height is set to normal

### DIFF
--- a/.changeset/famous-pianos-drum.md
+++ b/.changeset/famous-pianos-drum.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(secret): prevent unexpected icon button size when line-height is set to normal

--- a/packages/forge/src/lib/secret/_core.scss
+++ b/packages/forge/src/lib/secret/_core.scss
@@ -105,6 +105,7 @@
     (
       background-color: #{token(button-background)},
       icon-color: #{token(button-color)},
+      icon-size: inherit,
       padding: 0,
       shape: #{token(button-shape)},
       size: 1lh


### PR DESCRIPTION
## Summary
Set the secret's icon button to inherit its icon size from its container's font size, preventing unexpected sizing when `line-height: normal` is used.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
