### PR TITLE
fix(time-picker): display midnight (00:00) value when set before connected to the DOM

### DIFF
--- a/.changeset/time-picker-midnight-value.md
+++ b/.changeset/time-picker-midnight-value.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(time-picker): display midnight (00:00) value when set before connected to the DOM

--- a/packages/forge/src/lib/time-picker/time-picker-core.ts
+++ b/packages/forge/src/lib/time-picker/time-picker-core.ts
@@ -113,7 +113,7 @@ export class TimePickerCore implements ITimePickerCore {
     this._adapter.initializeAccessibility(this._identifier);
 
     // Detect if a value already exists in the input and set our values based on that
-    if (!this._value) {
+    if (this._value == null) {
       const inputValue = this._adapter.getInputValue();
       this._setValue(this._convertTimeStringToMillis(inputValue, this._use24HourTime, this._allowSeconds));
     }

--- a/packages/forge/src/lib/time-picker/time-picker.test.ts
+++ b/packages/forge/src/lib/time-picker/time-picker.test.ts
@@ -201,6 +201,16 @@ describe('TimePickerComponent', () => {
 
       expect((harness.element as any)._core._isInitialized).toBe(true);
     });
+
+    it('should display midnight value when set before the element is connected to the DOM', async () => {
+      harness = await createFixture({ detached: true });
+      harness.element.value = '00:00';
+      document.body.appendChild(harness.element);
+      await frame();
+
+      expect(harness.element.value).toBe('00:00');
+      expect(harness.inputElement.value).toBe('12:00 AM');
+    });
   });
 
   describe('Value Setting', () => {


### PR DESCRIPTION
## Summary

Fixes #1178.

The time picker stores its value as milliseconds since midnight, so midnight is `0`. The `if (!this._value)` guard in `initialize()` treated that falsy `0` as "no value set yet", read the (empty) `<input>`, and overwrote the midnight value with `null`. As a result, a `00:00` value set **before** the component connects to the DOM (the typical framework-binding flow, e.g. Forge Blazor/Angular/React) was never displayed, while every other time — including `00:01` — worked.

The fix replaces the falsy check with an explicit null check (`this._value == null`), which preserves the original intent — only adopt the input's value when none was set programmatically — while treating `0`/midnight as a valid value. This matches the existing null-check style used elsewhere in the file.

A regression test was added that sets `00:00` before connecting the element and asserts the value is retained and rendered as `12:00 AM`.

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes

None
