### PR TITLE
fix(time-picker): respect typed leading zeros in hours, minutes, and seconds

### DIFF
--- a/.changeset/itchy-pets-teach.md
+++ b/.changeset/itchy-pets-teach.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(time-picker): preserve typed leading zeros in hours, minutes, and seconds

--- a/.changeset/quick-zebras-report.md
+++ b/.changeset/quick-zebras-report.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(time-picker): preserve typed leading zeros so a completed segment does not coerce the next digit (e.g. `0205` now yields `02:05`)

--- a/.changeset/quick-zebras-report.md
+++ b/.changeset/quick-zebras-report.md
@@ -1,5 +1,0 @@
----
-'@tylertech/forge': patch
----
-
-fix(time-picker): preserve typed leading zeros so a completed segment does not coerce the next digit (e.g. `0205` now yields `02:05`)

--- a/packages/forge/src/lib/core/mask/intermediate-time-parser.ts
+++ b/packages/forge/src/lib/core/mask/intermediate-time-parser.ts
@@ -81,6 +81,14 @@ export class IntermediateTimeParser {
     return this._segmentParser.hours.length === 0;
   }
 
+  public get isInitialMinutesEntry(): boolean {
+    return this._segmentParser.minutes.length === 0;
+  }
+
+  public get isInitialSecondsEntry(): boolean {
+    return this._segmentParser.seconds.length === 0;
+  }
+
   public get hasOnlyHoursSegment(): boolean {
     return !!this._segmentParser.hours && !this._segmentParser.minutes && !this._segmentParser.seconds;
   }

--- a/packages/forge/src/lib/core/mask/time-input-mask.ts
+++ b/packages/forge/src/lib/core/mask/time-input-mask.ts
@@ -19,6 +19,11 @@ export class TimeInputMask {
   private _mask: InputMask<FactoryArg>;
   private _maskOptions: FactoryArg;
   private _acceptListener: (evt: InputEvent) => void;
+  // True while a segment holds a single auto-padded digit that may still be extended (e.g. `2` -> `02` -> `21`);
+  // cleared once it holds two digits so a completed segment can't absorb the next segment's keystroke.
+  private _hoursAutoPadded = false;
+  private _minutesAutoPadded = false;
+  private _secondsAutoPadded = false;
 
   constructor(
     private _element: HTMLInputElement,
@@ -125,6 +130,19 @@ export class TimeInputMask {
     // If all of the text is selected, we can safely assume the whole value is being overwritten
     if (parser.isAllSelected) {
       parser.reset();
+      this._hoursAutoPadded = false;
+      this._minutesAutoPadded = false;
+      this._secondsAutoPadded = false;
+    }
+
+    if (parser.isInitialHoursEntry) {
+      this._hoursAutoPadded = false;
+    }
+    if (parser.isInitialMinutesEntry) {
+      this._minutesAutoPadded = false;
+    }
+    if (parser.isInitialSecondsEntry) {
+      this._secondsAutoPadded = false;
     }
 
     // Attempt to pad a leading zero to the hours segment on initial entry only
@@ -132,16 +150,18 @@ export class TimeInputMask {
       // Replace just the hours segment with the padded value and update cursor position
       const newValue = parser.patchSegmentValue('hours', parser.asPaddedChar);
       parser.applyValue(newValue, 'hours-end');
+      this._hoursAutoPadded = true;
       return ':';
     }
 
     // Attempt to overwrite the hours (w/leading zero)
-    if (parser.hasOnlyHoursSegment && parser.canOverwriteHoursChar) {
+    if (parser.hasOnlyHoursSegment && parser.canOverwriteHoursChar && this._hoursAutoPadded) {
       const numNewHour = +`${parser.hoursSegmentNum}${parser.numChar}`;
       if (numNewHour <= 12 || (this._options.use24HourTime && numNewHour <= 23)) {
         // Overwrite the hours segment with the entered char concatenated with the previous entry value
         const newValue = parser.patchSegmentValue('hours', String(numNewHour));
         parser.applyValue(newValue, 'minutes-start');
+        this._hoursAutoPadded = false;
         return ':';
       }
     }
@@ -156,16 +176,18 @@ export class TimeInputMask {
       // Replace just the minute segment with the padded value and update cursor position
       const newValue = parser.patchSegmentValue('minutes', parser.asPaddedChar);
       parser.applyValue(newValue, 'minutes-end');
+      this._minutesAutoPadded = true;
       return ':';
     }
 
     // Attempt to overwrite the minutes (w/leading zero)
-    if (parser.canOverwriteMinutesChar) {
+    if (parser.canOverwriteMinutesChar && this._minutesAutoPadded) {
       const numNewMins = +`${parser.minutesSegmentNum}${parser.numChar}`;
       if (numNewMins < 60) {
-        // Overwrite the hours segment with the entered char concatenated with the previous entry value
+        // Overwrite the minutes segment with the entered char concatenated with the previous entry value
         const newValue = parser.patchSegmentValue('minutes', String(numNewMins));
         parser.applyValue(newValue, 'minutes-end');
+        this._minutesAutoPadded = false;
         return ':';
       }
     }
@@ -176,16 +198,18 @@ export class TimeInputMask {
         // Replace just the seconds segment with the padded value and update cursor position
         const newValue = parser.patchSegmentValue('seconds', parser.asPaddedChar);
         parser.applyValue(newValue, 'seconds-end');
+        this._secondsAutoPadded = true;
         return ':';
       }
 
       // Attempt to overwrite the seconds (w/leading zero)
-      if (parser.canOverwriteSecondsChar) {
+      if (parser.canOverwriteSecondsChar && this._secondsAutoPadded) {
         const numNewSeconds = +`${parser.secondsSegmentNum}${parser.numChar}`;
         if (numNewSeconds < 60) {
           // Overwrite the seconds segment with the entered char concatenated with the previous entry value
           const newValue = parser.patchSegmentValue('seconds', String(numNewSeconds));
           parser.applyValue(newValue, 'seconds-end');
+          this._secondsAutoPadded = false;
           return ':';
         }
       }

--- a/packages/forge/src/lib/core/mask/time-input-mask.ts
+++ b/packages/forge/src/lib/core/mask/time-input-mask.ts
@@ -19,8 +19,6 @@ export class TimeInputMask {
   private _mask: InputMask<FactoryArg>;
   private _maskOptions: FactoryArg;
   private _acceptListener: (evt: InputEvent) => void;
-  // True while a segment holds a single auto-padded digit that may still be extended (e.g. `2` -> `02` -> `21`);
-  // cleared once it holds two digits so a completed segment can't absorb the next segment's keystroke.
   private _hoursAutoPadded = false;
   private _minutesAutoPadded = false;
   private _secondsAutoPadded = false;

--- a/packages/forge/src/lib/time-picker/time-picker.test.ts
+++ b/packages/forge/src/lib/time-picker/time-picker.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-lit';
 import { html } from 'lit';
 import { IListItemComponent, LIST_ITEM_CONSTANTS } from '../list/index.js';
@@ -50,6 +51,15 @@ class TimePickerHarness extends TestHarness<ITimePickerComponent> {
     const value = this._setCharAtPos(this.inputElement.value, char, pos, clear);
     await this.setInputValue(value);
     await this.setCursorPos(pos);
+  }
+
+  // Types a sequence of characters into the input using real keyboard events, one keystroke at a time.
+  public async typeSequence(text: string): Promise<void> {
+    await userEvent.click(this.inputElement);
+    for (const char of text) {
+      await userEvent.keyboard(char);
+      await frame();
+    }
   }
 
   public async setInputValue(value: string): Promise<void> {
@@ -1659,6 +1669,89 @@ describe('TimePickerComponent', () => {
       await harness.writeValue('1', 2, true);
 
       expect(harness.element.value).toBe('03:01');
+    });
+
+    it('should respect a typed leading zero when entering 02xx in 24 hour time', async () => {
+      harness = await createFixture();
+      harness.element.use24HourTime = true;
+      harness.element.showMaskFormat = true;
+
+      await harness.typeSequence('0205');
+
+      expect(harness.element.value).toBe('02:05');
+    });
+
+    it('should respect a typed leading zero when entering 01xx in 24 hour time', async () => {
+      harness = await createFixture();
+      harness.element.use24HourTime = true;
+      harness.element.showMaskFormat = true;
+
+      await harness.typeSequence('0135');
+
+      expect(harness.element.value).toBe('01:35');
+    });
+
+    it('should respect a typed leading zero when entering 0230 in 24 hour time', async () => {
+      harness = await createFixture();
+      harness.element.use24HourTime = true;
+      harness.element.showMaskFormat = true;
+
+      await harness.typeSequence('0230');
+
+      expect(harness.element.value).toBe('02:30');
+    });
+
+    it('should still extend a single-digit hour into two digits in 24 hour time', async () => {
+      harness = await createFixture();
+      harness.element.use24HourTime = true;
+      harness.element.showMaskFormat = true;
+
+      await harness.typeSequence('201');
+
+      expect(harness.element.value).toBe('20:01');
+    });
+
+    it('should auto-pad a single-digit hour of 3 or higher and continue to minutes in 24 hour time', async () => {
+      harness = await createFixture();
+      harness.element.use24HourTime = true;
+      harness.element.showMaskFormat = true;
+
+      await harness.typeSequence('345');
+
+      expect(harness.element.value).toBe('03:45');
+    });
+
+    it('should respect a typed leading zero in the minutes segment when seconds are shown', async () => {
+      harness = await createFixture();
+      harness.element.use24HourTime = true;
+      harness.element.allowSeconds = true;
+      harness.element.showMaskFormat = true;
+
+      await harness.typeSequence('010203');
+
+      expect(harness.element.value).toBe('01:02:03');
+    });
+
+    it('should still extend a single-digit minute into two digits when seconds are shown', async () => {
+      harness = await createFixture();
+      harness.element.use24HourTime = true;
+      harness.element.allowSeconds = true;
+      harness.element.showMaskFormat = true;
+
+      await harness.typeSequence('013503');
+
+      expect(harness.element.value).toBe('01:35:03');
+    });
+
+    it('should respect a typed leading zero in the seconds segment when seconds are shown', async () => {
+      harness = await createFixture();
+      harness.element.use24HourTime = true;
+      harness.element.allowSeconds = true;
+      harness.element.showMaskFormat = true;
+
+      await harness.typeSequence('120102');
+
+      expect(harness.element.value).toBe('12:01:02');
     });
   });
 


### PR DESCRIPTION
## Summary

Written by Claude:

Fixes #1177.

Typing a leading-zero time into the masked field coerced it to the wrong value — e.g. `0205` produced `20:05` instead of `02:05` (also `0230` → `23:00`, `0135` → `13:05`). Times from `03xx` up, and dropdown selection, were unaffected.

The mask fills one digit at a time and supports extending a single typed digit into two (`2` then `1` → `21`), driven by the per-segment "overwrite" branches. Those branches only checked the segment's numeric value (`< 3` for hours, `< 60` for minutes/seconds), so a completed two-digit value like `02` (numerically `2`) was still treated as extendable and absorbed the next keystroke — the digit meant for the following segment. Hours `00`/`01`/`02` are the only values both `< 3` and legally extendable (to `20`–`23`), which is why only `01xx`/`02xx` were affected. The same pattern applied to the minutes and seconds segments.

The fix tracks, per segment, whether it currently holds a single auto-padded digit (still extendable) versus a completed two-digit value (locked). The overwrite branch now also requires that flag, so an explicitly typed leading zero is treated as a complete segment and the next keystroke advances, while the single-digit-then-extend behavior (`2` → `1` → `21`) is preserved.

Regression tests drive real keyboard events and cover the reported cases (`0205` → `02:05`, `0135` → `01:35`, `0230` → `02:30`), the minutes/seconds equivalents in seconds mode (`010203` → `01:02:03`), and guards for the preserved behaviors: single-digit extend (`2` → `1` → `21:00`), `3`–`9` auto-pad (`345` → `03:45`), and the previously-correct `03xx` path.

## Checklist
- [x] Tests added/updated
- [x] Changeset added (`pnpm changeset`)

[Jira item RPTW-5207](https://my.work.tylertech.com/browse/RPTW-5207)