### PR TITLE
fix(autocomplete): always send value when executing filter callback during initialization

### DIFF
--- a/.changeset/plenty-ends-yell.md
+++ b/.changeset/plenty-ends-yell.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(autocomplete): always send value when executing filter callback during initialization

--- a/packages/forge/src/lib/autocomplete/autocomplete-core.ts
+++ b/packages/forge/src/lib/autocomplete/autocomplete-core.ts
@@ -118,7 +118,7 @@ export class AutocompleteCore extends ListDropdownAwareCore implements IAutocomp
     if (this._values.length) {
       if (!this._selectedOptions.length) {
         try {
-          await this._executeFilter();
+          await this._executeFilter(false, true);
         } catch (e) {
           console.error(e);
         }
@@ -1103,7 +1103,7 @@ export class AutocompleteCore extends ListDropdownAwareCore implements IAutocomp
     this._selectedTextBuilder = fn;
 
     // If there are selected options, set the selected text again
-    if (this._selectedOptions.length) {
+    if (this._selectedOptions.length && this._isInitialized) {
       this._adapter.setSelectedText(this._getSelectedText());
     }
   }

--- a/packages/forge/src/lib/autocomplete/autocomplete.test.ts
+++ b/packages/forge/src/lib/autocomplete/autocomplete.test.ts
@@ -1173,6 +1173,25 @@ describe('AutocompleteComponent', () => {
       expect(filterSpy).toHaveBeenCalledWith('', null);
     });
 
+    it('should pass value to filter callback during initialization when value set before connecting', async () => {
+      const filterSpy = vi.fn(() => DEFAULT_FILTER_OPTIONS);
+
+      const component = document.createElement('forge-autocomplete') as AutocompleteComponentInternal;
+      const input = document.createElement('input');
+      input.type = 'text';
+      component.appendChild(input);
+
+      component.filter = filterSpy;
+      component.value = DEFAULT_FILTER_OPTIONS[1].value;
+
+      render(html`<div>${component}</div>`);
+      await frame();
+
+      expect(filterSpy).toHaveBeenCalledWith('', DEFAULT_FILTER_OPTIONS[1].value);
+      expect(input.value).toBe(DEFAULT_FILTER_OPTIONS[1].label);
+      expect(component.value).toBe(DEFAULT_FILTER_OPTIONS[1].value);
+    });
+
     it('should close dropdown if filter completes without the input having focus anymore', async () => {
       const harness = await createFixture({
         filter: () =>


### PR DESCRIPTION
## Summary
When the component initializes we check if the filter callback should execute, but it was not sending the current value as an argument if no selected options exist like it does when the `value` property is set for the first time via `_applyValue()`.

We now always execute the filter callback without filter text (there will be no filter text during init), and we always try to send the current value.

This covers the scenario where a value is set on the `<forge-autocomplete>` _before_ initialization (connecting to the DOM), and allows consumers to receive that value in their filter callbacks.

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
