### PR TITLE
feat(avatar): show default image when image url or text is absent

### DIFF
--- a/.changeset/new-jeans-make.md
+++ b/.changeset/new-jeans-make.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': minor
+---
+
+feat(avatar): show default image when an image url or text is absent

--- a/packages/forge/src/dev/pages/avatar/avatar.ejs
+++ b/packages/forge/src/dev/pages/avatar/avatar.ejs
@@ -49,6 +49,13 @@
       <forge-avatar image-url="https://httpstat.us/500" text="Invalid Url"></forge-avatar>
     </div>
   </section>
+
+  <section>
+    <h3 class="forge-typography--heading2">Empty</h3>
+    <div>
+      <forge-avatar></forge-avatar>
+    </div>
+  </section>
 </div>
 
 <script type="module" src="avatar.ts"></script>

--- a/packages/forge/src/lib/avatar/_core.scss
+++ b/packages/forge/src/lib/avatar/_core.scss
@@ -1,3 +1,4 @@
+@use '../core/styles/theme';
 @use '../core/styles/typography';
 @use './token-utils' as *;
 
@@ -34,4 +35,11 @@
 
 @mixin base-with-image() {
   background-color: inherit;
+}
+
+@mixin empty-image() {
+  inline-size: 100%;
+  block-size: 100%;
+  background-color: theme.variable(surface-container-low);
+  fill: theme.variable(surface-container-high);
 }

--- a/packages/forge/src/lib/avatar/avatar.scss
+++ b/packages/forge/src/lib/avatar/avatar.scss
@@ -22,8 +22,12 @@
 
 .forge-avatar {
   @include base;
+}
 
-  &--image {
-    @include base-with-image;
-  }
+.image {
+  @include base-with-image;
+}
+
+.empty-image {
+  @include empty-image;
 }

--- a/packages/forge/src/lib/avatar/avatar.test.ts
+++ b/packages/forge/src/lib/avatar/avatar.test.ts
@@ -129,12 +129,14 @@ describe('Avatar', () => {
     expect(el.imageUrl).toBe('');
   });
 
-  it('should have not have any content by default', async () => {
+  it('should render empty image by default', async () => {
     const screen = render(html`<forge-avatar></forge-avatar>`);
     const el = screen.container.querySelector('forge-avatar') as IAvatarComponent;
     await el.updateComplete;
 
-    expect(getDefaultSlotEl(el).textContent).toBe('');
+    const emptyImage = getShadowElement(el, '.empty-image');
+    expect(emptyImage).not.toBeNull();
+    expect(emptyImage?.querySelector('svg')).not.toBeNull();
   });
 
   it('should render slotted content in place of text content', async () => {
@@ -154,6 +156,80 @@ describe('Avatar', () => {
     const defaultSlot = getDefaultSlotEl(el);
 
     expect(defaultSlot.textContent).toBe('SLSWS');
+  });
+
+  it('should render empty image when no text or image url is provided', async () => {
+    const screen = render(html`<forge-avatar></forge-avatar>`);
+    const el = screen.container.querySelector('forge-avatar') as IAvatarComponent;
+    await el.updateComplete;
+
+    const emptyImage = getShadowElement(el, '.empty-image');
+
+    expect(emptyImage).not.toBeNull();
+    expect(emptyImage?.querySelector('svg')).not.toBeNull();
+  });
+
+  it('should not render empty image when text is provided', async () => {
+    const screen = render(html`<forge-avatar text="Tyler Forge"></forge-avatar>`);
+    const el = screen.container.querySelector('forge-avatar') as IAvatarComponent;
+    await el.updateComplete;
+
+    const emptyImage = getShadowElement(el, '.empty-image');
+
+    expect(emptyImage).toBeNull();
+    expect(getDefaultSlotEl(el).textContent).toBe('TF');
+  });
+
+  it('should not render empty image when image url is provided', async () => {
+    const screen = render(html`<forge-avatar image-url="https://cdn.forge.tylertech.com/v1/images/branding/tyler/talking-t-logo.svg"></forge-avatar>`);
+    const el = screen.container.querySelector('forge-avatar') as IAvatarComponent;
+    await el.updateComplete;
+    await task(1800);
+
+    const emptyImage = getShadowElement(el, '.empty-image');
+
+    expect(emptyImage).toBeNull();
+  });
+
+  it('should render empty image when image url fails to load', async () => {
+    const screen = render(html`<forge-avatar image-url="https://httpstat.us/404"></forge-avatar>`);
+    const el = screen.container.querySelector('forge-avatar') as IAvatarComponent;
+    await el.updateComplete;
+    await task(300);
+
+    const emptyImage = getShadowElement(el, '.empty-image');
+
+    expect(emptyImage).not.toBeNull();
+    expect(emptyImage?.querySelector('svg')).not.toBeNull();
+  });
+
+  it('should render text instead of empty image when text is added', async () => {
+    const screen = render(html`<forge-avatar></forge-avatar>`);
+    const el = screen.container.querySelector('forge-avatar') as IAvatarComponent;
+    await el.updateComplete;
+
+    expect(getShadowElement(el, '.empty-image')).not.toBeNull();
+
+    el.text = 'Tyler Forge';
+    await el.updateComplete;
+
+    expect(getShadowElement(el, '.empty-image')).toBeNull();
+    expect(getDefaultSlotEl(el).textContent).toBe('TF');
+  });
+
+  it('should render empty image when text is removed', async () => {
+    const screen = render(html`<forge-avatar text="Tyler Forge"></forge-avatar>`);
+    const el = screen.container.querySelector('forge-avatar') as IAvatarComponent;
+    await el.updateComplete;
+
+    expect(getShadowElement(el, '.empty-image')).toBeNull();
+
+    el.text = '';
+    await el.updateComplete;
+
+    const emptyImage = getShadowElement(el, '.empty-image');
+    expect(emptyImage).not.toBeNull();
+    expect(emptyImage?.querySelector('svg')).not.toBeNull();
   });
 
   function getRootEl(el: IAvatarComponent): HTMLElement {

--- a/packages/forge/src/lib/avatar/avatar.ts
+++ b/packages/forge/src/lib/avatar/avatar.ts
@@ -44,8 +44,11 @@ export const AVATAR_TAG_NAME: keyof HTMLElementTagNameMap = 'forge-avatar';
  * @cssproperty {number} --forge-avatar-size - The height and width of the avatar.
  * @cssproperty {number} --forge-avatar-transition-duration - The transition duration for animations.
  * @cssproperty {string} --forge-avatar-transition-timing - The transition timing function for animations.
+ * @cssproperty {color} --forge-theme-surface-container-low - The background color of the empty image.
+ * @cssproperty {color} --forge-theme-surface-container-high - The foreground color of the empty image.
  *
  * @csspart root - The root container element.
+ * @csspart empty-image - The empty image container element.
  *
  * @slot - The default slot for avatar content if not provided via text/imageUrl.
  *
@@ -83,7 +86,7 @@ export class AvatarComponent extends BaseLitElement implements IAvatarComponent 
 
   public willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has('imageUrl')) {
-      this._tryLoadImage();
+      this.#tryLoadImage();
     }
   }
 
@@ -92,14 +95,14 @@ export class AvatarComponent extends BaseLitElement implements IAvatarComponent 
       <div
         aria-hidden="true"
         part="root"
-        class=${classMap({ 'forge-avatar': true, 'forge-avatar--image': !!this._image })}
+        class=${classMap({ 'forge-avatar': true, image: !!this._image })}
         style=${this._image ? styleMap({ backgroundImage: `url(${this._image.src})` }) : nothing}>
-        <slot>${this._image ? nothing : charsByLetterCount(this.text, this.letterCount)}</slot>
+        <slot>${this.#renderContent()}</slot>
       </div>
     `;
   }
 
-  private async _tryLoadImage(): Promise<void> {
+  async #tryLoadImage(): Promise<void> {
     if (this.imageUrl) {
       const image = new Image();
       image.onload = () => (this._image = image);
@@ -108,5 +111,23 @@ export class AvatarComponent extends BaseLitElement implements IAvatarComponent 
     } else {
       this._image = undefined;
     }
+  }
+
+  #renderContent(): TemplateResult {
+    if (this._image) {
+      return html`${nothing}`;
+    }
+
+    if (this.text) {
+      return html`${charsByLetterCount(this.text, this.letterCount)}`;
+    }
+
+    return html`
+      <div class="empty-image" part="empty-image">
+        <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 24 24">
+          <path d="M12,6c2.5,0,4.5,2,4.5,4.5s-2,4.5-4.5,4.5-4.5-2-4.5-4.5,2-4.5,4.5-4.5M12,15.8c4.1,0,7.5,2.4,7.5,5.4v2.8H4.5v-2.8c0-3,3.4-5.4,7.5-5.4" />
+        </svg>
+      </div>
+    `;
   }
 }

--- a/packages/forge/src/stories/components/avatar/Avatar.mdx
+++ b/packages/forge/src/stories/components/avatar/Avatar.mdx
@@ -35,6 +35,12 @@ Avatars can be composed within other components, such as icon buttons.
 
 > **Important:** Be sure to provide an accessible label for the icon button.
 
+## Empty State
+
+Avatars can be rendered without any text or image, displaying a default empty image.
+
+<Canvas of={AvatarStories.Empty} />
+
 ## API
 
 <CustomArgTypes />

--- a/packages/forge/src/stories/components/avatar/Avatar.stories.ts
+++ b/packages/forge/src/stories/components/avatar/Avatar.stories.ts
@@ -75,6 +75,10 @@ export const WithIconButton: Story = {
   `
 };
 
+export const Empty: Story = {
+  render: () => html`<forge-avatar></forge-avatar>`
+};
+
 export const CSSOnly: Story = {
   ...standaloneStoryParams,
   render: () => html`<div class="forge-avatar">A</div>`


### PR DESCRIPTION
## Summary
Added a default image that displays when no image URL or text is provided.

## Checklist
- [x] Tests added/updated
- [x] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
