### PR TITLE
fix(select): keyboard navigation from selected option after mouse click open

### DIFF
--- a/.changeset/strong-beans-bow.md
+++ b/.changeset/strong-beans-bow.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(select): keyboard navigation from selected option after mouse click open

--- a/packages/forge/src/lib/list-dropdown/list-dropdown-core.ts
+++ b/packages/forge/src/lib/list-dropdown/list-dropdown-core.ts
@@ -148,6 +148,7 @@ export class ListDropdownCore implements IListDropdownCore {
       this.activateOption(this._config.activeStartIndex, false);
       this._adapter.scrollSelectedOptionIntoView(false);
     } else if (this._config.selectedValues && this._config.selectedValues.length) {
+      this.activateSelectedOption();
       this._adapter.scrollSelectedOptionIntoView(false);
     } else if (typeof this._config.visibleStartIndex === 'number' && this._nonDividerOptions[this._config.visibleStartIndex]) {
       this._adapter.scrollOptionIntoView(this._config.visibleStartIndex);

--- a/packages/forge/src/lib/list-dropdown/list-dropdown.test.ts
+++ b/packages/forge/src/lib/list-dropdown/list-dropdown.test.ts
@@ -569,11 +569,12 @@ describe('ListDropdown', () => {
     await delayPopupAnimation();
 
     const listItems = getListItems();
-    expect(listItems[2].active).toBe(false);
+    expect(listItems[2].active).toBe(true);
 
     context.listDropdown.activateFirstOption();
 
     expect(listItems[0].active).toBe(true);
+    expect(listItems[2].active).toBe(false);
 
     context.listDropdown.destroy();
     if (context.targetElement.isConnected) {

--- a/packages/forge/src/lib/select/select/select.test.ts
+++ b/packages/forge/src/lib/select/select/select.test.ts
@@ -333,6 +333,42 @@ describe('Select', () => {
       const listItems = harness.getListItems();
       expect(harness.element.getAttribute('aria-activedescendant')).toBe(listItems[1].querySelector('button')?.id);
     });
+
+    it('should navigate from selected option when opened via mouse click then arrow down pressed', async () => {
+      const harness = await createFixture();
+      harness.element.value = 'two';
+      await frame();
+
+      await harness.clickElement(harness.element);
+      await harness.popoverToggleAnimation;
+
+      expect(harness.element.open).toBe(true);
+
+      harness.element.focus();
+      await harness.pressKey('ArrowDown');
+      await frame();
+
+      const listItems = harness.getListItems();
+      expect(harness.element.getAttribute('aria-activedescendant')).toBe(listItems[2].querySelector('button')?.id);
+    });
+
+    it('should navigate from selected option when opened via mouse click then arrow up pressed', async () => {
+      const harness = await createFixture();
+      harness.element.value = 'two';
+      await frame();
+
+      await harness.clickElement(harness.element);
+      await harness.popoverToggleAnimation;
+
+      expect(harness.element.open).toBe(true);
+
+      harness.element.focus();
+      await harness.pressKey('ArrowUp');
+      await frame();
+
+      const listItems = harness.getListItems();
+      expect(harness.element.getAttribute('aria-activedescendant')).toBe(listItems[0].querySelector('button')?.id);
+    });
   });
 
   describe('selection state', () => {


### PR DESCRIPTION
## Summary
When dropdown opened via mouse click with selected value, arrow keys incorrectly navigated to first/last option instead of from selected option. Fixed by activating selected option in `activateInitialOption()` when `selectedValues` exist.

- Modified `list-dropdown-core.ts` to call `activateSelectedOption()` on open
- Added tests for mouse click + arrow key navigation
- Updated existing test expectations for new behavior

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
