### PR TITLE
fix(blocks): wire up interactivity across several block templates

### DIFF
--- a/blocks/src/blocks/components/autocomplete/demo/demo.ts
+++ b/blocks/src/blocks/components/autocomplete/demo/demo.ts
@@ -1,0 +1,61 @@
+import type { AutocompleteFilterCallback, IAutocompleteComponent } from '@tylertech/forge/autocomplete';
+
+const states = [
+  { label: 'Alabama', value: 'AL' },
+  { label: 'Alaska', value: 'AK' },
+  { label: 'Arizona', value: 'AZ' },
+  { label: 'Arkansas', value: 'AR' },
+  { label: 'California', value: 'CA' },
+  { label: 'Colorado', value: 'CO' },
+  { label: 'Connecticut', value: 'CT' },
+  { label: 'Delaware', value: 'DE' },
+  { label: 'Florida', value: 'FL' },
+  { label: 'Georgia', value: 'GA' },
+  { label: 'Hawaii', value: 'HI' },
+  { label: 'Idaho', value: 'ID' },
+  { label: 'Illinois', value: 'IL' },
+  { label: 'Indiana', value: 'IN' },
+  { label: 'Iowa', value: 'IA' },
+  { label: 'Kansas', value: 'KS' },
+  { label: 'Kentucky', value: 'KY' },
+  { label: 'Louisiana', value: 'LA' },
+  { label: 'Maine', value: 'ME' },
+  { label: 'Maryland', value: 'MD' },
+  { label: 'Massachusetts', value: 'MA' },
+  { label: 'Michigan', value: 'MI' },
+  { label: 'Minnesota', value: 'MN' },
+  { label: 'Mississippi', value: 'MS' },
+  { label: 'Missouri', value: 'MO' },
+  { label: 'Montana', value: 'MT' },
+  { label: 'Nebraska', value: 'NE' },
+  { label: 'Nevada', value: 'NV' },
+  { label: 'New Hampshire', value: 'NH' },
+  { label: 'New Jersey', value: 'NJ' },
+  { label: 'New Mexico', value: 'NM' },
+  { label: 'New York', value: 'NY' },
+  { label: 'North Carolina', value: 'NC' },
+  { label: 'North Dakota', value: 'ND' },
+  { label: 'Ohio', value: 'OH' },
+  { label: 'Oklahoma', value: 'OK' },
+  { label: 'Oregon', value: 'OR' },
+  { label: 'Pennsylvania', value: 'PA' },
+  { label: 'Rhode Island', value: 'RI' },
+  { label: 'South Carolina', value: 'SC' },
+  { label: 'South Dakota', value: 'SD' },
+  { label: 'Tennessee', value: 'TN' },
+  { label: 'Texas', value: 'TX' },
+  { label: 'Utah', value: 'UT' },
+  { label: 'Vermont', value: 'VT' },
+  { label: 'Virginia', value: 'VA' },
+  { label: 'Washington', value: 'WA' },
+  { label: 'West Virginia', value: 'WV' },
+  { label: 'Wisconsin', value: 'WI' },
+  { label: 'Wyoming', value: 'WY' }
+];
+
+const filter: AutocompleteFilterCallback = filterText => states.filter(state => state.label.toLowerCase().includes(filterText.toLowerCase()));
+
+const autocomplete = document.querySelector<IAutocompleteComponent>('forge-autocomplete');
+if (autocomplete) {
+  autocomplete.filter = filter;
+}

--- a/blocks/src/blocks/components/chip-field/demo/demo.html
+++ b/blocks/src/blocks/components/chip-field/demo/demo.html
@@ -4,8 +4,8 @@
   @description Demo usage example for the forge-chip-field component.
   @tags chip-field, demo, storybook, component-example
 -->
-<forge-chip-field variant theme shape>
+<forge-chip-field>
   <label slot="label" for="tag-input">Tags</label>
-  <input type="text" id="tag-input">
+  <input type="text" id="tag-input" />
   <div slot="support-text">Press enter to create a tag</div>
 </forge-chip-field>

--- a/blocks/src/blocks/components/chip-field/demo/demo.ts
+++ b/blocks/src/blocks/components/chip-field/demo/demo.ts
@@ -1,0 +1,25 @@
+import type { IChipFieldComponent } from '@tylertech/forge/chip-field';
+
+const chipField = document.querySelector('forge-chip-field') as IChipFieldComponent;
+
+chipField?.addEventListener('forge-chip-field-member-added', ({ detail: name }) => {
+  const chip = document.createElement('forge-chip');
+  chip.setAttribute('slot', 'member');
+  chip.type = 'field';
+  chip.dense = true;
+  chip.value = name;
+  chip.textContent = name;
+
+  chip.addEventListener('forge-chip-delete', () => {
+    if (chip.disabled) {
+      return;
+    }
+    chip.remove();
+  });
+
+  chipField.appendChild(chip);
+});
+
+chipField?.addEventListener('forge-chip-field-member-removed', ({ detail }) => {
+  chipField.removeChild(detail);
+});

--- a/blocks/src/blocks/components/dialog/bottom-sheet/bottom-sheet.html
+++ b/blocks/src/blocks/components/dialog/bottom-sheet/bottom-sheet.html
@@ -5,12 +5,12 @@
   @tags dialog, bottom-sheet, storybook, component-example
 -->
 <div>
-  <forge-button variant="raised">Open dialog</forge-button>
-  <forge-dialog preset="bottom-sheet">
+  <forge-button id="open-dialog-button" variant="raised">Open dialog</forge-button>
+  <forge-dialog id="dialog" preset="bottom-sheet">
     <forge-scaffold>
       <forge-toolbar slot="header" no-divider>
         <h1 class="forge-typography--heading4" id="dialog-title" slot="start">Title text</h1>
-        <forge-icon-button slot="end" aria-label="Close dialog">
+        <forge-icon-button id="close-dialog-icon-button" slot="end" aria-label="Close dialog">
           <forge-icon name="close">
           </forge-icon>
         </forge-icon-button>
@@ -20,7 +20,7 @@
         Corrupti, ad hic velit praesentium voluptatum dolores?
       </p>
       <forge-toolbar slot="footer" no-divider>
-        <forge-button slot="end" variant="raised">Close</forge-button>
+        <forge-button id="close-dialog-button" slot="end" variant="raised">Close</forge-button>
       </forge-toolbar>
     </forge-scaffold>
   </forge-dialog>

--- a/blocks/src/blocks/components/dialog/bottom-sheet/bottom-sheet.ts
+++ b/blocks/src/blocks/components/dialog/bottom-sheet/bottom-sheet.ts
@@ -1,4 +1,15 @@
+import type { IButtonComponent, IDialogComponent, IIconButtonComponent } from '@tylertech/forge';
 import { IconRegistry } from '@tylertech/forge/icon';
 import { tylIconClose } from '@tylertech/tyler-icons';
 
 IconRegistry.define([tylIconClose]);
+
+const openButton = document.getElementById('open-dialog-button') as IButtonComponent;
+const dialog = document.getElementById('dialog') as IDialogComponent;
+const closeIconButton = document.getElementById('close-dialog-icon-button') as IIconButtonComponent;
+const closeButton = document.getElementById('close-dialog-button') as IButtonComponent;
+
+openButton?.addEventListener('click', () => (dialog.open = true));
+closeIconButton?.addEventListener('click', () => (dialog.open = false));
+closeButton?.addEventListener('click', () => (dialog.open = false));
+dialog?.addEventListener('forge-dialog-close', () => (dialog.open = false));

--- a/blocks/src/blocks/components/dialog/demo/demo.html
+++ b/blocks/src/blocks/components/dialog/demo/demo.html
@@ -5,12 +5,12 @@
   @tags dialog, demo, storybook, component-example
 -->
 <div>
-  <forge-button variant="raised">Open dialog</forge-button>
-  <forge-dialog>
+  <forge-button id="open-dialog-button" variant="raised">Open dialog</forge-button>
+  <forge-dialog id="dialog">
     <forge-scaffold>
       <forge-toolbar slot="header" no-divider>
         <h1 class="forge-typography--heading4" id="dialog-title" slot="start">Title text</h1>
-        <forge-icon-button slot="end" aria-label="Close dialog">
+        <forge-icon-button id="close-dialog-icon-button" slot="end" aria-label="Close dialog">
           <forge-icon name="close">
           </forge-icon>
         </forge-icon-button>
@@ -20,7 +20,7 @@
         Corrupti, ad hic velit praesentium voluptatum dolores?
       </p>
       <forge-toolbar slot="footer" no-divider>
-        <forge-button slot="end" variant="raised">Close</forge-button>
+        <forge-button id="close-dialog-button" slot="end" variant="raised">Close</forge-button>
       </forge-toolbar>
     </forge-scaffold>
   </forge-dialog>

--- a/blocks/src/blocks/components/dialog/demo/demo.ts
+++ b/blocks/src/blocks/components/dialog/demo/demo.ts
@@ -1,4 +1,15 @@
+import type { IButtonComponent, IDialogComponent, IIconButtonComponent } from '@tylertech/forge';
 import { IconRegistry } from '@tylertech/forge/icon';
 import { tylIconClose } from '@tylertech/tyler-icons';
 
 IconRegistry.define([tylIconClose]);
+
+const openButton = document.getElementById('open-dialog-button') as IButtonComponent;
+const dialog = document.getElementById('dialog') as IDialogComponent;
+const closeIconButton = document.getElementById('close-dialog-icon-button') as IIconButtonComponent;
+const closeButton = document.getElementById('close-dialog-button') as IButtonComponent;
+
+openButton?.addEventListener('click', () => (dialog.open = true));
+closeIconButton?.addEventListener('click', () => (dialog.open = false));
+closeButton?.addEventListener('click', () => (dialog.open = false));
+dialog?.addEventListener('forge-dialog-close', () => (dialog.open = false));

--- a/blocks/src/blocks/components/dialog/fullscreen/fullscreen.html
+++ b/blocks/src/blocks/components/dialog/fullscreen/fullscreen.html
@@ -5,12 +5,12 @@
   @tags dialog, fullscreen, storybook, component-example
 -->
 <div>
-  <forge-button variant="raised">Open dialog</forge-button>
-  <forge-dialog fullscreen>
+  <forge-button id="open-dialog-button" variant="raised">Open dialog</forge-button>
+  <forge-dialog id="dialog" fullscreen>
     <forge-scaffold>
       <forge-toolbar slot="header" no-divider>
         <h1 class="forge-typography--heading4" id="dialog-title" slot="start">Title text</h1>
-        <forge-icon-button slot="end" aria-label="Close dialog">
+        <forge-icon-button id="close-dialog-icon-button" slot="end" aria-label="Close dialog">
           <forge-icon name="close">
           </forge-icon>
         </forge-icon-button>
@@ -20,7 +20,7 @@
         Corrupti, ad hic velit praesentium voluptatum dolores?
       </p>
       <forge-toolbar slot="footer" no-divider>
-        <forge-button slot="end" variant="raised">Close</forge-button>
+        <forge-button id="close-dialog-button" slot="end" variant="raised">Close</forge-button>
       </forge-toolbar>
     </forge-scaffold>
   </forge-dialog>

--- a/blocks/src/blocks/components/dialog/fullscreen/fullscreen.ts
+++ b/blocks/src/blocks/components/dialog/fullscreen/fullscreen.ts
@@ -1,4 +1,15 @@
+import type { IButtonComponent, IDialogComponent, IIconButtonComponent } from '@tylertech/forge';
 import { IconRegistry } from '@tylertech/forge/icon';
 import { tylIconClose } from '@tylertech/tyler-icons';
 
 IconRegistry.define([tylIconClose]);
+
+const openButton = document.getElementById('open-dialog-button') as IButtonComponent;
+const dialog = document.getElementById('dialog') as IDialogComponent;
+const closeIconButton = document.getElementById('close-dialog-icon-button') as IIconButtonComponent;
+const closeButton = document.getElementById('close-dialog-button') as IButtonComponent;
+
+openButton?.addEventListener('click', () => (dialog.open = true));
+closeIconButton?.addEventListener('click', () => (dialog.open = false));
+closeButton?.addEventListener('click', () => (dialog.open = false));
+dialog?.addEventListener('forge-dialog-close', () => (dialog.open = false));

--- a/blocks/src/blocks/components/dialog/left-sheet/left-sheet.html
+++ b/blocks/src/blocks/components/dialog/left-sheet/left-sheet.html
@@ -5,12 +5,12 @@
   @tags dialog, left-sheet, storybook, component-example
 -->
 <div>
-  <forge-button variant="raised">Open dialog</forge-button>
-  <forge-dialog preset="left-sheet">
+  <forge-button id="open-dialog-button" variant="raised">Open dialog</forge-button>
+  <forge-dialog id="dialog" preset="left-sheet">
     <forge-scaffold>
       <forge-toolbar slot="header" no-divider>
         <h1 class="forge-typography--heading4" id="dialog-title" slot="start">Title text</h1>
-        <forge-icon-button slot="end" aria-label="Close dialog">
+        <forge-icon-button id="close-dialog-icon-button" slot="end" aria-label="Close dialog">
           <forge-icon name="close">
           </forge-icon>
         </forge-icon-button>
@@ -20,7 +20,7 @@
         Corrupti, ad hic velit praesentium voluptatum dolores?
       </p>
       <forge-toolbar slot="footer" no-divider>
-        <forge-button slot="end" variant="raised">Close</forge-button>
+        <forge-button id="close-dialog-button" slot="end" variant="raised">Close</forge-button>
       </forge-toolbar>
     </forge-scaffold>
   </forge-dialog>

--- a/blocks/src/blocks/components/dialog/left-sheet/left-sheet.ts
+++ b/blocks/src/blocks/components/dialog/left-sheet/left-sheet.ts
@@ -1,4 +1,15 @@
+import type { IButtonComponent, IDialogComponent, IIconButtonComponent } from '@tylertech/forge';
 import { IconRegistry } from '@tylertech/forge/icon';
 import { tylIconClose } from '@tylertech/tyler-icons';
 
 IconRegistry.define([tylIconClose]);
+
+const openButton = document.getElementById('open-dialog-button') as IButtonComponent;
+const dialog = document.getElementById('dialog') as IDialogComponent;
+const closeIconButton = document.getElementById('close-dialog-icon-button') as IIconButtonComponent;
+const closeButton = document.getElementById('close-dialog-button') as IButtonComponent;
+
+openButton?.addEventListener('click', () => (dialog.open = true));
+closeIconButton?.addEventListener('click', () => (dialog.open = false));
+closeButton?.addEventListener('click', () => (dialog.open = false));
+dialog?.addEventListener('forge-dialog-close', () => (dialog.open = false));

--- a/blocks/src/blocks/components/dialog/right-sheet/right-sheet.html
+++ b/blocks/src/blocks/components/dialog/right-sheet/right-sheet.html
@@ -5,12 +5,12 @@
   @tags dialog, right-sheet, storybook, component-example
 -->
 <div>
-  <forge-button variant="raised">Open dialog</forge-button>
-  <forge-dialog preset="right-sheet">
+  <forge-button id="open-dialog-button" variant="raised">Open dialog</forge-button>
+  <forge-dialog id="dialog" preset="right-sheet">
     <forge-scaffold>
       <forge-toolbar slot="header" no-divider>
         <h1 class="forge-typography--heading4" id="dialog-title" slot="start">Title text</h1>
-        <forge-icon-button slot="end" aria-label="Close dialog">
+        <forge-icon-button id="close-dialog-icon-button" slot="end" aria-label="Close dialog">
           <forge-icon name="close">
           </forge-icon>
         </forge-icon-button>
@@ -20,7 +20,7 @@
         Corrupti, ad hic velit praesentium voluptatum dolores?
       </p>
       <forge-toolbar slot="footer" no-divider>
-        <forge-button slot="end" variant="raised">Close</forge-button>
+        <forge-button id="close-dialog-button" slot="end" variant="raised">Close</forge-button>
       </forge-toolbar>
     </forge-scaffold>
   </forge-dialog>

--- a/blocks/src/blocks/components/dialog/right-sheet/right-sheet.ts
+++ b/blocks/src/blocks/components/dialog/right-sheet/right-sheet.ts
@@ -1,4 +1,15 @@
+import type { IButtonComponent, IDialogComponent, IIconButtonComponent } from '@tylertech/forge';
 import { IconRegistry } from '@tylertech/forge/icon';
 import { tylIconClose } from '@tylertech/tyler-icons';
 
 IconRegistry.define([tylIconClose]);
+
+const openButton = document.getElementById('open-dialog-button') as IButtonComponent;
+const dialog = document.getElementById('dialog') as IDialogComponent;
+const closeIconButton = document.getElementById('close-dialog-icon-button') as IIconButtonComponent;
+const closeButton = document.getElementById('close-dialog-button') as IButtonComponent;
+
+openButton?.addEventListener('click', () => (dialog.open = true));
+closeIconButton?.addEventListener('click', () => (dialog.open = false));
+closeButton?.addEventListener('click', () => (dialog.open = false));
+dialog?.addEventListener('forge-dialog-close', () => (dialog.open = false));

--- a/blocks/src/blocks/components/dialog/top-sheet/top-sheet.html
+++ b/blocks/src/blocks/components/dialog/top-sheet/top-sheet.html
@@ -5,12 +5,12 @@
   @tags dialog, top-sheet, storybook, component-example
 -->
 <div>
-  <forge-button variant="raised">Open dialog</forge-button>
-  <forge-dialog preset="top-sheet">
+  <forge-button id="open-dialog-button" variant="raised">Open dialog</forge-button>
+  <forge-dialog id="dialog" preset="top-sheet">
     <forge-scaffold>
       <forge-toolbar slot="header" no-divider>
         <h1 class="forge-typography--heading4" id="dialog-title" slot="start">Title text</h1>
-        <forge-icon-button slot="end" aria-label="Close dialog">
+        <forge-icon-button id="close-dialog-icon-button" slot="end" aria-label="Close dialog">
           <forge-icon name="close">
           </forge-icon>
         </forge-icon-button>
@@ -20,7 +20,7 @@
         Corrupti, ad hic velit praesentium voluptatum dolores?
       </p>
       <forge-toolbar slot="footer" no-divider>
-        <forge-button slot="end" variant="raised">Close</forge-button>
+        <forge-button id="close-dialog-button" slot="end" variant="raised">Close</forge-button>
       </forge-toolbar>
     </forge-scaffold>
   </forge-dialog>

--- a/blocks/src/blocks/components/dialog/top-sheet/top-sheet.ts
+++ b/blocks/src/blocks/components/dialog/top-sheet/top-sheet.ts
@@ -1,4 +1,15 @@
+import type { IButtonComponent, IDialogComponent, IIconButtonComponent } from '@tylertech/forge';
 import { IconRegistry } from '@tylertech/forge/icon';
 import { tylIconClose } from '@tylertech/tyler-icons';
 
 IconRegistry.define([tylIconClose]);
+
+const openButton = document.getElementById('open-dialog-button') as IButtonComponent;
+const dialog = document.getElementById('dialog') as IDialogComponent;
+const closeIconButton = document.getElementById('close-dialog-icon-button') as IIconButtonComponent;
+const closeButton = document.getElementById('close-dialog-button') as IButtonComponent;
+
+openButton?.addEventListener('click', () => (dialog.open = true));
+closeIconButton?.addEventListener('click', () => (dialog.open = false));
+closeButton?.addEventListener('click', () => (dialog.open = false));
+dialog?.addEventListener('forge-dialog-close', () => (dialog.open = false));

--- a/blocks/src/blocks/forms/add-illustration/add-illustration.ts
+++ b/blocks/src/blocks/forms/add-illustration/add-illustration.ts
@@ -1,0 +1,32 @@
+import type { IChipFieldComponent } from '@tylertech/forge/chip-field';
+import type { IChipComponent } from '@tylertech/forge/chips';
+
+const chipField = document.querySelector('forge-chip-field') as IChipFieldComponent;
+
+function wireChipDelete(chip: IChipComponent): void {
+  chip.addEventListener('forge-chip-delete', () => {
+    if (chip.disabled) {
+      return;
+    }
+    chip.remove();
+  });
+}
+
+chipField?.querySelectorAll('forge-chip').forEach(wireChipDelete);
+
+chipField?.addEventListener('forge-chip-field-member-added', ({ detail: name }) => {
+  const chip = document.createElement('forge-chip');
+  chip.setAttribute('slot', 'member');
+  chip.type = 'input';
+  chip.dense = true;
+  chip.value = name;
+  chip.textContent = name;
+
+  wireChipDelete(chip);
+
+  chipField.appendChild(chip);
+});
+
+chipField?.addEventListener('forge-chip-field-member-removed', ({ detail }) => {
+  chipField.removeChild(detail);
+});


### PR DESCRIPTION
## Summary
- Wire up open/close interactivity for the dialog blocks (`demo`, `fullscreen`, `bottom-sheet`, `left-sheet`, `right-sheet`, `top-sheet`), which were missing the TS logic from the original storybook stories.
- Add filtering logic to the `autocomplete` demo block so it behaves like the other autocomplete examples.
- Add tag add/remove logic to the `chip-field` demo block.
- Wire up the keywords chip field in the `add-illustration` form block (add new tags, delete existing/static chips).

## Test plan
- [x] `tsc --noEmit` passes for the `blocks` package
- [x] `pnpm build:blocks` compiles all affected blocks with their script tags correctly wired
- [x] Verified interactively in a browser (Playwright) for each block:
  - Dialog blocks open via button and close via icon-button/footer button/close event
  - Autocomplete demo filters states as you type
  - Chip-field demo adds a tag on Enter and removes it on delete
  - Add Illustration form: existing chips can be deleted and new tags can be added