### PR TITLE
fix(calendar-dropdown): remove disallowed aria-selected attribute

### DIFF
--- a/.changeset/five-rivers-buy.md
+++ b/.changeset/five-rivers-buy.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(calendar-dropdown): remove unallowed aria-selected attribute

--- a/.changeset/five-rivers-buy.md
+++ b/.changeset/five-rivers-buy.md
@@ -2,4 +2,4 @@
 '@tylertech/forge': patch
 ---
 
-fix(calendar-dropdown): remove unallowed aria-selected attribute
+fix(calendar-dropdown): remove disallowed aria-selected attribute

--- a/packages/forge/src/lib/calendar/calendar-dropdown/calendar-dropdown.ts
+++ b/packages/forge/src/lib/calendar/calendar-dropdown/calendar-dropdown.ts
@@ -107,8 +107,7 @@ export class CalendarDropdown implements ICalendarDropdown {
       this.activeChangeCallback?.call(this, id);
       if (this._announcerElement) {
         this._announcerElement.id = id;
-        this._announcerElement.setAttribute('aria-selected', evt.detail.selected.toString());
-        this._announcerElement.textContent = evt.detail.text;
+        this._announcerElement.textContent = `${evt.detail.text} ${evt.detail.selected ? 'selected' : 'deselected'}`;
       }
     });
 


### PR DESCRIPTION
## Summary
Removes the disallowed `aria-selected` attribute from the calendar dropdown's live announcer element.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
