### PR TITLE
feat: global config decorator

### DIFF
--- a/.changeset/common-sides-taste.md
+++ b/.changeset/common-sides-taste.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+feat: create global configuration decorator

--- a/.changeset/dirty-donuts-sin.md
+++ b/.changeset/dirty-donuts-sin.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(field): fix global configuration overriding externally set property values

--- a/packages/forge/src/lib/core/decorators/global-configuration-decorator.test.ts
+++ b/packages/forge/src/lib/core/decorators/global-configuration-decorator.test.ts
@@ -1,0 +1,404 @@
+import { CUSTOM_ELEMENT_NAME_PROPERTY } from '@tylertech/forge-core';
+import { html, LitElement, TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-lit';
+import { IBaseAdapter } from '../base/base-adapter.js';
+import { TylerForgeGlobalConfiguration } from '../configuration/global-configuration.js';
+import { globalConfig } from './global-configuration-decorator.js';
+
+describe('globalConfig decorator', () => {
+  let originalConfig: TylerForgeGlobalConfiguration | undefined;
+
+  beforeEach(() => {
+    // Save original config
+    originalConfig = window.TylerForgeGlobalConfiguration;
+    // Clear config before each test
+    window.TylerForgeGlobalConfiguration = {};
+  });
+
+  afterEach(() => {
+    // Restore original config
+    if (originalConfig !== undefined) {
+      window.TylerForgeGlobalConfiguration = originalConfig;
+    } else {
+      delete (window as any).TylerForgeGlobalConfiguration;
+    }
+  });
+
+  describe('with Lit components (HTMLElement)', () => {
+    const TAG_NAME = 'test-global-config-lit';
+
+    @customElement(TAG_NAME)
+    class TestGlobalConfigLit extends LitElement {
+      public static [CUSTOM_ELEMENT_NAME_PROPERTY] = TAG_NAME;
+
+      @globalConfig()
+      @property({ type: String })
+      public variant = 'default';
+
+      @globalConfig()
+      @property({ type: Boolean })
+      public enabled = false;
+
+      @globalConfig()
+      @property({ type: Number })
+      public count = 10;
+
+      public render(): TemplateResult {
+        return html`<div>${this.variant}</div>`;
+      }
+    }
+
+    function setupTest(): TestGlobalConfigLit {
+      const screen = render(html`<test-global-config-lit></test-global-config-lit>`);
+      return screen.container.querySelector(TAG_NAME) as TestGlobalConfigLit;
+    }
+
+    it('should use default value when no global config is set', () => {
+      const element = setupTest();
+
+      expect(element.variant).toBe('default');
+      expect(element.enabled).toBe(false);
+      expect(element.count).toBe(10);
+    });
+
+    it('should apply global configuration value over default', () => {
+      window.TylerForgeGlobalConfiguration = {
+        [TAG_NAME as keyof typeof window.TylerForgeGlobalConfiguration]: {
+          variant: 'outlined',
+          enabled: true,
+          count: 42
+        }
+      };
+
+      const element = setupTest();
+
+      expect(element.variant).toBe('outlined');
+      expect(element.enabled).toBe(true);
+      expect(element.count).toBe(42);
+    });
+
+    it('should only apply global config values that are defined', () => {
+      window.TylerForgeGlobalConfiguration = {
+        [TAG_NAME as keyof typeof window.TylerForgeGlobalConfiguration]: {
+          variant: 'outlined'
+          // enabled and count not set
+        }
+      };
+
+      const element = setupTest();
+
+      expect(element.variant).toBe('outlined');
+      expect(element.enabled).toBe(false); // uses default
+      expect(element.count).toBe(10); // uses default
+    });
+
+    it('should allow setting property value after initialization', () => {
+      const element = setupTest();
+
+      element.variant = 'filled';
+
+      expect(element.variant).toBe('filled');
+    });
+
+    it('should allow setting property value and still respect global config on new instances', () => {
+      window.TylerForgeGlobalConfiguration = {
+        [TAG_NAME as keyof typeof window.TylerForgeGlobalConfiguration]: {
+          variant: 'outlined'
+        }
+      };
+
+      const element1 = setupTest();
+      // First access initializes with global config value
+      expect(element1.variant).toBe('outlined');
+
+      // Then set it to a different value
+      element1.variant = 'filled';
+      expect(element1.variant).toBe('filled');
+
+      const element2 = setupTest();
+      expect(element2.variant).toBe('outlined'); // new instance still uses global config
+    });
+
+    it('should throw TypeError when global config type does not match default type', () => {
+      // Test with Core class pattern to avoid Lit's internal property access
+      const ERROR_TAG_NAME = 'test-global-config-type-error';
+
+      interface ITestAdapter extends IBaseAdapter {
+        hostElement: HTMLElement;
+      }
+
+      class TestCoreTypeError {
+        @globalConfig()
+        private _variant = 'default';
+
+        constructor(private _adapter: ITestAdapter) {}
+
+        public get variant(): string {
+          return this._variant;
+        }
+      }
+
+      class TestElementTypeError extends HTMLElement {
+        private _core: TestCoreTypeError;
+
+        constructor() {
+          super();
+          const adapter: ITestAdapter = {
+            hostElement: this
+          } as unknown as ITestAdapter;
+          this._core = new TestCoreTypeError(adapter);
+        }
+
+        public get variant(): string {
+          return this._core.variant;
+        }
+      }
+
+      customElements.define(ERROR_TAG_NAME, TestElementTypeError);
+
+      window.TylerForgeGlobalConfiguration = {
+        [ERROR_TAG_NAME as keyof typeof window.TylerForgeGlobalConfiguration]: {
+          variant: 123 as any // wrong type
+        }
+      };
+
+      const screen = render(html`<test-global-config-type-error></test-global-config-type-error>`);
+      const element = screen.container.querySelector(ERROR_TAG_NAME) as TestElementTypeError;
+
+      expect(() => {
+        // Access the property to trigger initialization
+        const _ = element.variant;
+      }).toThrow(TypeError);
+    });
+
+    it('should not throw TypeError when comparing null values', () => {
+      window.TylerForgeGlobalConfiguration = {
+        [TAG_NAME as keyof typeof window.TylerForgeGlobalConfiguration]: {
+          variant: null as any
+        }
+      };
+
+      const element = setupTest();
+      expect(element.variant).toBe(null);
+    });
+  });
+
+  describe('with Core classes (legacy pattern)', () => {
+    const TAG_NAME = 'test-global-config-core';
+
+    interface ITestAdapter extends IBaseAdapter {
+      hostElement: HTMLElement;
+    }
+
+    class TestCore {
+      @globalConfig()
+      private _variant = 'default';
+
+      @globalConfig()
+      private _enabled = false;
+
+      constructor(private _adapter: ITestAdapter) {}
+
+      public get variant(): string {
+        return this._variant;
+      }
+
+      public set variant(value: string) {
+        this._variant = value;
+      }
+
+      public get enabled(): boolean {
+        return this._enabled;
+      }
+
+      public set enabled(value: boolean) {
+        this._enabled = value;
+      }
+    }
+
+    class TestElement extends HTMLElement {
+      private _core: TestCore;
+
+      constructor() {
+        super();
+        const adapter: ITestAdapter = {
+          hostElement: this
+        } as unknown as ITestAdapter;
+        this._core = new TestCore(adapter);
+      }
+
+      public get variant(): string {
+        return this._core.variant;
+      }
+
+      public set variant(value: string) {
+        this._core.variant = value;
+      }
+
+      public get enabled(): boolean {
+        return this._core.enabled;
+      }
+
+      public set enabled(value: boolean) {
+        this._core.enabled = value;
+      }
+    }
+
+    customElements.define(TAG_NAME, TestElement);
+
+    function setupTest(): TestElement {
+      const screen = render(html`<test-global-config-core></test-global-config-core>`);
+      return screen.container.querySelector(TAG_NAME) as TestElement;
+    }
+
+    it('should use default value when no global config is set', () => {
+      const element = setupTest();
+
+      expect(element.variant).toBe('default');
+      expect(element.enabled).toBe(false);
+    });
+
+    it('should apply global configuration value over default', () => {
+      window.TylerForgeGlobalConfiguration = {
+        [TAG_NAME as keyof typeof window.TylerForgeGlobalConfiguration]: {
+          variant: 'outlined',
+          enabled: true
+        }
+      };
+
+      const element = setupTest();
+
+      expect(element.variant).toBe('outlined');
+      expect(element.enabled).toBe(true);
+    });
+
+    it('should strip leading underscore from private property names for lookup', () => {
+      window.TylerForgeGlobalConfiguration = {
+        [TAG_NAME as keyof typeof window.TylerForgeGlobalConfiguration]: {
+          // Config uses 'variant', not '_variant'
+          variant: 'outlined'
+        }
+      };
+
+      const element = setupTest();
+
+      expect(element.variant).toBe('outlined');
+    });
+
+    it('should allow setting property value after initialization', () => {
+      const element = setupTest();
+
+      element.variant = 'filled';
+
+      expect(element.variant).toBe('filled');
+    });
+  });
+
+  describe('edge cases', () => {
+    const TAG_NAME = 'test-global-config-edge';
+
+    @customElement(TAG_NAME)
+    class TestGlobalConfigEdge extends LitElement {
+      public static [CUSTOM_ELEMENT_NAME_PROPERTY] = TAG_NAME;
+
+      @globalConfig()
+      @property({ type: String })
+      public nullable: string | null = null;
+
+      @globalConfig()
+      @property({ type: Object })
+      public objectValue: Record<string, any> = { key: 'value' };
+
+      public render(): TemplateResult {
+        return html`<div></div>`;
+      }
+    }
+
+    function setupTest(): TestGlobalConfigEdge {
+      const screen = render(html`<test-global-config-edge></test-global-config-edge>`);
+      return screen.container.querySelector(TAG_NAME) as TestGlobalConfigEdge;
+    }
+
+    it('should handle null default values', () => {
+      const element = setupTest();
+
+      expect(element.nullable).toBe(null);
+    });
+
+    it('should allow null values from global config', () => {
+      window.TylerForgeGlobalConfiguration = {
+        [TAG_NAME]: {
+          nullable: null
+        }
+      } as any;
+
+      const element = setupTest();
+
+      expect(element.nullable).toBe(null);
+    });
+
+    it('should handle object default values', () => {
+      const element = setupTest();
+
+      expect(element.objectValue).toEqual({ key: 'value' });
+    });
+
+    it('should apply object values from global config', () => {
+      window.TylerForgeGlobalConfiguration = {
+        [TAG_NAME as keyof typeof window.TylerForgeGlobalConfiguration]: {
+          objectValue: { foo: 'bar' }
+        }
+      };
+
+      const element = setupTest();
+
+      expect(element.objectValue).toEqual({ foo: 'bar' });
+    });
+
+    it('should only initialize once on first access', () => {
+      window.TylerForgeGlobalConfiguration = {
+        [TAG_NAME as keyof typeof window.TylerForgeGlobalConfiguration]: {
+          nullable: 'first'
+        }
+      };
+
+      const element = setupTest();
+
+      // First access
+      expect(element.nullable).toBe('first');
+
+      // Change global config (should not affect already-initialized element)
+      (window.TylerForgeGlobalConfiguration as any)[TAG_NAME]!.nullable = 'second';
+
+      // Second access - should still be 'first'
+      expect(element.nullable).toBe('first');
+    });
+
+    it('should not apply undefined values from global config', () => {
+      window.TylerForgeGlobalConfiguration = {
+        [TAG_NAME as keyof typeof window.TylerForgeGlobalConfiguration]: {
+          nullable: undefined
+        }
+      };
+
+      const element = setupTest();
+
+      expect(element.nullable).toBe(null); // uses default, not undefined
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw TypeError for symbol properties', () => {
+      const symbolProp = Symbol('test');
+
+      expect(() => {
+        class _TestClass {
+          @globalConfig()
+          public [symbolProp] = 'value';
+        }
+      }).toThrow(TypeError);
+    });
+  });
+});

--- a/packages/forge/src/lib/core/decorators/global-configuration-decorator.ts
+++ b/packages/forge/src/lib/core/decorators/global-configuration-decorator.ts
@@ -10,38 +10,39 @@ interface CoreWithAdapter {
  *
  * When the property is first accessed, the decorator will look up the tag name and property name
  * in the global configuration object and set the initial value from it. If not found in the
- * global configuration, it will use the provided default value.
+ * global configuration, it will use the property's initial value as the default.
  *
  * Works with both HTMLElement instances (Lit components) and Core classes (legacy pattern).
  * For Core classes, requires an `_adapter` property that provides access to the host element.
  *
- * @param defaultValue The default value to use if no global configuration is found
- * @throws {TypeError} If the default value type doesn't match the property type
+ * @throws {TypeError} If the global configuration value type doesn't match the property's initial value type
  *
  * @example
  * ```typescript
  * // On a Lit component
- * @globalConfig(false)
- * public someProperty: boolean;
+ * @globalConfig()
+ * public someProperty: boolean = false;
  *
  * // On a Core class
- * @globalConfig('outlined')
- * private _variant!: FieldVariant;
+ * @globalConfig()
+ * private _variant: FieldVariant = 'outlined';
  * ```
  */
-export function globalConfig<T>(defaultValue: T): PropertyDecorator {
+export function globalConfig(): PropertyDecorator {
   return function (target: object, propertyKey: string | symbol): void {
     if (typeof propertyKey === 'symbol') {
       throw new TypeError('globalConfig decorator cannot be used on symbol properties');
     }
 
     const privateKey = Symbol(`__globalConfig_${propertyKey}`);
+    const initializedKey = Symbol(`__globalConfig_initialized_${propertyKey}`);
 
     Object.defineProperty(target, propertyKey, {
-      get(this: (HTMLElement | CoreWithAdapter) & Record<symbol, any>): T {
-        // If we haven't initialized yet, check global config
-        if (!(privateKey in this)) {
-          let initialValue = defaultValue;
+      get(this: (HTMLElement | CoreWithAdapter) & Record<symbol, any>): any {
+        // If we haven't checked global config yet, do it now
+        if (!this[initializedKey]) {
+          // Use the current value as the default (set by the property initializer)
+          let initialValue = this[privateKey];
 
           // Get tag name based on whether this is an HTMLElement or a Core class
           let tagName: string | undefined;
@@ -65,26 +66,27 @@ export function globalConfig<T>(defaultValue: T): PropertyDecorator {
               const configValue = entry.valueOf(lookupKey as any);
               if (configValue !== undefined) {
                 // Type check: ensure the global config value matches the default value type
-                const defaultType = typeof defaultValue;
+                const defaultType = typeof initialValue;
                 const configType = typeof configValue;
 
-                if (defaultType !== configType && defaultValue !== null && configValue !== null) {
+                if (defaultType !== configType && initialValue !== null && configValue !== null) {
                   throw new TypeError(
                     `Type mismatch for property "${propertyKey}" on ${tagName}: ` + `expected ${defaultType} but global configuration provided ${configType}`
                   );
                 }
 
-                initialValue = configValue as T;
+                initialValue = configValue;
               }
             }
           }
 
           this[privateKey] = initialValue;
+          this[initializedKey] = true;
         }
 
         return this[privateKey];
       },
-      set(this: Record<symbol, any>, value: T): void {
+      set(this: Record<symbol, any>, value: any): void {
         this[privateKey] = value;
       },
       enumerable: true,

--- a/packages/forge/src/lib/core/decorators/global-configuration-decorator.ts
+++ b/packages/forge/src/lib/core/decorators/global-configuration-decorator.ts
@@ -1,0 +1,94 @@
+import { GlobalConfiguration } from '../configuration/global-configuration.js';
+import { IBaseAdapter } from '../base/base-adapter.js';
+
+interface CoreWithAdapter {
+  _adapter?: IBaseAdapter;
+}
+
+/**
+ * A decorator that automatically applies global configuration values to a property.
+ *
+ * When the property is first accessed, the decorator will look up the tag name and property name
+ * in the global configuration object and set the initial value from it. If not found in the
+ * global configuration, it will use the provided default value.
+ *
+ * Works with both HTMLElement instances (Lit components) and Core classes (legacy pattern).
+ * For Core classes, requires an `_adapter` property that provides access to the host element.
+ *
+ * @param defaultValue The default value to use if no global configuration is found
+ * @throws {TypeError} If the default value type doesn't match the property type
+ *
+ * @example
+ * ```typescript
+ * // On a Lit component
+ * @globalConfig(false)
+ * public someProperty: boolean;
+ *
+ * // On a Core class
+ * @globalConfig('outlined')
+ * private _variant!: FieldVariant;
+ * ```
+ */
+export function globalConfig<T>(defaultValue: T): PropertyDecorator {
+  return function (target: object, propertyKey: string | symbol): void {
+    if (typeof propertyKey === 'symbol') {
+      throw new TypeError('globalConfig decorator cannot be used on symbol properties');
+    }
+
+    const privateKey = Symbol(`__globalConfig_${propertyKey}`);
+
+    Object.defineProperty(target, propertyKey, {
+      get(this: (HTMLElement | CoreWithAdapter) & Record<symbol, any>): T {
+        // If we haven't initialized yet, check global config
+        if (!(privateKey in this)) {
+          let initialValue = defaultValue;
+
+          // Get tag name based on whether this is an HTMLElement or a Core class
+          let tagName: string | undefined;
+
+          if (this instanceof HTMLElement) {
+            // Direct HTMLElement access (Lit components)
+            tagName = this.localName || this.tagName?.toLowerCase();
+          } else if ('_adapter' in this && this._adapter?.hostElement) {
+            // Core class with adapter (legacy pattern)
+            const hostElement = this._adapter.hostElement;
+            tagName = hostElement.localName || hostElement.tagName?.toLowerCase();
+          }
+
+          // Remove leading underscore from property key for lookup (private properties like _variant -> variant)
+          const lookupKey = propertyKey.replace(/^_/, '');
+
+          if (tagName) {
+            const entry = GlobalConfiguration.get(tagName as keyof HTMLElementTagNameMap);
+
+            if (entry?.has(lookupKey as any)) {
+              const configValue = entry.valueOf(lookupKey as any);
+              if (configValue !== undefined) {
+                // Type check: ensure the global config value matches the default value type
+                const defaultType = typeof defaultValue;
+                const configType = typeof configValue;
+
+                if (defaultType !== configType && defaultValue !== null && configValue !== null) {
+                  throw new TypeError(
+                    `Type mismatch for property "${propertyKey}" on ${tagName}: ` + `expected ${defaultType} but global configuration provided ${configType}`
+                  );
+                }
+
+                initialValue = configValue as T;
+              }
+            }
+          }
+
+          this[privateKey] = initialValue;
+        }
+
+        return this[privateKey];
+      },
+      set(this: Record<symbol, any>, value: T): void {
+        this[privateKey] = value;
+      },
+      enumerable: true,
+      configurable: true
+    });
+  };
+}

--- a/packages/forge/src/lib/core/decorators/index.ts
+++ b/packages/forge/src/lib/core/decorators/index.ts
@@ -1,0 +1,1 @@
+export { globalConfig } from './global-configuration-decorator.js';

--- a/packages/forge/src/lib/core/index.ts
+++ b/packages/forge/src/lib/core/index.ts
@@ -1,5 +1,6 @@
 export * from './base/index.js';
 export * from './configuration/index.js';
+export * from './decorators/index.js';
 export * from './delegates/index.js';
 export * from './utils/index.js';
 export * from './mask/index.js';

--- a/packages/forge/src/lib/field/field-adapter.ts
+++ b/packages/forge/src/lib/field/field-adapter.ts
@@ -2,8 +2,8 @@ import { addClass, getShadowElement, removeClass, toggleClass } from '@tylertech
 import { BaseAdapter, IBaseAdapter } from '../core/base/index.js';
 import { FOCUS_INDICATOR_TAG_NAME, IFocusIndicatorComponent } from '../focus-indicator/index.js';
 import { FieldLabelPosition } from './base/base-field-constants.js';
-import { IFieldComponent } from './field.js';
 import { FIELD_CONSTANTS } from './field-constants.js';
+import { IFieldComponent } from './field.js';
 
 export interface IFieldAdapter extends IBaseAdapter<IFieldComponent> {
   readonly focusIndicator: IFocusIndicatorComponent;
@@ -69,6 +69,7 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
     } else {
       this._rootElement.prepend(this._labelElement);
     }
+    this.setHostAttribute(FIELD_CONSTANTS.attributes.LABEL_POSITION, value);
   }
 
   /**
@@ -77,7 +78,7 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
   public setFloatingLabel(value: boolean): void {
     const className = value ? FIELD_CONSTANTS.classes.FLOATING_IN : FIELD_CONSTANTS.classes.FLOATING_OUT;
     const animationName = value ? FIELD_CONSTANTS.animations.FLOAT_IN_LABEL : FIELD_CONSTANTS.animations.FLOAT_OUT_LABEL;
-    const animationEndListener: EventListener = (evt: AnimationEvent) => {
+    const animationEndListener = (evt: AnimationEvent): void => {
       if (evt.animationName === animationName) {
         removeClass(className, this._rootElement);
         this._rootElement.removeEventListener('animationend', animationEndListener);

--- a/packages/forge/src/lib/field/field-adapter.ts
+++ b/packages/forge/src/lib/field/field-adapter.ts
@@ -69,7 +69,6 @@ export class FieldAdapter extends BaseAdapter<IFieldComponent> implements IField
     } else {
       this._rootElement.prepend(this._labelElement);
     }
-    this.setHostAttribute(FIELD_CONSTANTS.attributes.LABEL_POSITION, value);
   }
 
   /**

--- a/packages/forge/src/lib/field/field-core.ts
+++ b/packages/forge/src/lib/field/field-core.ts
@@ -67,8 +67,14 @@ export class FieldCore implements IFieldCore {
     this._adapter.initializeSlots();
 
     // Setting the label position and variant here for global config decorator compatibility
+    // Skipping if there are already host attributes set to avoid overwriting values that may have been set externally
     this._adapter.setLabelPosition(this._labelPosition);
-    this._adapter.setHostAttribute(FIELD_CONSTANTS.attributes.VARIANT, this._variant);
+    if (!this._adapter.getHostAttribute(FIELD_CONSTANTS.attributes.VARIANT)) {
+      this._adapter.setHostAttribute(FIELD_CONSTANTS.attributes.LABEL_POSITION, this._labelPosition);
+    }
+    if (!this._adapter.getHostAttribute(FIELD_CONSTANTS.attributes.VARIANT)) {
+      this._adapter.setHostAttribute(FIELD_CONSTANTS.attributes.VARIANT, this._variant);
+    }
 
     if (this._popoverIcon) {
       this._adapter.addPopoverIconListener('click', this._popoverIconClickListener);
@@ -112,6 +118,8 @@ export class FieldCore implements IFieldCore {
       }
 
       this._adapter.setLabelPosition(this._labelPosition);
+      // Moved this out of the adapter method
+      this._adapter.setHostAttribute(FIELD_CONSTANTS.attributes.LABEL_POSITION, this._labelPosition);
     }
   }
 

--- a/packages/forge/src/lib/field/field-core.ts
+++ b/packages/forge/src/lib/field/field-core.ts
@@ -1,3 +1,4 @@
+import { globalConfig } from '../core/index.js';
 import { FocusIndicatorFocusMode } from '../focus-indicator/index.js';
 import {
   FieldDensity,
@@ -36,14 +37,16 @@ export interface IFieldCore {
 }
 
 export class FieldCore implements IFieldCore {
-  private _labelPosition: FieldLabelPosition = FIELD_CONSTANTS.defaults.DEFAULT_LABEL_POSITION;
+  @globalConfig(FIELD_CONSTANTS.defaults.DEFAULT_LABEL_POSITION)
+  private _labelPosition!: FieldLabelPosition;
   private _labelAlignment: FieldLabelAlignment = FIELD_CONSTANTS.defaults.DEFAULT_LABEL_ALIGNMENT;
   private _floatLabel = false;
   private _invalid = false;
   private _required = false;
   private _optional = false;
   private _disabled = false;
-  private _variant: FieldVariant = FIELD_CONSTANTS.defaults.DEFAULT_VARIANT;
+  @globalConfig(FIELD_CONSTANTS.defaults.DEFAULT_VARIANT)
+  private _variant!: FieldVariant;
   private _theme: FieldTheme = FIELD_CONSTANTS.defaults.DEFAULT_THEME;
   private _shape: FieldShape = FIELD_CONSTANTS.defaults.DEFAULT_SHAPE;
   private _density: FieldDensity = FIELD_CONSTANTS.defaults.DEFAULT_DENSITY;
@@ -62,8 +65,10 @@ export class FieldCore implements IFieldCore {
   public initialize(): void {
     this._adapter.addRootListener('slotchange', this._slotChangeListener);
     this._adapter.initializeSlots();
-    this._adapter.tryApplyGlobalConfiguration(['labelPosition', 'variant']);
+
+    // Setting the label position and variant here for global config decorator compatibility
     this._adapter.setLabelPosition(this._labelPosition);
+    this._adapter.setHostAttribute(FIELD_CONSTANTS.attributes.VARIANT, this._variant);
 
     if (this._popoverIcon) {
       this._adapter.addPopoverIconListener('click', this._popoverIconClickListener);

--- a/packages/forge/src/lib/field/field-core.ts
+++ b/packages/forge/src/lib/field/field-core.ts
@@ -37,16 +37,17 @@ export interface IFieldCore {
 }
 
 export class FieldCore implements IFieldCore {
-  @globalConfig(FIELD_CONSTANTS.defaults.DEFAULT_LABEL_POSITION)
-  private _labelPosition!: FieldLabelPosition;
+  @globalConfig()
+  private _labelPosition: FieldLabelPosition = FIELD_CONSTANTS.defaults.DEFAULT_LABEL_POSITION;
+  @globalConfig()
+  private _variant: FieldVariant = FIELD_CONSTANTS.defaults.DEFAULT_VARIANT;
+
   private _labelAlignment: FieldLabelAlignment = FIELD_CONSTANTS.defaults.DEFAULT_LABEL_ALIGNMENT;
   private _floatLabel = false;
   private _invalid = false;
   private _required = false;
   private _optional = false;
   private _disabled = false;
-  @globalConfig(FIELD_CONSTANTS.defaults.DEFAULT_VARIANT)
-  private _variant!: FieldVariant;
   private _theme: FieldTheme = FIELD_CONSTANTS.defaults.DEFAULT_THEME;
   private _shape: FieldShape = FIELD_CONSTANTS.defaults.DEFAULT_SHAPE;
   private _density: FieldDensity = FIELD_CONSTANTS.defaults.DEFAULT_DENSITY;
@@ -69,10 +70,10 @@ export class FieldCore implements IFieldCore {
     // Setting the label position and variant here for global config decorator compatibility
     // Skipping if there are already host attributes set to avoid overwriting values that may have been set externally
     this._adapter.setLabelPosition(this._labelPosition);
-    if (!this._adapter.getHostAttribute(FIELD_CONSTANTS.attributes.VARIANT)) {
+    if (this._labelPosition !== FIELD_CONSTANTS.defaults.DEFAULT_LABEL_POSITION && !this._adapter.getHostAttribute(FIELD_CONSTANTS.attributes.LABEL_POSITION)) {
       this._adapter.setHostAttribute(FIELD_CONSTANTS.attributes.LABEL_POSITION, this._labelPosition);
     }
-    if (!this._adapter.getHostAttribute(FIELD_CONSTANTS.attributes.VARIANT)) {
+    if (this._variant !== FIELD_CONSTANTS.defaults.DEFAULT_VARIANT && !this._adapter.getHostAttribute(FIELD_CONSTANTS.attributes.VARIANT)) {
       this._adapter.setHostAttribute(FIELD_CONSTANTS.attributes.VARIANT, this._variant);
     }
 


### PR DESCRIPTION
## Summary
Created a global config decorator to replace the adapter-based approach currently used. The decorator is compatible with the new Lit architecture, keeps value definitions in one place, and solves issues with global configuration values overriding externally set values when a component initializes.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
