### PR TITLE
feat(button): implement invoker commands api

### DIFF
--- a/.changeset/breezy-showers-act.md
+++ b/.changeset/breezy-showers-act.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': minor
+---
+
+feat(icon-button): implement invoker commands api

--- a/.changeset/jolly-breads-add.md
+++ b/.changeset/jolly-breads-add.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': minor
+---
+
+feat(button): implement invoker commands api

--- a/.changeset/red-pillows-like.md
+++ b/.changeset/red-pillows-like.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': minor
+---
+
+feat(floating-action-button): implement invoker commands api

--- a/packages/forge/src/lib/button/base/base-button-constants.ts
+++ b/packages/forge/src/lib/button/base/base-button-constants.ts
@@ -35,3 +35,4 @@ export type ButtonTarget = '_blank' | '_self' | '_parent' | '_top';
 export interface ButtonClickOptions {
   animateStateLayer?: boolean;
 }
+export type CommandType = 'show-modal' | 'close' | 'request-close' | 'show-popover' | 'hide-popover' | 'toggle-popover' | `--${string}` | '';

--- a/packages/forge/src/lib/button/base/base-button.test.ts
+++ b/packages/forge/src/lib/button/base/base-button.test.ts
@@ -1101,6 +1101,285 @@ describe('BaseButton', () => {
     expect(clickSpy).toHaveBeenCalledOnce();
   });
 
+  describe('invoker commands', () => {
+    it('should set command property', async () => {
+      const screen = render(html`<forge-test-base-button command="show-modal">Button</forge-test-base-button>`);
+      const el = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+      await el.updateComplete;
+
+      expect(el.command).toBe('show-modal');
+      expect(el.getAttribute('command')).toBe('show-modal');
+    });
+
+    it('should set command property dynamically', async () => {
+      const screen = render(html`<forge-test-base-button>Button</forge-test-base-button>`);
+      const el = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+
+      el.command = 'close';
+      await el.updateComplete;
+
+      expect(el.command).toBe('close');
+      expect(el.getAttribute('command')).toBe('close');
+    });
+
+    it('should set commandFor property', async () => {
+      const screen = render(html`<forge-test-base-button command-for="target-element">Button</forge-test-base-button>`);
+      const el = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+      await el.updateComplete;
+
+      expect(el.commandFor).toBe('target-element');
+      expect(el.getAttribute('command-for')).toBe('target-element');
+    });
+
+    it('should set commandFor property dynamically', async () => {
+      const screen = render(html`<forge-test-base-button>Button</forge-test-base-button>`);
+      const el = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+
+      el.commandFor = 'target-element';
+      await el.updateComplete;
+
+      expect(el.commandFor).toBe('target-element');
+      expect(el.getAttribute('command-for')).toBe('target-element');
+    });
+
+    it('should resolve commandForElement by ID', async () => {
+      const screen = render(html`
+        <div>
+          <forge-test-base-button command="show-modal" command-for="target">Button</forge-test-base-button>
+          <div id="target">Target</div>
+        </div>
+      `);
+      const button = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+      const target = screen.container.querySelector('#target') as HTMLElement;
+      await button.updateComplete;
+
+      expect(button.commandForElement).toBe(target);
+    });
+
+    it('should set commandForElement directly', async () => {
+      const screen = render(html`
+        <div>
+          <forge-test-base-button command="show-modal">Button</forge-test-base-button>
+          <div id="target">Target</div>
+        </div>
+      `);
+      const button = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+      const target = screen.container.querySelector('#target') as HTMLElement;
+
+      button.commandForElement = target;
+      await button.updateComplete;
+
+      expect(button.commandForElement).toBe(target);
+    });
+
+    it('should dispatch command event when clicked', async () => {
+      const screen = render(html`
+        <div>
+          <forge-test-base-button command="show-modal" command-for="target">Button</forge-test-base-button>
+          <div id="target">Target</div>
+        </div>
+      `);
+      const button = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+      const target = screen.container.querySelector('#target') as HTMLElement;
+      const commandSpy = vi.fn();
+      target.addEventListener('command', commandSpy);
+
+      await userEvent.click(button);
+      await frame();
+
+      expect(commandSpy).toHaveBeenCalledOnce();
+      const event = commandSpy.mock.calls[0][0];
+      expect(event.type).toBe('command');
+      expect(event.cancelable).toBe(true);
+    });
+
+    it('should dispatch command event with correct command value', async () => {
+      const screen = render(html`
+        <div>
+          <forge-test-base-button command="close" command-for="target">Button</forge-test-base-button>
+          <div id="target">Target</div>
+        </div>
+      `);
+      const button = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+      const target = screen.container.querySelector('#target') as HTMLElement;
+      const commandSpy = vi.fn();
+      target.addEventListener('command', commandSpy);
+
+      await userEvent.click(button);
+      await frame();
+
+      expect(commandSpy).toHaveBeenCalledOnce();
+      const event = commandSpy.mock.calls[0][0];
+      if ('command' in event) {
+        expect(event.command).toBe('close');
+      } else {
+        expect(event.detail.command).toBe('close');
+      }
+    });
+
+    it('should dispatch command event with correct source', async () => {
+      const screen = render(html`
+        <div>
+          <forge-test-base-button command="show-modal" command-for="target">Button</forge-test-base-button>
+          <div id="target">Target</div>
+        </div>
+      `);
+      const button = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+      const target = screen.container.querySelector('#target') as HTMLElement;
+      const commandSpy = vi.fn();
+      target.addEventListener('command', commandSpy);
+
+      await userEvent.click(button);
+      await frame();
+
+      expect(commandSpy).toHaveBeenCalledOnce();
+      const event = commandSpy.mock.calls[0][0];
+      if ('source' in event) {
+        expect(event.source).toBe(button);
+      } else {
+        expect(event.detail.source).toBe(button);
+      }
+    });
+
+    it('should not dispatch command event when command is empty', async () => {
+      const screen = render(html`
+        <div>
+          <forge-test-base-button command-for="target">Button</forge-test-base-button>
+          <div id="target">Target</div>
+        </div>
+      `);
+      const button = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+      const target = screen.container.querySelector('#target') as HTMLElement;
+      const commandSpy = vi.fn();
+      target.addEventListener('command', commandSpy);
+
+      await userEvent.click(button);
+      await frame();
+
+      expect(commandSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not dispatch command event when target element not found', async () => {
+      const screen = render(html`<forge-test-base-button command="show-modal" command-for="nonexistent">Button</forge-test-base-button>`);
+      const button = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+      const commandSpy = vi.fn();
+      document.addEventListener('command', commandSpy);
+
+      await userEvent.click(button);
+      await frame();
+
+      expect(commandSpy).not.toHaveBeenCalled();
+      document.removeEventListener('command', commandSpy);
+    });
+
+    it('should dispatch command event when enter key is pressed', async () => {
+      const screen = render(html`
+        <div>
+          <forge-test-base-button command="show-modal" command-for="target">Button</forge-test-base-button>
+          <div id="target">Target</div>
+        </div>
+      `);
+      const button = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+      const target = screen.container.querySelector('#target') as HTMLElement;
+      const commandSpy = vi.fn();
+      target.addEventListener('command', commandSpy);
+
+      button.focus();
+      await userEvent.keyboard('{Enter}');
+      await frame();
+
+      expect(commandSpy).toHaveBeenCalledOnce();
+    });
+
+    it('should dispatch command event when space key is pressed', async () => {
+      const screen = render(html`
+        <div>
+          <forge-test-base-button command="show-modal" command-for="target">Button</forge-test-base-button>
+          <div id="target">Target</div>
+        </div>
+      `);
+      const button = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+      const target = screen.container.querySelector('#target') as HTMLElement;
+      const commandSpy = vi.fn();
+      target.addEventListener('command', commandSpy);
+
+      button.focus();
+      await userEvent.keyboard(' ');
+      await frame();
+
+      expect(commandSpy).toHaveBeenCalledOnce();
+    });
+
+    it('should support custom command values', async () => {
+      const screen = render(html`
+        <div>
+          <forge-test-base-button command="--my-custom-command" command-for="target">Button</forge-test-base-button>
+          <div id="target">Target</div>
+        </div>
+      `);
+      const button = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+      const target = screen.container.querySelector('#target') as HTMLElement;
+      const commandSpy = vi.fn();
+      target.addEventListener('command', commandSpy);
+
+      await userEvent.click(button);
+      await frame();
+
+      expect(commandSpy).toHaveBeenCalledOnce();
+      const event = commandSpy.mock.calls[0][0];
+      if ('command' in event) {
+        expect(event.command).toBe('--my-custom-command');
+      } else {
+        expect(event.detail.command).toBe('--my-custom-command');
+      }
+    });
+
+    it('should not dispatch command event when disabled', async () => {
+      const screen = render(html`
+        <div>
+          <forge-test-base-button disabled command="show-modal" command-for="target">Button</forge-test-base-button>
+          <div id="target">Target</div>
+        </div>
+      `);
+      const button = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+      const target = screen.container.querySelector('#target') as HTMLElement;
+      const commandSpy = vi.fn();
+      target.addEventListener('command', commandSpy);
+
+      await userEvent.click(button, { force: true });
+      await frame();
+
+      expect(commandSpy).not.toHaveBeenCalled();
+    });
+
+    it('should prefer commandForElement over commandFor attribute', async () => {
+      const screen = render(html`
+        <div>
+          <forge-test-base-button command="show-modal" command-for="target-1">Button</forge-test-base-button>
+          <div id="target-1">Target 1</div>
+          <div id="target-2">Target 2</div>
+        </div>
+      `);
+      const button = screen.container.querySelector('forge-test-base-button') as ButtonComponent;
+      const target1 = screen.container.querySelector('#target-1') as HTMLElement;
+      const target2 = screen.container.querySelector('#target-2') as HTMLElement;
+
+      const commandSpy1 = vi.fn();
+      const commandSpy2 = vi.fn();
+      target1.addEventListener('command', commandSpy1);
+      target2.addEventListener('command', commandSpy2);
+
+      button.commandForElement = target2;
+      await button.updateComplete;
+
+      await userEvent.click(button);
+      await frame();
+
+      expect(commandSpy1).not.toHaveBeenCalled();
+      expect(commandSpy2).toHaveBeenCalledOnce();
+    });
+  });
+
   function getRootEl(btn: ButtonComponent): HTMLElement {
     return btn.shadowRoot?.querySelector('#root') as HTMLElement;
   }

--- a/packages/forge/src/lib/button/base/base-button.ts
+++ b/packages/forge/src/lib/button/base/base-button.ts
@@ -45,11 +45,12 @@ export abstract class BaseButton extends BaseLitElement {
   /** @deprecated Used for compatibility with legacy Forge @customElement decorator. */
   public static [CUSTOM_ELEMENT_NAME_PROPERTY]: string;
 
+  public static readonly formAssociated = true;
+
   // Label awareness (for compatibility)
   public [forgeLabelRef]?: { [updateTarget](target: HTMLElement): boolean };
 
-  public static readonly formAssociated = true;
-
+  // Public properties - Button behavior
   /**
    * Gets/sets the type of button.
    * @default "button"
@@ -81,6 +82,15 @@ export abstract class BaseButton extends BaseLitElement {
   #disabled = false;
 
   /**
+   * Gets/sets whether the button is dense.
+   * @default false
+   * @attribute
+   */
+  @property({ type: Boolean, reflect: true })
+  public dense = false;
+
+  // Public properties - Popover
+  /**
    * Gets/sets whether to show a popover icon.
    * @default false
    * @attribute popover-icon
@@ -88,6 +98,13 @@ export abstract class BaseButton extends BaseLitElement {
   @property({ type: Boolean, reflect: true, attribute: 'popover-icon' })
   public popoverIcon = false;
 
+  /** @ignore */
+  public popoverTargetElement: HTMLElement | null = null;
+
+  /** @ignore */
+  public popoverTargetAction: 'click' | 'hover' = 'click';
+
+  // Public properties - Form association
   /**
    * Gets/sets the button name for form association.
    * @default ''
@@ -104,14 +121,7 @@ export abstract class BaseButton extends BaseLitElement {
   @property({ reflect: true })
   public value = '';
 
-  /**
-   * Gets/sets whether the button is dense.
-   * @default false
-   * @attribute
-   */
-  @property({ type: Boolean, reflect: true })
-  public dense = false;
-
+  // Public properties - Invoker commands
   /**
    * Indicates to the targeted element which action to take.
    * @default ''
@@ -141,18 +151,13 @@ export abstract class BaseButton extends BaseLitElement {
   }
   #commandForElement: typeof this.commandForElement;
 
-  // PopoverInvokerElement
-  /** @ignore */
-  public popoverTargetElement: HTMLElement | null = null;
-  /** @ignore */
-  public popoverTargetAction: 'click' | 'hover' = 'click';
-
   // Internal state
   protected _internals: ElementInternals;
 
   @state()
   protected _stateLayerDisabled = false;
 
+  // Event listeners
   #clickListener = this._onClick.bind(this);
   #keydownListener = this.#onKeydown.bind(this);
   #slotChangeListener = (): void => this.#detectSlottedAnchor();
@@ -174,6 +179,7 @@ export abstract class BaseButton extends BaseLitElement {
     this._internals = this.attachInternals();
   }
 
+  // Lifecycle methods
   public override connectedCallback(): void {
     super.connectedCallback();
 
@@ -207,6 +213,7 @@ export abstract class BaseButton extends BaseLitElement {
     }
   }
 
+  // Render methods
   protected _renderDefaultSlot(): TemplateResult {
     return html` <slot @slotchange=${this.#slotChangeListener}></slot>`;
   }
@@ -228,11 +235,12 @@ export abstract class BaseButton extends BaseLitElement {
     `;
   }
 
-  // Public API
+  // Public API - Form association
   public get form(): HTMLFormElement | null {
     return this._internals.form;
   }
 
+  // Public API - User interaction
   public override click(): void {
     if (this.disabled) {
       return;
@@ -249,7 +257,7 @@ export abstract class BaseButton extends BaseLitElement {
     }
   }
 
-  // Label awareness callbacks
+  // Public API - Label awareness callbacks
   public labelClickedCallback(): void {
     this.click();
   }
@@ -258,12 +266,12 @@ export abstract class BaseButton extends BaseLitElement {
     setDefaultAria(this, this._internals, { ariaLabel: value }, { setAttribute: !this.hasAttribute('aria-label') });
   }
 
-  // Symbol accessors for compatibility
+  // Public API - Symbol accessors for compatibility
   public get [internals](): ElementInternals {
     return this._internals;
   }
 
-  // Private implementation methods
+  // Event handlers
   protected async _onClick(evt: PointerEvent): Promise<void> {
     const isFormType = this.type === 'submit' || this.type === 'reset';
 
@@ -305,6 +313,7 @@ export abstract class BaseButton extends BaseLitElement {
     }
   }
 
+  // Private methods - Accessibility and anchor detection
   #detectSlottedAnchor(): void {
     if (this._anchorElements.length) {
       this.disabled = false;
@@ -352,6 +361,14 @@ export abstract class BaseButton extends BaseLitElement {
     }
   }
 
+  #animateStateLayer(): void {
+    if (this._stateLayerElement?.disabled || !this._stateLayerElement?.isConnected) {
+      return;
+    }
+    this._stateLayerElement?.playAnimation();
+  }
+
+  // Private methods - Form association
   #clickFormButton(type: string): void {
     if (!this._internals.form) {
       return;
@@ -384,6 +401,7 @@ export abstract class BaseButton extends BaseLitElement {
     }
   }
 
+  // Private methods - Popover management
   #hasPopoverTarget(): boolean {
     return this.hasAttribute('popovertarget') || !!this.popoverTargetElement;
   }
@@ -456,13 +474,7 @@ export abstract class BaseButton extends BaseLitElement {
     return popoverElement as HTMLElement | null;
   }
 
-  #animateStateLayer(): void {
-    if (this._stateLayerElement?.disabled || !this._stateLayerElement?.isConnected) {
-      return;
-    }
-    this._stateLayerElement?.playAnimation();
-  }
-
+  // Private methods - Invoker commands
   #invokeCommand(): void {
     if (!this.command) {
       return;

--- a/packages/forge/src/lib/button/base/base-button.ts
+++ b/packages/forge/src/lib/button/base/base-button.ts
@@ -5,13 +5,13 @@ import { property, query, queryAssignedElements, state } from 'lit/decorators.js
 import { DEFERRED_LABEL_TARGET, ExperimentalFocusOptions, forgeLabelRef, internals, updateTarget } from '../../constants.js';
 import { BaseLitElement } from '../../core/base/base-lit-element.js';
 import { setDefaultAria } from '../../core/utils/a11y-utils.js';
-import { supportsPopover } from '../../core/utils/feature-detection.js';
+import { supportsInvokerCommands, supportsPopover, CommandEvent as FallbackCommandEvent } from '../../core/utils/feature-detection.js';
 import { BUTTON_FORM_ATTRIBUTES, cloneAttributes } from '../../core/utils/reflect-utils.js';
 import { toggleState } from '../../core/utils/utils.js';
 import { FOCUS_INDICATOR_TAG_NAME, IFocusIndicatorComponent } from '../../focus-indicator/index.js';
 import { IconRegistry } from '../../icon/icon-registry.js';
 import { IStateLayerComponent, STATE_LAYER_CONSTANTS } from '../../state-layer/index.js';
-import { BASE_BUTTON_CONSTANTS, ButtonType } from './base-button-constants.js';
+import { BASE_BUTTON_CONSTANTS, ButtonType, CommandType } from './base-button-constants.js';
 
 /** @deprecated - This will be removed in the future. Please switch to using BaseButton. */
 export interface IBaseButton {
@@ -111,6 +111,35 @@ export abstract class BaseButton extends BaseLitElement {
    */
   @property({ type: Boolean, reflect: true })
   public dense = false;
+
+  /**
+   * Indicates to the targeted element which action to take.
+   * @default ''
+   * @attribute
+   */
+  @property()
+  public command: CommandType = '';
+
+  /**
+   * Targets another element to be invoked.
+   * @default ''
+   * @attribute command-for
+   */
+  @property()
+  public commandFor = '';
+
+  /**
+   * Targets another element to be invoked.
+   * @default undefined
+   */
+  @property({ attribute: false })
+  public set commandForElement(value: HTMLElement | undefined) {
+    this.#commandForElement = value;
+  }
+  public get commandForElement(): HTMLElement | undefined {
+    return this.#commandForElement ?? this.ownerDocument.getElementById(this.commandFor) ?? undefined;
+  }
+  #commandForElement: typeof this.commandForElement;
 
   // PopoverInvokerElement
   /** @ignore */
@@ -252,8 +281,10 @@ export abstract class BaseButton extends BaseLitElement {
     }
 
     if (isFormType) {
-      this.#clickFormButton(this.type);
+      return this.#clickFormButton(this.type);
     }
+
+    this.#invokeCommand();
   }
 
   async #onKeydown(evt: KeyboardEvent): Promise<void> {
@@ -430,5 +461,22 @@ export abstract class BaseButton extends BaseLitElement {
       return;
     }
     this._stateLayerElement?.playAnimation();
+  }
+
+  #invokeCommand(): void {
+    if (!this.command) {
+      return;
+    }
+
+    const targetElement = this.commandForElement;
+    if (!targetElement) {
+      return;
+    }
+
+    if (supportsInvokerCommands()) {
+      targetElement.dispatchEvent(new CommandEvent('command', { source: this, command: this.command, cancelable: true }));
+    } else {
+      targetElement.dispatchEvent(new FallbackCommandEvent('command', { source: this, command: this.command, cancelable: true }));
+    }
   }
 }

--- a/packages/forge/src/lib/core/utils/feature-detection.ts
+++ b/packages/forge/src/lib/core/utils/feature-detection.ts
@@ -75,3 +75,25 @@ export function supportsScrollIntoViewContainerOption(): boolean {
   cachedScrollIntoViewContainerSupport = containerAccessed;
   return containerAccessed;
 }
+
+/**
+ * Detects whether the browser supports the Invoker Commands API.
+ * @returns {boolean}
+ */
+export function supportsInvokerCommands(): boolean {
+  return typeof CommandEvent !== 'undefined';
+}
+
+/**
+ * Custom CommandEvent class to be used if the browser does not support the Invoker Commands API.
+ */
+export class CommandEvent extends Event {
+  public command: string;
+  public source: HTMLElement;
+
+  constructor(type: string, eventInitDict: EventInit & { command: string; source: HTMLElement }) {
+    super(type, eventInitDict);
+    this.command = eventInitDict?.command;
+    this.source = eventInitDict?.source;
+  }
+}


### PR DESCRIPTION
## Summary
Implemented the Invoker Commands API in components extending the base button. This adds `command` and `commandfor` properties/attributes and a `commandForElement` property to the components. When the component is clicked a "command" event dispatches from the element targeted by `commandfor`/`commandForElement`. In contexts that don't yet support `CommandEvent` a custom `CommandEvent` extended from `Event` is used instead.

## Checklist
- [x] Tests added/updated
- [x] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
