### PR TITLE
fix(autocomplete): prevent stale dropdown popovers by destroying previous instances

### DIFF
--- a/.changeset/grumpy-jars-build.md
+++ b/.changeset/grumpy-jars-build.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(autocomplete): prevent stale dropdown popovers by destroying previous instances

--- a/packages/forge/src/lib/autocomplete/autocomplete-adapter.ts
+++ b/packages/forge/src/lib/autocomplete/autocomplete-adapter.ts
@@ -113,6 +113,11 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
     if (!this._targetElement) {
       return;
     }
+    // If a previous dropdown is still around (e.g. mid-close animation), destroy it immediately
+    // so we never leave a stale popover orphaned in the DOM when a new one opens.
+    if (this._listDropdown) {
+      this._listDropdown.destroy();
+    }
     this._listDropdown = new ListDropdown(this._targetElement, config);
     this._listDropdown.open();
     this._inputElement.setAttribute('aria-expanded', 'true');
@@ -131,18 +136,23 @@ export class AutocompleteAdapter extends BaseAdapter<IAutocompleteComponent> imp
       return;
     }
 
-    const { anchorElement } = this._listDropdown.dropdownElement as IPopoverComponent;
+    // Capture the current dropdown so an awaited close can't null a newer one that opened in the meantime
+    const listDropdown = this._listDropdown;
+
+    const { anchorElement } = listDropdown.dropdownElement as IPopoverComponent;
     if (anchorElement && anchorElement instanceof HTMLElement) {
       anchorElement?.removeEventListener(POPOVER_CONSTANTS.events.TOGGLE, listener);
     }
 
     if (destroy) {
-      this._listDropdown.destroy();
+      listDropdown.destroy();
     } else {
-      await this._listDropdown.close();
+      await listDropdown.close();
     }
 
-    this._listDropdown = undefined;
+    if (this._listDropdown === listDropdown) {
+      this._listDropdown = undefined;
+    }
   }
 
   public setBusyVisibility(isVisible: boolean): void {


### PR DESCRIPTION
## Summary
Rapidly cycling the autocomplete (type → select → type → select…, as QA automation does) could leave orphaned `<forge-popover>` elements stranded in the DOM.

### Root cause
The adapter tracks a single `_listDropdown` reference, but closing is async (awaits the popover's zoom exit animation) while opening is synchronous:

- Selecting an option starts an awaited close — the old popover stays in the DOM while animating out.
- The next keystroke synchronously opens a new popover, overwriting `_listDropdown`.
- The original close resolves, removes the old popover, and nulls `_listDropdown` — clobbering the reference to the new, still-open popover, which can now never be closed or removed.

Each race leaves another popover behind. Small/zero debounce and keyboard-driven opens widen the window, which is why automation hits it but manual use usually doesn't.

### Fix
Two guards in `autocomplete-adapter.ts`:

- `show()` — destroy any lingering dropdown before creating a new one, so at most one popover is ever in the DOM.
- `hide()` — capture the dropdown locally and only null `_listDropdown` if it's still the same instance after the awaited close, so a late close can't clobber a newer dropdown.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
