### PR TITLE
fix(expansion-panel): fix open-icon sync

### DIFF
--- a/.changeset/wild-shoes-switch.md
+++ b/.changeset/wild-shoes-switch.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(expansion-panel): fix open-icon sync with expansion-panel

--- a/packages/forge/src/lib/expansion-panel/expansion-panel.test.ts
+++ b/packages/forge/src/lib/expansion-panel/expansion-panel.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-lit';
 import { userEvent } from 'vitest/browser';
 import { task } from '../core/utils/utils.js';
-import type { IOpenIconComponent } from '../open-icon/open-icon.js';
+import type { IOpenIconComponent, OpenIconComponent } from '../open-icon/open-icon.js';
 import { EXPANSION_PANEL_CONSTANTS, emulateUserToggle } from './expansion-panel-constants.js';
 import type { ExpansionPanelComponent } from './expansion-panel.js';
 
@@ -719,6 +719,59 @@ describe('Expansion Panel', () => {
       expect(openIcon.open).toBe(false);
       await userEvent.click(trigger);
       expect(openIcon.open).toBe(true);
+    });
+
+    it('should sync open icon when openIconElement is set before connecting to DOM', async () => {
+      const screen = render(html`<div></div>`);
+      const container = screen.container.querySelector('div') as HTMLElement;
+
+      const fragment = document.createElement('div');
+      fragment.innerHTML = `
+        <forge-open-icon></forge-open-icon>
+        <forge-expansion-panel>
+          <button slot="header"></button>
+          <div></div>
+        </forge-expansion-panel>
+      `;
+      const openIcon = fragment.querySelector('forge-open-icon')!;
+      const panel = fragment.querySelector('forge-expansion-panel')!;
+      const button = fragment.querySelector('button')!;
+
+      panel.openIconElement = openIcon;
+
+      container.append(openIcon, panel);
+      await task();
+
+      expect(openIcon.open).toBe(false);
+      await userEvent.click(button);
+      expect(openIcon.open).toBe(true);
+    });
+
+    it('should immediately sync open icon to panel open state', async () => {
+      const screen = render(html`
+        <div>
+          <forge-open-icon id="open-icon-1"></forge-open-icon>
+          <forge-open-icon id="open-icon-2"></forge-open-icon>
+          <forge-expansion-panel open>
+            <div>Content</div>
+          </forge-expansion-panel>
+        </div>
+      `);
+      const container = screen.container.querySelector('div')!;
+      const openIcon1 = container.querySelector('#open-icon-1') as OpenIconComponent;
+      const openIcon2 = container.querySelector('#open-icon-2') as OpenIconComponent;
+      const expansionPanel = container.querySelector('forge-expansion-panel')!;
+      await task();
+
+      //By ref
+      expansionPanel.openIconElement = openIcon1;
+      await task();
+      expect(openIcon1.open).toBe(true);
+
+      //By id
+      expansionPanel.openIcon = 'open-icon-2';
+      await task();
+      expect(openIcon2.open).toBe(true);
     });
   });
 

--- a/packages/forge/src/lib/expansion-panel/expansion-panel.ts
+++ b/packages/forge/src/lib/expansion-panel/expansion-panel.ts
@@ -175,7 +175,9 @@ export class ExpansionPanelComponent extends BaseLitElement implements IExpansio
       this.#tryToggleOpenIcon();
     }
     if (changedProperties.has('openIcon')) {
-      this.openIconElement = this.#getOpenIconElementById(this.openIcon);
+      if (this.openIcon) {
+        this.openIconElement = this.#getOpenIconElementById(this.openIcon);
+      }
     }
     if (changedProperties.has('orientation')) {
       toggleState(this.#internals, 'horizontal', this.orientation === 'horizontal');

--- a/packages/forge/src/lib/expansion-panel/expansion-panel.ts
+++ b/packages/forge/src/lib/expansion-panel/expansion-panel.ts
@@ -171,13 +171,13 @@ export class ExpansionPanelComponent extends BaseLitElement implements IExpansio
     if (changedProperties.has('open')) {
       this.#handleOpen();
     }
-    if (changedProperties.has('open') || changedProperties.has('openIconElement')) {
-      this.#tryToggleOpenIcon();
-    }
     if (changedProperties.has('openIcon')) {
       if (this.openIcon) {
         this.openIconElement = this.#getOpenIconElementById(this.openIcon);
       }
+    }
+    if (changedProperties.has('open') || changedProperties.has('openIcon') || changedProperties.has('openIconElement')) {
+      this.#tryToggleOpenIcon();
     }
     if (changedProperties.has('orientation')) {
       toggleState(this.#internals, 'horizontal', this.orientation === 'horizontal');


### PR DESCRIPTION
## Summary
Fixes two issues with the open-icon syncing to expansion-panel described here: https://github.com/tyler-technologies-oss/forge/issues/1134

Issue 1 occurs because lit's `willUpdate` fires once for all properties with an initial value in `@property`. If `openIconElement` is set before the component connects, the `if (changedProperties.has('openIcon'))` fires afterwards with the initial empty string value and overwrites `this.openIconElement` to null.

The downside of this fix is now you can't unset the open-icon by setting `openIcon` to empty string. But you could by setting `openIconElement` to undefined/null. This doesn't seem like a huge deal? Also, maybe a new `ReactiveController` to handle the open icon would have been ideal? I'm totally new to lit and had limited time to work on this, so just wanted to improve the existing code.

I am open to any improvements on this @samrichardsontylertech, maybe you came up with a more robust pattern for this kind of thing when you made `ExpansionPanelTriggerController`

Issue 2 was simple enough to fix by adding `changedProperties.has('openIcon')` to the cases that call `tryToggleOpenIcon` and making sure changing `openIcon`  was setting `openIconElement` beforehand

## Checklist
- [X] Tests added/updated
- [ ] Docs updated (if applicable)
- [X] Changeset added (`pnpm changeset`)

## Breaking Changes
None
