### PR TITLE
fix(paginator): allow page size not in page size options

### DIFF
--- a/.changeset/bright-regions-knock.md
+++ b/.changeset/bright-regions-knock.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(paginator): allow default page size that is not in page size options

--- a/.changeset/full-games-decide.md
+++ b/.changeset/full-games-decide.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': patch
+---
+
+fix(paginator): hide page size options select when page size options is a null value or empty array

--- a/.changeset/tasty-rules-juggle.md
+++ b/.changeset/tasty-rules-juggle.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge-core': patch
+---
+
+fix(utils): prevent coerceNumberArray returning [0] when an array should be empty

--- a/packages/forge-core/src/utils/utils.ts
+++ b/packages/forge-core/src/utils/utils.ts
@@ -152,6 +152,7 @@ export function coerceNumberArray(strOrNumOrArray: string | Array<string | numbe
     return strOrNumOrArray
       .replace(/ |\[|]|"/g, '')
       .split(',')
+      .filter(Boolean)
       .map(n => Number(n));
   } else if (typeof strOrNumOrArray === 'number') {
     return [strOrNumOrArray];

--- a/packages/forge/src/lib/paginator/paginator.test.ts
+++ b/packages/forge/src/lib/paginator/paginator.test.ts
@@ -354,7 +354,7 @@ describe('Paginator', () => {
       expect(harness.rangeLabelText).toBe('1-20 of 100');
     });
 
-    it('should hide page size select if no options', async () => {
+    it('should remove page size select from DOM when set to an empty array', async () => {
       const harness = await createFixture();
 
       expect(harness.pageSizeSelect).toBeTruthy();
@@ -362,7 +362,43 @@ describe('Paginator', () => {
       harness.paginatorElement.pageSizeOptions = [];
       await harness.paginatorElement.updateComplete;
 
-      expect(harness.pageSizeSelect.hidden).toBe(true);
+      expect(harness.pageSizeSelect).toBeNull();
+    });
+
+    it('should remove page size select from DOM when set to null', async () => {
+      const harness = await createFixture();
+
+      expect(harness.pageSizeSelect).toBeTruthy();
+
+      harness.paginatorElement.pageSizeOptions = null as unknown as number[];
+      await harness.paginatorElement.updateComplete;
+
+      expect(harness.pageSizeSelect).toBeNull();
+    });
+
+    it('should remove page size select from DOM when set to undefined', async () => {
+      const harness = await createFixture();
+
+      expect(harness.pageSizeSelect).toBeTruthy();
+
+      harness.paginatorElement.pageSizeOptions = undefined as unknown as number[];
+      await harness.paginatorElement.updateComplete;
+
+      expect(harness.pageSizeSelect).toBeNull();
+    });
+
+    it('should not render page size select on initialization when pageSizeOptions is an empty array', async () => {
+      const harness = await createFixture({ pageSizeOptions: [] });
+
+      expect(harness.pageSizeSelect).toBeNull();
+    });
+
+    it('should allow a pageSize that is not included in pageSizeOptions on initialization', async () => {
+      const harness = await createFixture({ pageSize: 40, pageSizeOptions: [10, 20, 30] });
+
+      expect(harness.paginatorElement.pageSize).toBe(40);
+      expect(harness.paginatorElement.pageSizeOptions).toEqual([10, 20, 30]);
+      expect(harness.pageSizeSelect.value).toBe('40');
     });
   });
 
@@ -923,6 +959,7 @@ interface IPaginatorFixtureConfig {
   total?: number;
   pageIndex?: number;
   pageSize?: number;
+  pageSizeOptions?: number[];
   offset?: number;
   label?: string;
   firstLast?: boolean;
@@ -935,6 +972,7 @@ async function createFixture({
   total,
   pageIndex,
   pageSize,
+  pageSizeOptions,
   offset,
   label,
   firstLast,
@@ -947,6 +985,7 @@ async function createFixture({
       total=${total ?? nothing}
       page-index=${pageIndex ?? nothing}
       page-size=${pageSize ?? nothing}
+      .pageSizeOptions=${pageSizeOptions ?? nothing}
       offset=${offset ?? nothing}
       label=${label ?? nothing}
       ?first-last=${firstLast}

--- a/packages/forge/src/lib/paginator/paginator.ts
+++ b/packages/forge/src/lib/paginator/paginator.ts
@@ -345,18 +345,7 @@ export class PaginatorComponent extends BaseLitElement implements IPaginatorComp
           <div class="label" part="label" id="label">
             <slot name="label">${this.label}</slot>
           </div>
-
-          <forge-select
-            class="page-size-options"
-            aria-labelledby="label"
-            label-position="none"
-            density="extra-small"
-            part="page-size-options"
-            ?hidden=${!this.pageSizeOptions.length}
-            ?disabled=${this.disabled}
-            .value=${String(this.pageSize)}
-            @change=${this.#handlePageSizeChange}></forge-select>
-
+          ${this.#renderPageSizeSelect()}
           <div class="range-label" part="range-label">
             <slot name="range-label">${this.#rangeLabel}</slot>
           </div>
@@ -400,6 +389,23 @@ export class PaginatorComponent extends BaseLitElement implements IPaginatorComp
           ${this.firstLast ? this.#renderLastPageButton() : nothing}
         </div>
       </div>
+    `;
+  }
+
+  #renderPageSizeSelect(): TemplateResult | typeof nothing {
+    if (!isArray(this.pageSizeOptions) || !this.pageSizeOptions.length) {
+      return nothing;
+    }
+    return html`
+      <forge-select
+        class="page-size-options"
+        aria-labelledby="label"
+        label-position="none"
+        density="extra-small"
+        part="page-size-options"
+        ?disabled=${this.disabled}
+        .value=${String(this.pageSize)}
+        @change=${this.#handlePageSizeChange}></forge-select>
     `;
   }
 
@@ -542,9 +548,6 @@ export class PaginatorComponent extends BaseLitElement implements IPaginatorComp
       .map(o => ({ label: `${o}`, value: `${o}` }))
       .sort((a, b) => coerceNumber(a.value) - coerceNumber(b.value));
     this._pageSizeSelect.options = options;
-    if (!options.find(o => coerceNumber(o.value) === this.pageSize)) {
-      this.pageSize = coerceNumber(options[0].value);
-    }
   }
 
   #tryFocus(elements: Array<IIconButtonComponent | ISelectComponent | undefined>, options?: FocusOptions): void {

--- a/packages/forge/src/lib/tabs/tab/tab.ts
+++ b/packages/forge/src/lib/tabs/tab/tab.ts
@@ -348,6 +348,7 @@ export class TabComponent extends BaseLitElement implements ITabComponent {
   }
 
   #requestSync(): void {
+    /** @ignore */
     this.dispatchEvent(
       new CustomEvent(TAB_CONSTANTS.events.REQUEST_SYNC, {
         bubbles: true,


### PR DESCRIPTION
## Summary
Allows setting a paginator page size that isn't present in the page size options.

## Checklist
- [x] Tests added/updated
- [x] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
