### PR TITLE
feat(app-bar-menu-button): add ARIA attributes to show menu button state

### DIFF
--- a/.changeset/hot-rooms-buy.md
+++ b/.changeset/hot-rooms-buy.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge': minor
+---
+
+feat(app-bar-menu-button): add `expanded`, `controls`, and `hasPopup` properties for ARIA state on the internal button

--- a/packages/forge/src/lib/app-bar/menu-button/app-bar-menu-button-constants.ts
+++ b/packages/forge/src/lib/app-bar/menu-button/app-bar-menu-button-constants.ts
@@ -3,7 +3,10 @@ import { COMPONENT_NAME_PREFIX } from '../../constants.js';
 const elementName: keyof HTMLElementTagNameMap = `${COMPONENT_NAME_PREFIX}app-bar-menu-button`;
 
 const observedAttributes = {
-  ICON: 'icon'
+  ICON: 'icon',
+  EXPANDED: 'expanded',
+  CONTROLS: 'controls',
+  HAS_POPUP: 'has-popup'
 };
 
 const attributes = {

--- a/packages/forge/src/lib/app-bar/menu-button/app-bar-menu-button.test.ts
+++ b/packages/forge/src/lib/app-bar/menu-button/app-bar-menu-button.test.ts
@@ -80,4 +80,58 @@ describe('App Bar Menu Button', () => {
 
     expect(clickSpy).toHaveBeenCalledOnce();
   });
+
+  it('should default expanded to false and reflect it only on menu icon button', async () => {
+    const screen = render(html`<forge-app-bar-menu-button></forge-app-bar-menu-button>`);
+    const el = screen.container.querySelector('forge-app-bar-menu-button') as IAppBarMenuButtonComponent;
+    const iconButtonEl = el.querySelector('forge-icon-button') as HTMLElement;
+
+    expect(el.expanded).toBe(false);
+    expect(iconButtonEl.getAttribute('aria-expanded')).toBe('false');
+    expect(el.hasAttribute('aria-expanded')).toBe(false);
+  });
+
+  it('should update aria-expanded on the menu icon button when expanded changes', async () => {
+    const screen = render(html`<forge-app-bar-menu-button expanded></forge-app-bar-menu-button>`);
+    const el = screen.container.querySelector('forge-app-bar-menu-button') as IAppBarMenuButtonComponent;
+    const iconButtonEl = el.querySelector('forge-icon-button') as HTMLElement;
+
+    expect(iconButtonEl.getAttribute('aria-expanded')).toBe('true');
+
+    el.removeAttribute('expanded');
+    await frame();
+
+    expect(el.expanded).toBe(false);
+    expect(iconButtonEl.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('should reflect controls only on the menu icon button', async () => {
+    const screen = render(html`<forge-app-bar-menu-button controls="nav-drawer"></forge-app-bar-menu-button>`);
+    const el = screen.container.querySelector('forge-app-bar-menu-button') as IAppBarMenuButtonComponent;
+    const iconButtonEl = el.querySelector('forge-icon-button') as HTMLElement;
+
+    expect(el.controls).toBe('nav-drawer');
+    expect(iconButtonEl.getAttribute('aria-controls')).toBe('nav-drawer');
+    expect(el.hasAttribute('aria-controls')).toBe(false);
+
+    el.removeAttribute('controls');
+    await frame();
+
+    expect(iconButtonEl.getAttribute('aria-controls')).toBeNull();
+  });
+
+  it('should default hasPopup to "menu" and reflect overrides only on the menu icon button', async () => {
+    const screen = render(html`<forge-app-bar-menu-button></forge-app-bar-menu-button>`);
+    const el = screen.container.querySelector('forge-app-bar-menu-button') as IAppBarMenuButtonComponent;
+    const iconButtonEl = el.querySelector('forge-icon-button') as HTMLElement;
+
+    expect(el.hasPopup).toBe('menu');
+    expect(iconButtonEl.getAttribute('aria-haspopup')).toBe('menu');
+
+    el.setAttribute('has-popup', 'dialog');
+    await frame();
+
+    expect(iconButtonEl.getAttribute('aria-haspopup')).toBe('dialog');
+    expect(el.hasAttribute('aria-haspopup')).toBe(false);
+  });
 });

--- a/packages/forge/src/lib/app-bar/menu-button/app-bar-menu-button.ts
+++ b/packages/forge/src/lib/app-bar/menu-button/app-bar-menu-button.ts
@@ -1,4 +1,4 @@
-import { customElement, attachLightTemplate, toggleAttribute, getLightElement } from '@tylertech/forge-core';
+import { customElement, attachLightTemplate, toggleAttribute, getLightElement, coerceBoolean } from '@tylertech/forge-core';
 import { APP_BAR_MENU_BUTTON_CONSTANTS } from './app-bar-menu-button-constants.js';
 import { IconButtonComponent, ICON_BUTTON_CONSTANTS, IIconButtonComponent } from '../../icon-button/index.js';
 import { TooltipComponent } from '../../tooltip/index.js';
@@ -11,6 +11,9 @@ import template from './app-bar-menu-button.html';
 
 export interface IAppBarMenuButtonComponent extends IBaseComponent {
   icon: string;
+  expanded: boolean;
+  controls: string | null;
+  hasPopup: string | null;
 }
 
 declare global {
@@ -25,8 +28,14 @@ declare global {
  * @summary A menu toggle button component with a predefined hamburger menu icon, typically used in an app bar's start slot to open navigation menus.
  *
  * @property {string} [icon=menu] - The name of an alternative icon to display.
+ * @property {boolean} [expanded=false] - Whether the menu controlled by this button is expanded. Reflected as `aria-expanded` on the internal button.
+ * @property {string} [controls] - The id of the element (e.g., drawer or menu) controlled by this button. Reflected as `aria-controls` on the internal button.
+ * @property {string} [hasPopup=menu] - Indicates the button opens a menu or dialog. Valid values include "menu", "dialog", "true". Reflected as `aria-haspopup` on the internal button.
  *
  * @attribute {string} [icon=menu] - The name of an alternative icon to display.
+ * @attribute {boolean} [expanded=false] - Whether the menu controlled by this button is expanded. Reflected as `aria-expanded` on the internal button.
+ * @attribute {string} [controls] - The id of the element (e.g., drawer or menu) controlled by this button. Reflected as `aria-controls` on the internal button.
+ * @attribute {string} [has-popup=menu] - Indicates the button opens a menu or dialog. Valid values include "menu", "dialog", "true". Reflected as `aria-haspopup` on the internal button.
  * @attribute {string} [aria-label] - The aria-label to apply to the button.
  * @attribute {string} [aria-labelledby] - The id of an element to use as the aria-labelledby attribute.
  */
@@ -43,6 +52,9 @@ export class AppBarMenuButtonComponent extends BaseComponent implements IAppBarM
   private _iconElement: IIconComponent;
   private _forwardObserver?: MutationObserver;
   private _iconName: string = tylIconMenu.name;
+  private _expanded = false;
+  private _controls: string | null = null;
+  private _hasPopup: string | null = 'menu';
 
   constructor() {
     super();
@@ -60,6 +72,10 @@ export class AppBarMenuButtonComponent extends BaseComponent implements IAppBarM
     if (this._iconElement.name !== this._iconName) {
       this._iconElement.name = this._iconName;
     }
+
+    this._iconButtonElement.setAttribute('aria-expanded', String(this._expanded));
+    toggleAttribute(this._iconButtonElement, !!this._controls, 'aria-controls', this._controls ?? undefined);
+    toggleAttribute(this._iconButtonElement, !!this._hasPopup, 'aria-haspopup', this._hasPopup ?? undefined);
 
     const originalAriaLabelledby = this._iconButtonElement.getAttribute('aria-labelledby');
 
@@ -81,6 +97,15 @@ export class AppBarMenuButtonComponent extends BaseComponent implements IAppBarM
       case APP_BAR_MENU_BUTTON_CONSTANTS.attributes.ICON:
         this.icon = newValue;
         break;
+      case APP_BAR_MENU_BUTTON_CONSTANTS.attributes.EXPANDED:
+        this.expanded = coerceBoolean(newValue);
+        break;
+      case APP_BAR_MENU_BUTTON_CONSTANTS.attributes.CONTROLS:
+        this.controls = newValue;
+        break;
+      case APP_BAR_MENU_BUTTON_CONSTANTS.attributes.HAS_POPUP:
+        this.hasPopup = newValue;
+        break;
     }
   }
 
@@ -94,6 +119,46 @@ export class AppBarMenuButtonComponent extends BaseComponent implements IAppBarM
         this._iconElement.name = this._iconName;
       }
       this.setAttribute(APP_BAR_MENU_BUTTON_CONSTANTS.attributes.ICON, this._iconName);
+    }
+  }
+
+  public get expanded(): boolean {
+    return this._expanded;
+  }
+  public set expanded(value: boolean) {
+    const newValue = !!value;
+    if (this._expanded !== newValue) {
+      this._expanded = newValue;
+      if (this._iconButtonElement) {
+        this._iconButtonElement.setAttribute('aria-expanded', String(newValue));
+      }
+      toggleAttribute(this, newValue, APP_BAR_MENU_BUTTON_CONSTANTS.attributes.EXPANDED);
+    }
+  }
+
+  public get controls(): string | null {
+    return this._controls;
+  }
+  public set controls(value: string | null) {
+    if (this._controls !== value) {
+      this._controls = value;
+      if (this._iconButtonElement) {
+        toggleAttribute(this._iconButtonElement, !!value, 'aria-controls', value ?? undefined);
+      }
+      toggleAttribute(this, !!value, APP_BAR_MENU_BUTTON_CONSTANTS.attributes.CONTROLS, value ?? undefined);
+    }
+  }
+
+  public get hasPopup(): string | null {
+    return this._hasPopup;
+  }
+  public set hasPopup(value: string | null) {
+    if (this._hasPopup !== value) {
+      this._hasPopup = value;
+      if (this._iconButtonElement) {
+        toggleAttribute(this._iconButtonElement, !!value, 'aria-haspopup', value ?? undefined);
+      }
+      toggleAttribute(this, !!value, APP_BAR_MENU_BUTTON_CONSTANTS.attributes.HAS_POPUP, value ?? undefined);
     }
   }
 }


### PR DESCRIPTION
## Summary
Updates will add `aria-expanded`, `aria-haspopup` and `aria-controls` on the menu-button of forge-app-bar component. This enhancement will let screen readers announce the state of the menu (whether expanded or collapsed). Developers using this component does not have to add the ARIA attributes manually as this would create issues flagged by acceesibility tools.

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (if applicable)
- [x] Changeset added (`pnpm changeset`)

## Breaking Changes
None
