### PR TITLE
fix(globalconfig): add duck-type fallback for instanceof check

### DIFF
--- a/.changeset/bumpy-cobras-turn.md
+++ b/.changeset/bumpy-cobras-turn.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(globalconfig): add duck-type fallback for instanceof check

--- a/.changeset/fresh-olives-agree.md
+++ b/.changeset/fresh-olives-agree.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge-core': patch
+---
+
+feat(utils): add `isHTMLElement` helper

--- a/packages/forge-core/src/utils/utils.ts
+++ b/packages/forge-core/src/utils/utils.ts
@@ -100,6 +100,31 @@ export function isObject(obj: any): boolean {
 }
 
 /**
+ * Safely checks if an object is an HTMLElement instance.
+ * Works in both browser environments and environments where HTMLElement might not be
+ * a proper constructor (e.g. Node-based testing environments).
+ * @param {any} obj - The object to check.
+ * @returns {boolean}
+ */
+export function isHTMLElement(obj: any): obj is HTMLElement {
+  if (typeof HTMLElement === 'function') {
+    try {
+      return obj instanceof HTMLElement;
+    } catch {
+      // instanceof can throw if rights-hand side is not available in the environment, fall through to duck-typing
+    }
+  }
+
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    typeof obj.nodeType === 'number' &&
+    typeof obj.nodeName === 'string' &&
+    (typeof obj.localName === 'string' || typeof obj.tagName === 'string')
+  );
+}
+
+/**
  * Coerces a string to a boolean.
  * @param {string} value The value to convert.
  * @returns {boolean}

--- a/packages/forge/src/lib/core/decorators/global-configuration-decorator.ts
+++ b/packages/forge/src/lib/core/decorators/global-configuration-decorator.ts
@@ -1,6 +1,6 @@
 import { GlobalConfiguration } from '../configuration/global-configuration.js';
 import { IBaseAdapter } from '../base/base-adapter.js';
-import { isHTMLElement } from '../utils/feature-detection.js';
+import { isHTMLElement } from '@tylertech/forge-core';
 
 interface CoreWithAdapter {
   _adapter?: IBaseAdapter;

--- a/packages/forge/src/lib/core/decorators/global-configuration-decorator.ts
+++ b/packages/forge/src/lib/core/decorators/global-configuration-decorator.ts
@@ -1,5 +1,6 @@
 import { GlobalConfiguration } from '../configuration/global-configuration.js';
 import { IBaseAdapter } from '../base/base-adapter.js';
+import { isHTMLElement } from '../utils/feature-detection.js';
 
 interface CoreWithAdapter {
   _adapter?: IBaseAdapter;
@@ -47,7 +48,7 @@ export function globalConfig(): PropertyDecorator {
           // Get tag name based on whether this is an HTMLElement or a Core class
           let tagName: string | undefined;
 
-          if (this instanceof HTMLElement) {
+          if (isHTMLElement(this)) {
             // Direct HTMLElement access (Lit components)
             tagName = this.localName || this.tagName?.toLowerCase();
           } else if ('_adapter' in this && this._adapter?.hostElement) {

--- a/packages/forge/src/lib/core/utils/feature-detection.ts
+++ b/packages/forge/src/lib/core/utils/feature-detection.ts
@@ -37,30 +37,3 @@ export function supportsHover(): boolean {
 export function prefersReducedMotion(): boolean {
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
-
-/**
- * Safely checks if an object is an HTMLElement instance.
- * Works in both browser environments and environments where HTMLElement might not be
- * a proper constructor (e.g. Node-based testing environments).
- * @param {any} obj - The object to check.
- * @returns {boolean}
- */
-export function isHTMLElement(obj: any): obj is HTMLElement {
-  // First check if HTMLElement is a function (constructor) before using instanceof
-  if (typeof HTMLElement === 'function') {
-    try {
-      return obj instanceof HTMLElement;
-    } catch {
-      // instanceof can throw if rights-hand side is not available in the environment, fall through to duck-typing
-    }
-  }
-
-  // Duck-typing fallback: check for properties commonly found on HTMLElements
-  return (
-    typeof obj === 'object' &&
-    obj !== null &&
-    typeof obj.nodeType === 'number' &&
-    typeof obj.nodeName === 'string' &&
-    (typeof obj.localName === 'string' || typeof obj.tagName === 'string')
-  );
-}

--- a/packages/forge/src/lib/core/utils/feature-detection.ts
+++ b/packages/forge/src/lib/core/utils/feature-detection.ts
@@ -37,3 +37,30 @@ export function supportsHover(): boolean {
 export function prefersReducedMotion(): boolean {
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
+
+/**
+ * Safely checks if an object is an HTMLElement instance.
+ * Works in both browser environments and environments where HTMLElement might not be
+ * a proper constructor (e.g. Node-based testing environments).
+ * @param {any} obj - The object to check.
+ * @returns {boolean}
+ */
+export function isHTMLElement(obj: any): obj is HTMLElement {
+  // First check if HTMLElement is a function (constructor) before using instanceof
+  if (typeof HTMLElement === 'function') {
+    try {
+      return obj instanceof HTMLElement;
+    } catch {
+      // instanceof can throw if rights-hand side is not available in the environment, fall through to duck-typing
+    }
+  }
+
+  // Duck-typing fallback: check for properties commonly found on HTMLElements
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    typeof obj.nodeType === 'number' &&
+    typeof obj.nodeName === 'string' &&
+    (typeof obj.localName === 'string' || typeof obj.tagName === 'string')
+  );
+}


### PR DESCRIPTION
## Summary
Adds a fallback for the `instanceof HTMLElement` conditional by calling a new helper function that gracefully falls back to a duck-type check in case `HTMLElement` is not available in the environment. This can happen in bundlers where the use node for module loading, which causes decorators to be evaluated when the module is evaluated.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
