### PR TITLE
fix(secret): reduce icon button size

### DIFF
--- a/.changeset/cool-snails-hang.md
+++ b/.changeset/cool-snails-hang.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': minor
+---
+
+fix(secret): reduce default icon button size

--- a/.changeset/seven-rules-ring.md
+++ b/.changeset/seven-rules-ring.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': minor
+---
+
+feat(secret): add button size token

--- a/packages/forge/src/lib/core/styles/tokens/secret/_tokens.scss
+++ b/packages/forge/src/lib/core/styles/tokens/secret/_tokens.scss
@@ -12,6 +12,7 @@ $tokens: (
   button-color: utils.module-val(secret, button-color, theme.variable(on-surface-inverse)),
   button-shape: utils.module-val(secret, button-shape, shape.variable(medium)),
   button-padding: utils.module-val(secret, button-padding, spacing.variable(xsmall)),
+  button-size: utils.module-val(secret, button-size, spacing.variable(medium-large)),
   icon-size: utils.module-val(secret, icon-size, typography.font-size-relative('1000')),
   text-button-shape: utils.module-val(secret, text-button-shape, shape.variable(full)),
   text-decoration-line: utils.module-val(secret, text-decoration-line, underline),

--- a/packages/forge/src/lib/secret/_core.scss
+++ b/packages/forge/src/lib/secret/_core.scss
@@ -105,10 +105,10 @@
     (
       background-color: #{token(button-background)},
       icon-color: #{token(button-color)},
-      icon-size: inherit,
+      icon-size: min(inherit, #{token(button-size)}),
       padding: 0,
       shape: #{token(button-shape)},
-      size: 1lh
+      size: #{token(button-size)}
     )
   );
   @include focus-indicator.provide-theme(

--- a/packages/forge/src/lib/secret/secret.scss
+++ b/packages/forge/src/lib/secret/secret.scss
@@ -63,30 +63,28 @@
   }
 }
 
-:host(:state(open)) {
+.open {
+  &:not(.block) {
+    .content {
+      @include content-inline-open;
+    }
+  }
+
   .text-button {
     @include text-button-open;
   }
 }
 
-:host(:not(:state(open))) {
-  .forge-secret {
-    @include closed;
-  }
-}
-
-:host(:not(:state(block)):state(open)) {
-  .content {
-    @include content-inline-open;
-  }
+.forge-secret:not(.open) {
+  @include closed;
 }
 
 :host(:state(block)) {
   @include host-block;
+}
 
-  .forge-secret {
-    @include base-block;
-  }
+.block {
+  @include base-block;
 
   .content {
     @include content-block;

--- a/packages/forge/src/lib/secret/secret.ts
+++ b/packages/forge/src/lib/secret/secret.ts
@@ -38,6 +38,7 @@ export const SECRET_TAG_NAME: keyof HTMLElementTagNameMap = 'forge-secret';
  * @cssproperty --forge-secret-button-color - The text and icon color of the button.
  * @cssproperty --forge-secret-button-shape - The button's border radius.
  * @cssproperty --forge-secret-button-padding - The inline padding around the button or inline and block padding around the text button.
+ * @cssproperty --forge-secret-button-size - The button's width and height.
  * @cssproperty --forge-secret-icon-size - The icon's size.
  * @cssproperty --forge-secret-text-button-shape - The text button's border radius.
  * @cssproperty --forge-secret-text-decoration-line - The decoration line applied to open inline content.
@@ -205,7 +206,13 @@ export class SecretComponent extends BaseLitElement {
     return html`
       <span
         part="root"
-        class=${classMap({ 'forge-secret': true, reverse: this.buttonPosition === 'start', 'show-on-hover': this.showOnHover })}
+        class=${classMap({
+          'forge-secret': true,
+          open: this.open,
+          block: this.block,
+          reverse: this.buttonPosition === 'start',
+          'show-on-hover': this.showOnHover
+        })}
         @click="${this.#handleClick}">
         <span
           class=${classMap({


### PR DESCRIPTION
## Summary
Sets the secret component's icon button size to 20px by default and adds a `--forge-secret-button-size` token to control it. Also refactored the secret's CSS to target internal classes instead of custom state set on the host for consistency across components.

## Checklist
- [ ] Tests added/updated
- [x] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
