### PR TITLE
fix(chip-field): initialize has-members class for pre-slotted chips

### DIFF
--- a/.changeset/lucky-carrots-shop.md
+++ b/.changeset/lucky-carrots-shop.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(chip-field): initialize has-members class for pre-slotted chips

--- a/.changeset/solid-lions-roll.md
+++ b/.changeset/solid-lions-roll.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(stepper, button-toggle): properly remove slot-change event listeners

--- a/packages/forge/src/lib/button-toggle/button-toggle-group/button-toggle-group-adapter.ts
+++ b/packages/forge/src/lib/button-toggle/button-toggle-group/button-toggle-group-adapter.ts
@@ -43,7 +43,7 @@ export class ButtonToggleGroupAdapter extends BaseAdapter<IButtonToggleGroupComp
   }
 
   public removeSlotChangeListener(listener: EventListener): void {
-    this._defaultSlotElement.addEventListener('slotchange', listener);
+    this._defaultSlotElement.removeEventListener('slotchange', listener);
   }
 
   public deselect(selectedToggle: IButtonToggleComponent): void {

--- a/packages/forge/src/lib/chip-field/chip-field-core.ts
+++ b/packages/forge/src/lib/chip-field/chip-field-core.ts
@@ -31,6 +31,10 @@ export class ChipFieldCore extends BaseFieldCore<IChipFieldAdapter> implements I
 
   public initialize(): void {
     this._adapter.initialize();
+
+    // Initialize has-members class for pre-slotted chips
+    this._adapter.toggleContainerClass(CHIP_FIELD_CONSTANTS.classes.HAS_MEMBERS, this._adapter.getSlottedMemberElements().length > 0);
+
     this._adapter.addRootListener('mousedown', this._mouseDownListener, { capture: true });
     this._adapter.addRootListener('click', this._clickListener);
     this._adapter.addRootListener('keydown', this._rootKeyDownListener);

--- a/packages/forge/src/lib/chip-field/chip-field.test.ts
+++ b/packages/forge/src/lib/chip-field/chip-field.test.ts
@@ -651,6 +651,24 @@ describe('Chip Field', () => {
       expect(focusSpy).toHaveBeenCalled();
     });
   });
+
+  describe('initialization with pre-slotted members', () => {
+    it('should apply has-members class when chips are pre-slotted', async () => {
+      const screen = render(html`
+        <forge-chip-field>
+          <label for="cf-input">Label</label>
+          <input type="text" id="cf-input" />
+          <forge-chip slot="member" value="One">One</forge-chip>
+          <forge-chip slot="member" value="Two">Two</forge-chip>
+          <forge-chip slot="member" value="Three">Three</forge-chip>
+        </forge-chip-field>
+      `);
+      const chipField = screen.container.querySelector('forge-chip-field') as IChipFieldComponent;
+      const containerElement = getShadowElement(chipField, CHIP_FIELD_CONSTANTS.selectors.CONTAINER);
+
+      expect(containerElement.classList.contains(CHIP_FIELD_CONSTANTS.classes.HAS_MEMBERS)).toBe(true);
+    });
+  });
 });
 
 class ChipFieldHarness {

--- a/packages/forge/src/lib/stepper/stepper/stepper-adapter.ts
+++ b/packages/forge/src/lib/stepper/stepper/stepper-adapter.ts
@@ -57,7 +57,7 @@ export class StepperAdapter extends BaseAdapter<IStepperComponent> implements IS
     this._slotElement.addEventListener('slotchange', listener);
   }
   public removeSlotChangeListener(listener: EventListener): void {
-    this._slotElement.addEventListener('slotchange', listener);
+    this._slotElement.removeEventListener('slotchange', listener);
   }
 
   public getLastStep(): IStepComponent {


### PR DESCRIPTION
## Summary
Fixes issue where chip-field wouldn't initially apply `has-members` class if slotted content was available at the time of initial render, in which case `slotchange` would never fire.

Fixes #1154 

Also fixing two instances of `removeSlotChangeListener` that were calling `addEventListener` instead of `removeEventListener` that were found as part of the audit for similar issues in other components.

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
