### PR TITLE
Fix/calendar menu animation bugs

### DIFF
--- a/.changeset/honest-sails-thank.md
+++ b/.changeset/honest-sails-thank.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(calendar): fixed menu animation state sync issue causing blank month & year menus

--- a/packages/forge/src/lib/calendar/calendar-adapter.ts
+++ b/packages/forge/src/lib/calendar/calendar-adapter.ts
@@ -342,6 +342,11 @@ export class CalendarAdapter extends BaseAdapter<ICalendarComponent> implements 
   public setMonth(month: number, locale?: string): void {
     const monthButton = this._container.querySelector(CALENDAR_CONSTANTS.selectors.MONTH_BUTTON);
     if (monthButton) {
+      const span = monthButton.querySelector('span');
+      if (span) {
+        span.textContent = getLocalizedMonth(month, 'long', locale);
+        return;
+      }
       const content = getMonthButtonContent(month, locale);
       monthButton.replaceChildren(content[0], content[1]);
       return;
@@ -356,6 +361,11 @@ export class CalendarAdapter extends BaseAdapter<ICalendarComponent> implements 
   public setYear(year: number, locale?: string): void {
     const yearButton = this._container.querySelector(CALENDAR_CONSTANTS.selectors.YEAR_BUTTON);
     if (yearButton) {
+      const span = yearButton.querySelector('span');
+      if (span) {
+        span.textContent = getLocalizedYear(year, 'numeric', locale);
+        return;
+      }
       const content = getYearButtonContent(year, locale);
       yearButton.replaceChildren(content[0], content[1]);
       return;

--- a/packages/forge/src/lib/calendar/calendar-menu/calendar-menu-adapter.ts
+++ b/packages/forge/src/lib/calendar/calendar-menu/calendar-menu-adapter.ts
@@ -72,8 +72,8 @@ export class CalendarMenuAdapter extends BaseAdapter<ICalendarMenuComponent> imp
   public setClosed(): void {
     this._container.classList.remove(CALENDAR_MENU_CONSTANTS.classes.OPEN);
     this._container.classList.add(CALENDAR_MENU_CONSTANTS.classes.CLOSING);
-    this.toggleHostAttribute('hidden', true);
     playKeyframeAnimation(this._container, CALENDAR_MENU_CONSTANTS.classes.CLOSING, true).then(() => {
+      this.toggleHostAttribute('hidden', true);
       removeAllChildren(this._container);
     });
   }
@@ -88,6 +88,7 @@ export class CalendarMenuAdapter extends BaseAdapter<ICalendarMenuComponent> imp
     }
     this._container.appendChild(element);
     this.toggleHostAttribute('hidden', false);
+    this._container.classList.remove(CALENDAR_MENU_CONSTANTS.classes.CLOSING);
     this._container.classList.add(CALENDAR_MENU_CONSTANTS.classes.OPEN);
     if (!replace) {
       this.setFocusAtIndex(focusedIndex, setFocus, preventFocus);
@@ -104,6 +105,7 @@ export class CalendarMenuAdapter extends BaseAdapter<ICalendarMenuComponent> imp
     }
     this._container.appendChild(element);
     this.toggleHostAttribute('hidden', false);
+    this._container.classList.remove(CALENDAR_MENU_CONSTANTS.classes.CLOSING);
     this._container.classList.add(CALENDAR_MENU_CONSTANTS.classes.OPEN);
     this._scrollItemIntoView('selected');
     if (!replace) {


### PR DESCRIPTION
## Summary
Fixes a state sync issue related to the calendar month and year menus that was causing the menus to be blank upon reopen.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
